### PR TITLE
feat(kb-ui): add npm publish metadata (closes #2)

### DIFF
--- a/packages/kb-ui/package.json
+++ b/packages/kb-ui/package.json
@@ -2,6 +2,26 @@
   "name": "@hiver/kb-ui",
   "version": "0.1.0",
   "description": "Hiver KB component library — pixel-perfect React components for app.hiverkb.com",
+  "license": "MIT",
+  "author": "Hiver",
+  "homepage": "https://github.com/geekv30/kb#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/geekv30/kb.git",
+    "directory": "packages/kb-ui"
+  },
+  "bugs": {
+    "url": "https://github.com/geekv30/kb/issues"
+  },
+  "keywords": [
+    "hiver",
+    "kb",
+    "knowledge-base",
+    "react",
+    "components",
+    "ui",
+    "tailwind"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -16,6 +36,13 @@
   "files": [
     "dist"
   ],
+  "sideEffects": [
+    "**/*.css"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",


### PR DESCRIPTION
## Summary

Phase 8 npm publish prep. Closes #2.

Adds 8 npm-standard fields to `packages/kb-ui/package.json`:
- Manifest: `license`, `author`, `homepage`, `repository`, `bugs`, `keywords`
- Packaging: `sideEffects: ["**/*.css"]`, `publishConfig: { access: "public" }`

## Why each one

- **license / author / homepage / repository / bugs** — npmjs.com renders these on the package page; required for a credible v1 release
- **keywords** — discoverability
- **sideEffects: ["**/*.css"]** — tells bundlers tree-shaking is safe for JS but `import '@hiver/kb-ui/styles'` must be preserved (would otherwise be dead-code-eliminated)
- **publishConfig.access: "public"** — scoped packages default to private; without this `npm publish` errors

## Verification

- [x] `npm run build` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm pack` produces tarball containing `dist/index.*`, `dist/tokens.css`, `package.json` only
- [x] Extracted tarball manifest confirms all 8 new fields populated correctly
- [x] No existing field modified (existing exports/files/scripts/deps untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)