### PR TITLE
fix(kb-ui): ship tokens.css from dist (closes #1)

### DIFF
--- a/packages/kb-ui/package.json
+++ b/packages/kb-ui/package.json
@@ -11,7 +11,7 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
-    "./styles": "./src/tokens.css"
+    "./styles": "./dist/tokens.css"
   },
   "files": [
     "dist"

--- a/packages/kb-ui/tsup.config.ts
+++ b/packages/kb-ui/tsup.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'tsup';
+import { copyFile } from 'node:fs/promises';
 
 export default defineConfig({
   entry: ['src/index.ts'],
@@ -8,4 +9,7 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   external: ['react', 'react-dom'],
+  onSuccess: async () => {
+    await copyFile('src/tokens.css', 'dist/tokens.css');
+  },
 });


### PR DESCRIPTION
## Summary

Phase 8 npm publish blocker. Closes #1.

The exports map pointed at `./src/tokens.css` but `files: ["dist"]` excluded `src/` from the npm tarball — every consumer doing `import '@hiver/kb-ui/styles'` would 404 post-publish.

- `tsup.config.ts`: `onSuccess` hook copies `src/tokens.css` → `dist/tokens.css` after each build
- `package.json`: retarget `exports["./styles"]` to `./dist/tokens.css`

## Verification

- [x] `npm run build` from `packages/kb-ui` — pass (esm + cjs + dts)
- [x] `dist/tokens.css` byte-identical to `src/tokens.css` (`diff` produced no output)
- [x] `npx tsc --noEmit` clean
- [x] Demo dev server still resolves the styles import

## Out of scope

A pre-existing demo import gap (commit `de1f197` dropped `AISubNav` from kb-ui without updating the demo) surfaced when running `npm run demo:build`. Filed as #13. Blocks Phase 8.5 smoke test, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)