### PR TITLE
chore(kb-ui): bump v1.0.0 + ship styles types stub (closes #5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6880,7 +6880,8 @@
     },
     "packages/kb-ui": {
       "name": "@hiver/kb-ui",
-      "version": "0.1.0",
+      "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.0",
         "@radix-ui/react-dropdown-menu": "^2.1.0",

--- a/packages/kb-ui/package.json
+++ b/packages/kb-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiver/kb-ui",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Hiver KB component library — pixel-perfect React components for app.hiverkb.com",
   "license": "MIT",
   "author": "Hiver",
@@ -31,7 +31,10 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
-    "./styles": "./dist/tokens.css"
+    "./styles": {
+      "types": "./dist/styles.d.ts",
+      "default": "./dist/tokens.css"
+    }
   },
   "files": [
     "dist"
@@ -44,7 +47,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node scripts/emit-styles-dts.mjs",
     "dev": "tsup --watch",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",

--- a/packages/kb-ui/scripts/emit-styles-dts.mjs
+++ b/packages/kb-ui/scripts/emit-styles-dts.mjs
@@ -1,0 +1,20 @@
+// Emits `dist/styles.d.ts` — a side-effect-only type stub for the
+// `@hiver/kb-ui/styles` subpath. Kept out of `tsup.config.ts` because
+// tsup's DTS rollup runs in a worker thread and would race with us.
+import { writeFile, mkdir } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const distDir = resolve(here, '..', 'dist');
+const target = resolve(distDir, 'styles.d.ts');
+
+const STYLES_DTS = `// Type declaration stub for the side-effect-only \`@hiver/kb-ui/styles\` subpath.
+// The actual artifact is \`dist/tokens.css\` (CSS variables / @theme tokens) — this
+// file exists so strict-TS consumers can do \`import '@hiver/kb-ui/styles';\`
+// without hitting TS2882. There are no runtime exports.
+export {};
+`;
+
+await mkdir(distDir, { recursive: true });
+await writeFile(target, STYLES_DTS);


### PR DESCRIPTION
## Summary

Pre-publish smoke test for `@hiver/kb-ui` v1.0.0. The smoke test surfaced two real publish blockers that are folded into this PR so #5 closes against a green gate.

1. **Version bump** `0.1.0` → `1.0.0`. Issue #2 added publish metadata but never bumped the version; CHANGELOG.md (issue #3) already documents this as the 1.0.0 release.
2. **`@hiver/kb-ui/styles` types stub.** Strict-TS consumers (`moduleResolution: "Bundler"`, `strict: true`) get TS2882 on `import '@hiver/kb-ui/styles'` because the export points to a `.css` with no companion `.d.ts`. That exact import is in #5's acceptance criteria, so it had to be fixed.
   - `exports["./styles"]` now conditional: `types` → stub, `default` → tokens.css. Runtime unchanged.
   - `dist/styles.d.ts` is a 5-line side-effect stub (`export {};`).
   - Emitted by `scripts/emit-styles-dts.mjs`, chained after `tsup` in the build script. No coupling to tsup internals.

## Smoke-test results (run against the final state of this PR)

| Step | Result |
|---|---|
| `npm pack` → `hiver-kb-ui-1.0.0.tgz` | ✅ |
| Tarball includes `dist/index.{js,mjs,d.ts,d.mts}`, `dist/tokens.css`, `dist/styles.d.ts`, `package.json`, `README.md` | ✅ |
| Tarball excludes `src/`, `node_modules/`, `storybook-static/`, `*.log` | ✅ |
| Scratch-dir strict-TS tsc on `import { AppShell, KBBreadcrumbBar, useAIGapsReducer } from '@hiver/kb-ui'; import '@hiver/kb-ui/styles';` | ✅ zero errors |
| `require.resolve('@hiver/kb-ui/styles')` → `dist/tokens.css` | ✅ |
| `apps/demo` swap to `file:tarball` → `npm install` + `npm run demo:build` | ✅ |
| `apps/demo/scripts/phase-7-5-9-signoff.mjs` against the tarball-installed kb-ui | ✅ `SIGN-OFF: PASS` 56 / 56 |
| Demo restored to workspace `*`; `git diff apps/demo/package.json` clean | ✅ |

## Test plan

- [x] `npm run --workspace=packages/kb-ui build` clean — emits `dist/styles.d.ts`
- [x] `npx tsc --noEmit -p packages/kb-ui` clean
- [x] `npx tsc --noEmit -p apps/demo` clean
- [x] Sign-off harness 56 / 56 against workspace symlink
- [x] Sign-off harness 56 / 56 against published-tarball install (the headline gate)

## Files

- `packages/kb-ui/package.json` (version + exports + build script)
- `packages/kb-ui/scripts/emit-styles-dts.mjs` (NEW)
- `package-lock.json` (incidental version mirror)

## Next up — issue #6 (needs YOU)

Issue #5 was the last automated gate before publish. Issue #6 (Phase 8.6 — Publish `@hiver/kb-ui` v1.0.0 to npm) needs three things from you:

1. Claim the `@hiver` scope on npmjs.com (free for public packages — fall back to `@hiverkb` if `@hiver` is taken; if you do, also bump the package name in `packages/kb-ui/package.json`).
2. `npm login` locally.
3. From `packages/kb-ui/`: `npm publish` (publishConfig.access is already set to `public`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)