### PR TITLE
docs: add LICENSE, READMEs, CHANGELOG (closes #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog
+
+All notable changes to `@hiver/kb-ui` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] — 2026-04-28
+
+Initial public release. Built across nine phases (0 through 7.5) culminating in a 56/56 cold-walk sign-off via the `apps/demo` integration harness.
+
+### Added
+
+#### Primitives
+
+- `Button` (with `ButtonVariant`)
+- `Badge` (with `BadgeVariant`)
+- `Avatar`
+- `TextInput`
+- `Dropdown`
+- `Divider`
+- `Breadcrumb` (with `BreadcrumbItem`)
+- `Card` (with `CardPadding`)
+
+#### Shell
+
+- `AppShell`
+- `KBBreadcrumbBar` (with `KBBreadcrumbItem`)
+
+#### Navigation
+
+- `SideNavRail` (with `NavRailItem`)
+- `FileExplorerNav` (with `NavItem`)
+
+#### Content
+
+- `DataTable` (with `DataTableColumn`)
+- `PageHeader` (with `PageHeaderSize`)
+- `ArticleBody` (with `ArticleBodyDecisions`, `ArticleSuggestionDecision`)
+- `SuggestionBlock`
+- `SuggestionCard` (with `SuggestionKind`, `SuggestionImpact`)
+- `NavArrow`
+
+#### Editor
+
+- `ContentEditor` (Tiptap-based)
+- `ArticleSettingsPanel` (with `ArticleSettings`, `ArticleSettingsPerson`, `ArticleVisibility`)
+
+#### AI gaps surface
+
+- `AISuggestionsCard` (with `AISuggestionsCardMode`)
+- `AIGapSuggestionCard`
+- `AICard` (with `AICardMode`)
+- Shared types: `AISuggestion`, `AISuggestionType`, `AISuggestionDecision`, `AISuggestionState`
+
+#### Analytics
+
+- `StatCard` (with `StatTrendDirection`)
+- `StatCardGrid`
+- `DateRangePill` (with `DateRange`)
+- `AnalyticsAreaChart` (with `AnalyticsAreaSeries`, `AnalyticsAreaChartGoalLine`, `AreaSeriesKey`)
+- `AnalyticsDonutChart` (with `DonutDatum`)
+- `AnalyticsChartCard`
+- `HelpfulnessTag` (with `HelpfulnessVariant`)
+- `AIConversationLogEntry` (with `AIConversationFeedback`, `AIConversationFollowUp`, `AIConversationTail`)
+- `AIConversationLogsCard` (with `SortOption`)
+
+#### Overlays
+
+- `SourcesSideSheet` (with `ConversationSource`)
+
+#### Brand
+
+- `CompanyLogo`
+- `AiIcon`
+
+#### Hooks
+
+- `useAIGapsReducer` plus `aiGapsReducer`, `initialAIGapsState`, `isPublishEnabled`, `isAllReviewed`
+- Types: `AIGapsState`, `AIGapsAction`, `AIGapsMode`, `UseAIGapsReducerResult`
+
+#### Foundations
+
+- Design tokens (`tokens.ts` plus `tokens.css`) — colors (kb palette, AI gaps semantic palette, analytics chart palette), typography, spacing, border radius
+- `import '@hiver/kb-ui/styles'` exposes the canonical Tailwind v4 plus tokens layer
+- `cn` utility re-exported for class composition
+
+[1.0.0]: https://github.com/geekv30/kb/releases/tag/v1.0.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hiver
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# Hiver KB Component Library
+
+`@hiver/kb-ui` is the React component library that powers Hiver's knowledge base product (`app.hiverkb.com`). It exists so designers, PMs, and engineers can assemble any new KB feature directly from a PRD — every primitive, nav surface, content block, editor, AI gap reviewer, and analytics card needed to match the product is already in the box, with 1:1 Figma fidelity.
+
+- npm: [`@hiver/kb-ui`](https://www.npmjs.com/package/@hiver/kb-ui)
+- Demo app: see "Explore" below
+
+## Install
+
+```bash
+npm install @hiver/kb-ui
+```
+
+## Quickstart
+
+```tsx
+import { AppShell, KBBreadcrumbBar, SideNavRail, FileExplorerNav } from '@hiver/kb-ui';
+import '@hiver/kb-ui/styles';
+
+export function App() {
+  return (
+    <AppShell
+      rail={<SideNavRail items={[]} activeId="home" />}
+      explorer={<FileExplorerNav items={[]} />}
+      breadcrumb={<KBBreadcrumbBar items={[{ id: 'home', label: 'Knowledge base' }]} />}
+    >
+      {/* your KB content here */}
+    </AppShell>
+  );
+}
+```
+
+## What's in the box
+
+About 40 components, organized by role:
+
+- **Primitives** — `Button`, `Badge`, `Avatar`, `TextInput`, `Dropdown`, `Divider`, `Breadcrumb`, `Card`
+- **Shell** — `AppShell`, `KBBreadcrumbBar`
+- **Navigation** — `SideNavRail`, `FileExplorerNav`
+- **Content** — `DataTable`, `PageHeader`, `ArticleBody`, `SuggestionBlock`, `SuggestionCard`, `NavArrow`
+- **Editor** (Tiptap-based) — `ContentEditor`, `ArticleSettingsPanel`
+- **AI gaps surface** — `AISuggestionsCard`, `AIGapSuggestionCard`, `AICard`
+- **Analytics** — `StatCard`, `StatCardGrid`, `DateRangePill`, `AnalyticsAreaChart`, `AnalyticsDonutChart`, `AnalyticsChartCard`, `HelpfulnessTag`, `AIConversationLogEntry`, `AIConversationLogsCard`
+- **Overlays** — `SourcesSideSheet`
+- **Brand** — `CompanyLogo`, `AiIcon`
+- **Hooks** — `useAIGapsReducer` (with `aiGapsReducer`, `initialAIGapsState`, `isPublishEnabled`, `isAllReviewed` and `AIGapsState` / `AIGapsAction` / `AIGapsMode` types)
+
+## Explore
+
+- **Storybook** — `npm run kb-ui:storybook` from the repo root (local for now; hosted Storybook is a future phase).
+- **Demo app** — `npm run demo:dev` from the repo root, launches a Vite app stitching every Phase 3-7 page pattern into one navigable product.
+
+## Tech stack
+
+React 18 + TypeScript strict, Tailwind CSS v4, Radix UI primitives, Tiptap (editor), Recharts (analytics), `@remixicon/react` (icons), tsup (build).
+
+## License
+
+MIT

--- a/packages/kb-ui/README.md
+++ b/packages/kb-ui/README.md
@@ -1,0 +1,37 @@
+# @hiver/kb-ui
+
+Pixel-perfect React component library for Hiver's knowledge base product — primitives, shell, nav, content, editor, AI gap review surface, and analytics in one package.
+
+## Install
+
+```bash
+npm install @hiver/kb-ui
+```
+
+## Quickstart
+
+```tsx
+import { AppShell, KBBreadcrumbBar, SideNavRail, FileExplorerNav } from '@hiver/kb-ui';
+import '@hiver/kb-ui/styles';
+
+export function App() {
+  return (
+    <AppShell
+      rail={<SideNavRail items={[]} activeId="home" />}
+      explorer={<FileExplorerNav items={[]} />}
+      breadcrumb={<KBBreadcrumbBar items={[{ id: 'home', label: 'Knowledge base' }]} />}
+    >
+      {/* your KB content here */}
+    </AppShell>
+  );
+}
+```
+
+## Documentation
+
+- [Repo README](https://github.com/geekv30/kb#readme)
+- Storybook (local: clone the repo, run `npm run kb-ui:storybook`)
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

Phase 8 npm publish prep. Closes #3.

Adds four new files:
- `LICENSE` — MIT
- `README.md` (repo root) — pitch + install + quickstart + component inventory
- `packages/kb-ui/README.md` — shorter npmjs.com landing page
- `CHANGELOG.md` — 1.0.0 entry dated 2026-04-28

## Verification

- [x] All component names in quickstart + CHANGELOG cross-checked against `packages/kb-ui/src/index.ts`
- [x] Quickstart snippet uses real prop interfaces (type-checks)
- [x] No section-sign character anywhere
- [x] `npm pack` from `packages/kb-ui/` tarball now includes `README.md` alongside `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)