### PR TITLE
fix(demo): finish phase 7.5 follow-through (closes #13)

### DIFF
--- a/apps/demo/src/routes/analytics/AIAnswerPerformancePage.tsx
+++ b/apps/demo/src/routes/analytics/AIAnswerPerformancePage.tsx
@@ -1,15 +1,17 @@
 // Phase 7.5.7 — Analytics: AI Answer Performance.
 //
-// Mirrors `KBAnalyticsAIAnswerPerformancePage` story composition exactly
-// (per CLAUDE.md "reuse main components, never recreate"). The story is
-// already pixel-tuned per Figma `1974:53167`.
+// Mirrors `packages/kb-ui/src/pages/KBAnalyticsAIAnswerPerformancePage.stories.tsx` —
+// uses `DataTable` + inline columns per Phase 7.5 consolidation.
+// `citedColumns` is lifted verbatim from the story; only the row-click
+// wiring is local (it maps a fixture id back to the real article slug
+// for navigation).
 //
 // Page composition (top → bottom):
 //   1. Custom <header>: title + subtitle | DateRangePill
 //   2. StatCardGrid "AI Search Performance" — 4 metrics
 //   3. AnalyticsChartCard "AI deflection rate over time" (positive area + Goal:70%)
 //   4. AIConversationLogsCard with 5 anonymised entries
-//   5. MostCitedArticlesTable
+//   5. DataTable "Most Cited KB Articles"
 //
 // Interactions (PRD §7.8):
 //   - DateRangePill change → toast placeholder
@@ -19,24 +21,57 @@
 //     opens, but the placeholder log fires alongside it. v1 wiring per
 //     PRD § 7.8 — the real "open contextual conversation drawer" lands
 //     in a future phase.)
-//   - MostCitedArticlesTable row → /articles/<slug>/edit
+//   - Most Cited row → /articles/<slug>/edit
 
 import type { MouseEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { RiFile3Line, RiInformationLine } from '@remixicon/react';
 import {
   AIConversationLogEntry,
   AIConversationLogsCard,
   AnalyticsAreaChart,
   AnalyticsChartCard,
+  DataTable,
   DateRangePill,
-  MostCitedArticlesTable,
   StatCardGrid,
+  type DataTableColumn,
 } from '@hiver/kb-ui';
 import { useMockStore } from '../../store/MockStoreContext';
 import { selectArticleById } from '../../store/selectors';
-import { aiAnswerFixtures } from '../../store/fixtures/analytics';
+import {
+  aiAnswerFixtures,
+  type MostCitedRow,
+} from '../../store/fixtures/analytics';
 import { routes } from '../../lib/routes';
 import { useToast } from '../../components/Toast';
+
+/* ─────────────────────────────────────────────────────────────
+ * Column config — lifted verbatim from
+ * `KBAnalyticsAIAnswerPerformancePage.stories.tsx`.
+ * ───────────────────────────────────────────────────────────── */
+
+const citedColumns: DataTableColumn<MostCitedRow>[] = [
+  {
+    id: 'title',
+    header: 'Article Title',
+    render: (r) => (
+      <span className="inline-flex items-center gap-2">
+        <RiFile3Line
+          size={16}
+          className="shrink-0 text-[#64758b]"
+          aria-hidden="true"
+        />
+        <span>{r.title}</span>
+      </span>
+    ),
+  },
+  {
+    id: 'citations',
+    header: 'Citations',
+    align: 'right',
+    render: (r) => r.citations,
+  },
+];
 
 export default function AIAnswerPerformancePage() {
   const navigate = useNavigate();
@@ -145,7 +180,27 @@ export default function AIAnswerPerformancePage() {
       </div>
 
       {/* Most cited articles */}
-      <MostCitedArticlesTable rows={mostCitedRows} onRowClick={goToArticle} />
+      <DataTable
+        dataKbComponent="most-cited-articles-table"
+        rows={mostCitedRows}
+        columns={citedColumns}
+        emptyMessage="No cited articles"
+        heading={
+          <div className="flex items-center">
+            <h3 className="text-[14px] font-medium leading-[20px] text-[#0f172a]">
+              Most Cited KB Articles
+            </h3>
+            <span className="ml-2 inline-flex" aria-hidden>
+              <RiInformationLine
+                size={16}
+                className="text-[#475569]"
+                aria-hidden="true"
+              />
+            </span>
+          </div>
+        }
+        onRowClick={(row) => goToArticle(row.id)}
+      />
     </div>
   );
 }

--- a/apps/demo/src/routes/analytics/ArticlePerformancePage.tsx
+++ b/apps/demo/src/routes/analytics/ArticlePerformancePage.tsx
@@ -1,41 +1,133 @@
 // Phase 7.5.7 — Analytics: Article Performance.
 //
-// Mirrors `KBAnalyticsArticlePerformancePage` story composition exactly
-// (per CLAUDE.md "reuse main components, never recreate"). The story is
-// already pixel-tuned per Figma `1974:53692`; we just consume the same
-// kb-ui components with this app's fixtures + real navigation handlers.
+// Mirrors `packages/kb-ui/src/pages/KBAnalyticsArticlePerformancePage.stories.tsx` —
+// uses `DataTable` + inline columns per Phase 7.5 consolidation.
+// Column configs (`attentionColumns`, `performanceColumns`) are
+// lifted verbatim from the story; only the row-click wiring is local
+// (it maps a fixture id back to the real article slug for navigation).
 //
 // Page composition (top → bottom):
 //   1. Custom <header>: title + subtitle (left) | DateRangePill (right)
 //   2. StatCardGrid "Support Performance" — 4 metrics
 //   3. AnalyticsChartCard "Article views over time" wrapping 2-series area chart
-//   4. 2-up: AnalyticsChartCard "Views by Category" (donut) | ArticlesNeedsAttentionTable
-//   5. ArticlePerformanceTable (full width)
+//   4. 2-up: AnalyticsChartCard "Views by Category" (donut) | DataTable needs-attention
+//   5. DataTable "Article Performance" (full width)
 //
 // Interactions (PRD §7.6):
-//   - DateRangePill click → toast placeholder (console.log; real toast in 7.5.8)
-//   - ArticlesNeedsAttentionTable row → /articles/<slug>/edit
-//   - ArticlePerformanceTable row → /articles/<slug>/edit
+//   - DateRangePill click → toast placeholder
+//   - Articles needing attention row → /articles/<slug>/edit
+//   - Article Performance row → /articles/<slug>/edit
 //
 // NB: kb-ui's `PageHeader` ships an opinionated "+ New article" CTA that
 // the analytics design does not show, so we match the story's plain
 // <header> element instead of forcing an unrelated component.
 
 import { useNavigate } from 'react-router-dom';
+import { RiFile3Line, RiInformationLine } from '@remixicon/react';
 import {
   AnalyticsAreaChart,
   AnalyticsChartCard,
   AnalyticsDonutChart,
-  ArticlePerformanceTable,
-  ArticlesNeedsAttentionTable,
+  DataTable,
   DateRangePill,
+  HelpfulnessTag,
   StatCardGrid,
+  type DataTableColumn,
 } from '@hiver/kb-ui';
 import { useMockStore } from '../../store/MockStoreContext';
 import { selectArticleById } from '../../store/selectors';
-import { articlePerformanceFixtures } from '../../store/fixtures/analytics';
+import {
+  articlePerformanceFixtures,
+  type ArticleAttentionRow,
+  type ArticlePerformanceRow,
+} from '../../store/fixtures/analytics';
 import { routes } from '../../lib/routes';
 import { useToast } from '../../components/Toast';
+
+/* ─────────────────────────────────────────────────────────────
+ * Column configs — lifted verbatim from
+ * `KBAnalyticsArticlePerformancePage.stories.tsx`.
+ * ───────────────────────────────────────────────────────────── */
+
+const attentionColumns: DataTableColumn<ArticleAttentionRow>[] = [
+  {
+    id: 'title',
+    header: 'Article Title',
+    render: (r) => (
+      <div className="flex items-center gap-2 min-w-0 pr-2">
+        <RiFile3Line
+          size={16}
+          className="shrink-0 text-[#64758b]"
+          aria-hidden="true"
+        />
+        <span className="truncate">{r.title}</span>
+      </div>
+    ),
+  },
+  {
+    id: 'helpfulness',
+    header: 'Helpfulness',
+    align: 'right',
+    render: (r) => <HelpfulnessTag value={r.helpfulness} variant={r.variant} />,
+  },
+];
+
+const performanceColumns: DataTableColumn<ArticlePerformanceRow>[] = [
+  {
+    id: 'title',
+    header: 'Article Title',
+    width: 230,
+    render: (r) => (
+      <div className="flex items-center gap-2 min-w-0 pr-2">
+        <RiFile3Line
+          size={16}
+          className="shrink-0 text-[#64758b]"
+          aria-hidden="true"
+        />
+        <span className="truncate">{r.title}</span>
+      </div>
+    ),
+  },
+  {
+    id: 'category',
+    header: 'Category',
+    width: 208,
+    headerClassName: 'pl-6',
+    className: 'pl-6',
+    render: (r) => (
+      <span className="inline-flex items-center px-2.5 py-1 rounded-full bg-[#f7f7f7] text-[13px] font-normal leading-[19px] text-[#0f172a]">
+        {r.category}
+      </span>
+    ),
+  },
+  {
+    id: 'totalViews',
+    header: 'Total Views',
+    width: 126,
+    headerClassName: 'pl-6',
+    className: 'pl-6',
+    render: (r) => r.totalViews,
+  },
+  {
+    id: 'avgTimeSpent',
+    header: 'Avg. Time Spent',
+    width: 158,
+    headerClassName: 'pl-6',
+    className: 'pl-6',
+    render: (r) => r.avgTimeSpent,
+  },
+  {
+    id: 'helpfulness',
+    header: 'Helpfulness',
+    width: 128,
+    align: 'right',
+    headerClassName: 'pr-6',
+    className: 'pr-6',
+    render: (r) => (
+      <HelpfulnessTag value={r.helpfulness} variant={r.helpfulnessVariant} />
+    ),
+  },
+];
 
 export default function ArticlePerformancePage() {
   const navigate = useNavigate();
@@ -113,15 +205,68 @@ export default function ArticlePerformancePage() {
           </AnalyticsChartCard>
         </div>
         <div className="flex-1 min-w-0">
-          <ArticlesNeedsAttentionTable
+          <DataTable
+            dataKbComponent="articles-needs-attention-table"
             rows={needsAttentionRows}
-            onRowClick={goToArticle}
+            columns={attentionColumns}
+            emptyMessage="No articles"
+            headingGap={8}
+            heading={
+              <div>
+                <div className="flex items-center">
+                  <h3 className="text-[14px] font-medium leading-[20px] text-[#0f172a]">
+                    Articles needs attention
+                  </h3>
+                  <RiInformationLine
+                    size={16}
+                    className="ml-2 text-[#475569]"
+                    aria-hidden="true"
+                  />
+                  <span className="flex-1" />
+                  <span
+                    className="inline-flex items-center px-2 py-0.5 rounded-full bg-[#f7f7f7] text-[12px] font-medium leading-[18px] text-[#0f172a]"
+                    aria-label={`${needsAttentionRows.length} Articles`}
+                  >
+                    {`${needsAttentionRows.length} Articles`}
+                  </span>
+                </div>
+                <p className="mt-1 text-[13px] font-normal leading-[19px] text-[#475569]">
+                  Articles with very low helpfulness index
+                </p>
+                <div className="mt-4 h-px bg-[#e2e8f0]" />
+              </div>
+            }
+            headerDivider={false}
+            onRowClick={(row) => goToArticle(row.id)}
           />
         </div>
       </div>
 
       {/* Article Performance table */}
-      <ArticlePerformanceTable rows={performanceRows} onRowClick={goToArticle} />
+      <DataTable
+        dataKbComponent="article-performance-table"
+        rows={performanceRows}
+        columns={performanceColumns}
+        emptyMessage="No articles"
+        headingGap={8}
+        heading={
+          <div>
+            <div className="flex items-center">
+              <h3 className="text-[14px] font-medium leading-[20px] text-[#0f172a]">
+                Article Performance
+              </h3>
+              <RiInformationLine
+                size={16}
+                className="ml-2 text-[#475569]"
+                aria-hidden="true"
+              />
+            </div>
+            <div className="mt-4 h-px bg-[#e2e8f0]" />
+          </div>
+        }
+        headerDivider={false}
+        onRowClick={(row) => goToArticle(row.id)}
+      />
     </div>
   );
 }

--- a/apps/demo/src/routes/analytics/SearchPage.tsx
+++ b/apps/demo/src/routes/analytics/SearchPage.tsx
@@ -1,31 +1,77 @@
 // Phase 7.5.7 — Analytics: Search.
 //
-// Mirrors `KBAnalyticsSearchPage` story composition exactly (per
-// CLAUDE.md "reuse main components, never recreate"). The story is
-// already pixel-tuned per Figma `1974:54154`.
+// Mirrors `packages/kb-ui/src/pages/KBAnalyticsSearchPage.stories.tsx` —
+// uses `DataTable` + inline columns per Phase 7.5 consolidation.
+// Column configs (`keywordColumns`, `gapColumns`) are lifted verbatim
+// from the story; the only adaptation is wiring "Write Article" CTAs
+// (and the DateRangePill) into the demo's toast helper.
 //
 // Page composition (top → bottom):
 //   1. Custom <header>: title + subtitle | DateRangePill
 //   2. 2-up:
 //      - AnalyticsChartCard "Search vol. over time"  (single-series area, no legend)
 //      - AnalyticsChartCard "Missed search rate"     (single-series area + Goal:70% line)
-//   3. SearchKeywordsTable
-//   4. ContentGapsTable
+//   3. DataTable "Top 5 Search Keywords"
+//   4. DataTable "Content Gaps" (with "Write Article" action button)
 //
 // Interactions (PRD §7.7):
 //   - DateRangePill change → toast placeholder
 //   - SearchKeywordsTable rows: no-op v1
 //   - ContentGapsTable rows: no-op v1
+//   - "Write Article" button → toast placeholder
 
+import { RiInformationLine, RiQuillPenLine } from '@remixicon/react';
 import {
   AnalyticsAreaChart,
   AnalyticsChartCard,
-  ContentGapsTable,
+  cn,
+  DataTable,
   DateRangePill,
-  SearchKeywordsTable,
+  type DataTableColumn,
 } from '@hiver/kb-ui';
-import { searchFixtures } from '../../store/fixtures/analytics';
+import {
+  searchFixtures,
+  type ContentGapRow,
+  type SearchKeywordRow,
+} from '../../store/fixtures/analytics';
 import { useToast } from '../../components/Toast';
+
+/* ─────────────────────────────────────────────────────────────
+ * Column configs — lifted verbatim from
+ * `KBAnalyticsSearchPage.stories.tsx`.
+ * ───────────────────────────────────────────────────────────── */
+
+const keywordColumns: DataTableColumn<SearchKeywordRow>[] = [
+  { id: 'keyword', header: 'Keywords', render: (r) => r.keyword },
+  {
+    id: 'count',
+    header: 'Search Count',
+    align: 'right',
+    render: (r) => r.count,
+  },
+];
+
+function WriteArticleButton({ onClick }: { onClick?: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-[6px] bg-[#f1f5f9] px-2 py-1',
+        'text-[14px] font-medium leading-[20px] text-[#0f172a]',
+        'transition-colors hover:bg-[#e2e8f0]',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
+      )}
+    >
+      <RiQuillPenLine
+        size={14}
+        className="text-[#475569]"
+        aria-hidden="true"
+      />
+      Write Article
+    </button>
+  );
+}
 
 export default function SearchPage() {
   const { showToast } = useToast();
@@ -43,6 +89,23 @@ export default function SearchPage() {
     // PRD §7.7: DateRangePill → no-op v1.
     showToast('Coming soon.', 'info');
   };
+
+  const handleWriteArticle = () => {
+    // PRD §7.7: "Write Article" button → no-op v1.
+    showToast('Coming soon.', 'info');
+  };
+
+  /* ── Content-gap columns — bound to the local toast helper. ── */
+  const gapColumns: DataTableColumn<ContentGapRow>[] = [
+    { id: 'topic', header: 'Topic', render: (r) => r.topic },
+    { id: 'frequency', header: 'Frequency', render: (r) => r.frequency },
+    { id: 'ticketRate', header: 'Ticket Rate', render: (r) => r.ticketRate },
+    {
+      id: 'action',
+      header: 'Action',
+      render: () => <WriteArticleButton onClick={handleWriteArticle} />,
+    },
+  ];
 
   return (
     <div data-route="analytics-search" className="flex flex-col gap-5">
@@ -94,10 +157,54 @@ export default function SearchPage() {
       </div>
 
       {/* Search keywords */}
-      <SearchKeywordsTable rows={keywordRows} />
+      <DataTable
+        dataKbComponent="search-keywords-table"
+        rows={keywordRows}
+        columns={keywordColumns}
+        emptyMessage="No keywords"
+        heading={
+          <div className="flex items-center">
+            <h3 className="text-[14px] font-medium leading-[20px] text-[#0f172a]">
+              Top 5 Search Keywords
+            </h3>
+            <span className="ml-2 inline-flex" aria-hidden>
+              <RiInformationLine
+                size={16}
+                className="text-[#475569]"
+                aria-hidden="true"
+              />
+            </span>
+          </div>
+        }
+      />
 
       {/* Content gaps */}
-      <ContentGapsTable rows={contentGapRows} />
+      <DataTable
+        dataKbComponent="content-gaps-table"
+        rows={contentGapRows}
+        columns={gapColumns}
+        emptyMessage="No content gaps"
+        heading={
+          <div>
+            <div className="flex items-center">
+              <h3 className="text-[14px] font-medium leading-[20px] text-[#0f172a]">
+                Content Gaps
+              </h3>
+              <span className="ml-2 inline-flex" aria-hidden>
+                <RiInformationLine
+                  size={16}
+                  className="text-[#475569]"
+                  aria-hidden="true"
+                />
+              </span>
+            </div>
+            <p className="mt-1 text-[13px] font-normal leading-[19px] text-[#475569]">
+              Topics users searched for but didn&apos;t find. Write articles
+              to close these gaps
+            </p>
+          </div>
+        }
+      />
     </div>
   );
 }

--- a/apps/demo/src/routes/kb/CategoryPage.tsx
+++ b/apps/demo/src/routes/kb/CategoryPage.tsx
@@ -1,10 +1,12 @@
 // Phase 7.5.4 — Category page.
 //
-// Composes the kb-ui `PageHeader` + `SubCategoriesTable` + `ArticlesTable`
-// per TRD §7.3. Resolves the deepest URL segment to a category, lists
-// its child sub-categories and articles, and wires the "+ New" CTA to
-// `editor/createNew` followed by an immediate navigation to the new
-// article's editor (PRD Journey A step 13).
+// Mirrors `packages/kb-ui/src/pages/KBCategoryPage.stories.tsx` —
+// uses `DataTable` + inline columns per Phase 7.5 consolidation.
+// The legacy `ArticlesTable` / `SubCategoriesTable` components were
+// collapsed into the single canonical `<DataTable<T> />` primitive in
+// commit `de1f197`; row geometry, colours, and chrome remain identical
+// (white card, slate border, 8 px radius, grey #f5f5f5 header,
+// 6 px vertical cell padding, h-12 row height).
 //
 // All visual elements come from `@hiver/kb-ui`. The only bespoke UI is
 // (a) the inline "category not found" state and (b) the inline empty
@@ -13,13 +15,19 @@
 
 import { useCallback, useMemo } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
-import { RiFile3Line } from '@remixicon/react';
 import {
-  ArticlesTable,
+  RiArrowRightSLine,
+  RiFile3Line,
+  RiFolderLine,
+  RiMore2Line,
+} from '@remixicon/react';
+import {
+  Avatar,
+  Badge,
+  cn,
+  DataTable,
   PageHeader,
-  SubCategoriesTable,
-  type Article as TableArticle,
-  type SubCategory as TableSubCategory,
+  type DataTableColumn,
 } from '@hiver/kb-ui';
 import { useMockStore } from '../../store/MockStoreContext';
 import {
@@ -33,9 +41,167 @@ import { formatRelativeDate } from '../../lib/relativeDate';
 import { EmptyState } from '../../components/EmptyState';
 
 /* ─────────────────────────────────────────────────────────────
+ * Row types — co-located with the page that owns them.
+ *
+ * These match the (now-dropped) `SubCategory` / `Article` shapes
+ * from kb-ui pre-Phase-7.5. `articleCount` is kept on the row for
+ * potential future use, but is not rendered (matches legacy
+ * SubCategoriesTable, which never displayed it either).
+ * ───────────────────────────────────────────────────────────── */
+
+type SubCategoryRow = {
+  id: string;
+  title: string;
+  articleCount: number;
+};
+
+type ArticleRow = {
+  id: string;
+  title: string;
+  status: 'published' | 'draft';
+  authorInitials?: string;
+  lastUpdated: string;
+};
+
+/* ─────────────────────────────────────────────────────────────
+ * Column configs — lifted verbatim from
+ * `KBCategoryPage.stories.tsx`. Geometry is the legacy
+ * ArticlesTable / SubCategoriesTable unwrapped chrome (white
+ * card, slate border, 8 px radius, grey #f5f5f5 header,
+ * 6-px vertical cell padding).
+ * ───────────────────────────────────────────────────────────── */
+
+const subCategoryColumns: DataTableColumn<SubCategoryRow>[] = [
+  {
+    id: 'title',
+    header: 'Sub-categories',
+    headerClassName: 'pl-4 pr-0 py-0 text-[#475569]',
+    className: 'pl-4 pr-0',
+    render: (item) => (
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          aria-label={`Open ${item.title}`}
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-[#64758b]',
+            'hover:bg-[#f8fafc] focus:bg-[#f8fafc] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]',
+          )}
+        >
+          <RiFolderLine size={16} aria-hidden="true" />
+        </button>
+        <span className="text-[14px] font-normal leading-[20px] text-[#0f172a]">
+          {item.title}
+        </span>
+      </div>
+    ),
+  },
+  {
+    id: 'chev',
+    header: '',
+    align: 'right',
+    width: 48,
+    headerClassName: 'pl-0 pr-4 py-0',
+    className: 'pl-0 pr-4',
+    render: () => (
+      <div className="flex items-center justify-end">
+        <RiArrowRightSLine
+          size={16}
+          className="text-[#64758b]"
+          aria-hidden="true"
+        />
+      </div>
+    ),
+  },
+];
+
+const articleColumns: DataTableColumn<ArticleRow>[] = [
+  {
+    id: 'title',
+    header: 'Articles',
+    headerClassName: 'pl-4 pr-0 py-0 text-[#475569]',
+    className: 'px-4',
+    render: (a) => (
+      <div className="flex items-center gap-1 min-w-0">
+        <button
+          type="button"
+          aria-label={`Open ${a.title}`}
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-[#64758b]',
+            'hover:bg-[#f8fafc] focus:bg-[#f8fafc] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]',
+          )}
+        >
+          <RiFile3Line size={16} aria-hidden="true" />
+        </button>
+        <span className="text-[14px] font-normal leading-[20px] text-[#0f172a] truncate">
+          {a.title}
+        </span>
+      </div>
+    ),
+  },
+  {
+    id: 'kebab',
+    header: '',
+    align: 'center',
+    width: 48,
+    headerClassName: 'px-0 py-0',
+    className: 'px-0',
+    render: (a) => (
+      <div className="flex items-center justify-center">
+        <button
+          type="button"
+          aria-label={`More actions for ${a.title}`}
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-[#94a3b8]',
+            'hover:bg-[#f8fafc] focus:bg-[#f8fafc] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]',
+          )}
+        >
+          <RiMore2Line size={16} aria-hidden="true" />
+        </button>
+      </div>
+    ),
+  },
+  {
+    id: 'status',
+    header: 'Status',
+    width: 127,
+    headerClassName: 'px-4 py-0 text-[#475569]',
+    className: 'px-4',
+    render: (a) => (
+      <Badge variant={a.status}>
+        {a.status === 'published' ? 'Published' : 'Draft'}
+      </Badge>
+    ),
+  },
+  {
+    id: 'author',
+    header: 'Author',
+    align: 'center',
+    width: 94,
+    headerClassName: 'px-4 py-0 text-[#475569]',
+    className: 'px-4',
+    render: (a) => (
+      <div className="flex items-center justify-center">
+        {a.authorInitials ? <Avatar initials={a.authorInitials} /> : null}
+      </div>
+    ),
+  },
+  {
+    id: 'updated',
+    header: 'Last Updated',
+    width: 251,
+    headerClassName: 'px-4 py-0 text-[#475569]',
+    className: 'px-4',
+    render: (a) => <span className="text-[#64758b]">{a.lastUpdated}</span>,
+  },
+];
+
+/* ─────────────────────────────────────────────────────────────
  * View-model helpers
  *
- * The store's domain shapes don't 1:1 match the kb-ui table props,
+ * The store's domain shapes don't 1:1 match the table row shapes,
  * so we project them here. Keeps the JSX tidy and makes it obvious
  * which fields the tables actually consume.
  * ───────────────────────────────────────────────────────────── */
@@ -43,7 +209,7 @@ import { EmptyState } from '../../components/EmptyState';
 function toSubCategoryRow(
   cat: Category,
   articleCount: number,
-): TableSubCategory {
+): SubCategoryRow {
   return {
     id: cat.id,
     title: cat.title,
@@ -54,7 +220,7 @@ function toSubCategoryRow(
 function toArticleRow(
   article: Article,
   author: User | undefined,
-): TableArticle {
+): ArticleRow {
   return {
     id: article.id,
     title: article.title,
@@ -203,23 +369,23 @@ export default function CategoryPage() {
   const childCategories = selectChildCategories(state, category.id);
   const articles = selectArticlesInCategory(state, category.id);
 
-  const subCategoryRows: TableSubCategory[] = childCategories.map((c) =>
+  const subCategoryRows: SubCategoryRow[] = childCategories.map((c) =>
     toSubCategoryRow(c, selectArticlesInCategory(state, c.id).length),
   );
-  const articleRows: TableArticle[] = articles.map((a) =>
+  const articleRows: ArticleRow[] = articles.map((a) =>
     toArticleRow(a, state.users[a.authorId]),
   );
 
   /* ── Click handlers ────────────────────────────────────────── */
 
-  const handleSubCategoryClick = (childId: string) => {
-    const child = state.categories[childId];
+  const handleSubCategoryClick = (row: SubCategoryRow) => {
+    const child = state.categories[row.id];
     if (!child) return;
     navigate(buildChildCategoryUrl(child, topLevel, mid, depth2));
   };
 
-  const handleArticleClick = (articleId: string) => {
-    const article = state.articles[articleId];
+  const handleArticleClick = (row: ArticleRow) => {
+    const article = state.articles[row.id];
     if (!article) return;
     navigate(routes.article(article.slug));
   };
@@ -242,15 +408,27 @@ export default function CategoryPage() {
       ) : (
         <>
           {subCategoryRows.length > 0 && (
-            <SubCategoriesTable
-              items={subCategoryRows}
-              onItemClick={handleSubCategoryClick}
+            <DataTable
+              dataKbComponent="sub-categories-table"
+              rows={subCategoryRows}
+              columns={subCategoryColumns}
+              wrapped={false}
+              headerBackground="#f5f5f5"
+              cellPaddingY={6}
+              emptyMessage="No sub-categories"
+              onRowClick={handleSubCategoryClick}
             />
           )}
           {articleRows.length > 0 && (
-            <ArticlesTable
-              articles={articleRows}
-              onArticleClick={handleArticleClick}
+            <DataTable
+              dataKbComponent="articles-table"
+              rows={articleRows}
+              columns={articleColumns}
+              wrapped={false}
+              headerBackground="#f5f5f5"
+              cellPaddingY={6}
+              emptyMessage="No articles"
+              onRowClick={handleArticleClick}
             />
           )}
         </>

--- a/apps/demo/src/shell/AISubNav.tsx
+++ b/apps/demo/src/shell/AISubNav.tsx
@@ -1,0 +1,149 @@
+// Figma: 9aGp5t9fH1d0PXi4LMhOdb#74:8871 (AI sub-rail, from the AI Optimise hub 74:8928)
+import * as React from 'react';
+import { cn } from '../lib/cn';
+
+/* ─────────────────────────────────────────────────────────────
+ * Types
+ * ───────────────────────────────────────────────────────────── */
+
+export type AISubNavItem = {
+  id: string;
+  icon: React.ReactNode;
+  label: string;
+  /**
+   * Visual role of the row.
+   * - `section`: renders a 1px inset divider BELOW the row; active state
+   *   (if any) has no pill bg — sections remain visually recessive.
+   * - `item`: no divider; active state renders a `#f1f5f9` pill.
+   *
+   * Both kinds are clickable — the distinction is visual only.
+   */
+  kind: 'section' | 'item';
+};
+
+export type AISubNavProps = {
+  items: AISubNavItem[];
+  activeId?: string;
+  onItemClick?: (id: string) => void;
+  className?: string;
+};
+
+/* ─────────────────────────────────────────────────────────────
+ * Internal — one row
+ *
+ * Geometry (measured from Figma 74:8871):
+ *   - Panel width 288, outer horizontal padding 16/16.
+ *   - Row height 44. Icon slot 20 (renders an 18-20px glyph inside).
+ *   - Label: 14/medium, primary text (#0f172a) — both kinds.
+ *   - Active pill: #f1f5f9 (surface-muted), radius 8, fills 256px width
+ *     (288 − 16L − 16R). Only on `kind: 'item'`.
+ *   - Hover pill: #f8fafc on non-active rows (both kinds).
+ * ───────────────────────────────────────────────────────────── */
+
+type RowProps = {
+  item: AISubNavItem;
+  isActive: boolean;
+  onClick: () => void;
+};
+
+function Row({ item, isActive, onClick }: RowProps) {
+  // Pill visibility rules per Figma:
+  // - section + active  → no pill (section rows don't highlight)
+  // - item + active     → #f1f5f9 pill
+  // - default / hover   → transparent / #f8fafc hover (item only)
+  const showActivePill = isActive && item.kind === 'item';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-current={isActive ? 'page' : undefined}
+      data-kb-part="sub-nav-row"
+      data-kb-kind={item.kind}
+      className={cn(
+        'flex h-[44px] w-full items-center gap-[8px]',
+        'mx-[16px] rounded-[8px] px-[8px]',
+        'transition-colors duration-150',
+        'text-left text-[14px] font-medium leading-5 text-[#0f172a]',
+        // Section rows aren't really click targets — sections are containers, not nav.
+        // Keep them focusable for a11y but show a default cursor and skip hover bg.
+        item.kind === 'section'
+          ? 'cursor-default'
+          : 'cursor-pointer',
+        showActivePill
+          ? 'bg-[#f1f5f9]'
+          : item.kind === 'item'
+            ? 'bg-transparent hover:bg-[#f8fafc]'
+            : 'bg-transparent',
+      )}
+      // mx-16 + w-full would double-count; subtract manually so the row is
+      // inset 16 on each side without expanding past the panel. 288 − 32 = 256.
+      style={{ width: 'calc(100% - 32px)' }}
+    >
+      <span
+        aria-hidden
+        className="flex size-[20px] items-center justify-center shrink-0"
+      >
+        {item.icon}
+      </span>
+      <span className="truncate">{item.label}</span>
+    </button>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * AISubNav
+ *
+ * 288-wide vertical panel rendered to the right of the app rail
+ * (54-wide) on the AI Optimise hub. Contains two top-level entries:
+ *   1. AI Centre  (kind: section — divider below, no pill on active)
+ *   2. AI Optimise (kind: item — primary highlight)
+ *
+ * Structurally mirrors FileExplorerNav (white bg, 1px right border,
+ * full viewport height when laid out inside a flex shell).
+ * ───────────────────────────────────────────────────────────── */
+
+export function AISubNav({
+  items,
+  activeId,
+  onItemClick,
+  className,
+}: AISubNavProps) {
+  return (
+    <aside
+      data-kb-component="ai-sub-nav"
+      aria-label="AI navigation"
+      className={cn(
+        'flex flex-col w-[288px] h-full bg-white border-r border-nav-rail',
+        'py-[12px]',
+        className,
+      )}
+    >
+      {items.map((item, idx) => {
+        const isLast = idx === items.length - 1;
+        const isActive = item.id === activeId;
+        return (
+          <React.Fragment key={item.id}>
+            <Row
+              item={item}
+              isActive={isActive}
+              onClick={() => onItemClick?.(item.id)}
+            />
+            {item.kind === 'section' && !isLast && (
+              // Asymmetric vertical margins: 4px above the divider keeps a
+              // breath between the section row label and the rule, while
+              // 12px below the divider matches Figma `74:8871` — the gap
+              // from the divider to the next pill ("AI Optimise") is
+              // `scale/space/xl` = 12px.
+              <div
+                aria-hidden
+                data-kb-part="sub-nav-divider"
+                className="h-px bg-nav-rail mx-[16px] mt-[4px] mb-[12px]"
+              />
+            )}
+          </React.Fragment>
+        );
+      })}
+    </aside>
+  );
+}

--- a/apps/demo/src/shell/AISubNavbar.tsx
+++ b/apps/demo/src/shell/AISubNavbar.tsx
@@ -1,4 +1,4 @@
-// Phase 7.5.3 — Route-aware wrapper around `AISubNav` for the
+// Phase 7.5.3 — Route-aware wrapper around the local `AISubNav` for the
 // `/ai-optimise/*` surface.
 //
 // Two rows per Figma `74:8871` (AI Optimise hub):
@@ -10,7 +10,8 @@
 
 import { RiMagicLine } from '@remixicon/react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { AISubNav, type AISubNavItem, AiIcon } from '@hiver/kb-ui';
+import { AiIcon } from '@hiver/kb-ui';
+import { AISubNav, type AISubNavItem } from './AISubNav';
 import { routes } from '../lib/routes';
 import { useToast } from '../components/Toast';
 

--- a/apps/demo/src/store/fixtures/analytics.ts
+++ b/apps/demo/src/store/fixtures/analytics.ts
@@ -17,14 +17,57 @@
 import type {
   AnalyticsAreaSeries,
   AnalyticsAreaChartGoalLine,
-  ArticleAttentionRow,
-  ArticlePerformanceRow,
-  ContentGapRow,
   DonutDatum,
-  MostCitedRow,
-  SearchKeywordRow,
+  HelpfulnessVariant,
   StatCardProps,
 } from '@hiver/kb-ui';
+
+/* ─────────────────────────────────────────────────────────────
+ * Row types (Phase 7.5 migration — moved app-side).
+ *
+ * After kb-ui collapsed its 7 bespoke `*Table` components into a
+ * single `<DataTable<T> />` primitive (commit `de1f197`), the
+ * row-shape types live with the consumer. The shapes are unchanged
+ * from the legacy ones — see the analytics pattern stories in
+ * `packages/kb-ui/src/pages/KBAnalytics*.stories.tsx` for the
+ * canonical column configs that pair with each row type.
+ * ───────────────────────────────────────────────────────────── */
+
+export type ArticleAttentionRow = {
+  id: string;
+  title: string;
+  helpfulness: string;
+  variant: HelpfulnessVariant;
+};
+
+export type ArticlePerformanceRow = {
+  id: string;
+  title: string;
+  category: string;
+  totalViews: string;
+  avgTimeSpent: string;
+  helpfulness: string;
+  helpfulnessVariant: HelpfulnessVariant;
+};
+
+export type ContentGapRow = {
+  id: string;
+  topic: string;
+  frequency: string;
+  ticketRate: string;
+};
+
+export type MostCitedRow = {
+  id: string;
+  title: string;
+  citations: number;
+};
+
+export type SearchKeywordRow = {
+  id: string;
+  keyword: string;
+  count: string;
+};
 
 /* ─────────────────────────────────────────────────────────────
  * Helpers


### PR DESCRIPTION
## Summary

- Ports `AISubNav` from kb-ui into `apps/demo/src/shell/AISubNav.tsx` as a local file (verbatim from commit `20edc40`); demo's `AISubNavbar` swaps to the local import.
- Migrates 5 demo files (4 routes + analytics fixtures) to use kb-ui's canonical `DataTable<T>` + inline column configs, lifted verbatim from the matching kb-ui pattern stories.
- Net effect: `npm run demo:build` works again and the sign-off harness passes 56 / 56 cold.

## Why the scope grew beyond AISubNav

Issue #13 was filed for AISubNav alone, discovered during issue #1 verification. Verifying the AISubNav fix surfaced **14 other dropped exports** the demo still referenced — same root cause (Phase 7.5's commit `de1f197` "Collapse 7 bespoke tables into one configurable DataTable"), same fix philosophy ("replaced at the app layer"). The demo's leading comments already say "Mirrors KB*Page.stories.tsx composition exactly" — this PR finishes the migration the kb-ui consolidation expected.

Pre-existing on `main` — not introduced by Phase 8 work. Confirmed by checking out `main`, rebuilding kb-ui, observing the same tsc errors.

## Test plan

- [x] `npx tsc --noEmit -p apps/demo` clean
- [x] `npm run --workspace=apps/demo build` succeeds (this is the regression of record)
- [x] `node apps/demo/scripts/phase-7-5-9-signoff.mjs` reports `SIGN-OFF: PASS` with 56 / 56
  - Journey A — Browse & Edit: 25 / 25
  - Journey B — AI Optimise Review: 21 / 21
  - Journey C — Analytics Drill: 10 / 10
- [x] Zero changes to `packages/kb-ui/` (demo-only fix)
- [x] Column configs lifted verbatim from kb-ui pattern stories (1:1 visual fidelity)

## Files

- `apps/demo/src/shell/AISubNav.tsx` (NEW — verbatim port)
- `apps/demo/src/shell/AISubNavbar.tsx` (import swap only)
- `apps/demo/src/routes/kb/CategoryPage.tsx` (DataTable + local column configs)
- `apps/demo/src/routes/analytics/ArticlePerformancePage.tsx` (DataTable + local column configs)
- `apps/demo/src/routes/analytics/SearchPage.tsx` (DataTable + local column configs)
- `apps/demo/src/routes/analytics/AIAnswerPerformancePage.tsx` (DataTable + local column configs)
- `apps/demo/src/store/fixtures/analytics.ts` (local row types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)