### PR TITLE
feat(kb-mcp): build component + token spec indices (closes #8)

### DIFF
--- a/packages/kb-mcp/package.json
+++ b/packages/kb-mcp/package.json
@@ -45,12 +45,12 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "typescript": "^5.4.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {
     "@hiver/kb-ui": "*",
     "@types/node": "^20.0.0",
-    "tsup": "^8.0.0",
-    "typescript": "^5.4.0"
+    "tsup": "^8.0.0"
   }
 }

--- a/packages/kb-mcp/src/index/component-index.ts
+++ b/packages/kb-mcp/src/index/component-index.ts
@@ -1,0 +1,527 @@
+// Walks `@hiver/kb-ui`'s `src/components/**/*.tsx` and builds an in-memory
+// index of every canonical component (the file-named export). The result is
+// a `Map<string, ComponentSpec>` keyed by component name, ready for future
+// MCP tools (issues #9, #10) to query by name, category, or Figma node.
+//
+// Scope notes:
+// - Targets the WORKSPACE install of `@hiver/kb-ui` (the `node_modules`
+//   symlink to `packages/kb-ui/`). Production tarballs only ship `dist/`,
+//   so this throws a clear error in that mode — handling that case is a
+//   separate, post-#6 polish step.
+// - One file = one canonical component. Helper exports in the same file
+//   are intentionally not indexed; only the export whose name matches the
+//   filename is returned.
+// - Prop extraction uses the TypeScript compiler API. If a single file
+//   fails to parse, that component ships with `props: []` and a stderr
+//   warning; the rest of the index still builds.
+
+import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs';
+import { dirname, basename, resolve, sep } from 'node:path';
+import { createRequire } from 'node:module';
+import ts from 'typescript';
+import type { ComponentIndex, ComponentPropSpec, ComponentSpec } from './types.js';
+
+const require = createRequire(import.meta.url);
+
+/* ─────────────────────────────────────────────────────────────
+ * kb-ui source resolution
+ * ───────────────────────────────────────────────────────────── */
+
+function resolveKbUiSrc(): string {
+  // Resolve through the package's main entry, then walk up to the package
+  // root. We can't `require.resolve('@hiver/kb-ui/package.json')` directly
+  // because kb-ui's `exports` map doesn't expose `./package.json`.
+  const mainEntry = require.resolve('@hiver/kb-ui');
+  // mainEntry => `.../node_modules/@hiver/kb-ui/dist/index.js` (or .mjs).
+  // The package root is the parent of `dist/`.
+  let root = dirname(mainEntry);
+  // Walk up until we find a directory containing `package.json`.
+  for (let i = 0; i < 5; i += 1) {
+    if (existsSync(resolve(root, 'package.json'))) break;
+    root = dirname(root);
+  }
+  const src = resolve(root, 'src');
+  if (!existsSync(src)) {
+    throw new Error(
+      `kb-ui source files not found at ${src} — kb-mcp currently requires the workspace install of @hiver/kb-ui (issue #8 scope). Production support tracked separately.`,
+    );
+  }
+  return src;
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Filesystem walking
+ * ───────────────────────────────────────────────────────────── */
+
+type ComponentFile = {
+  filePath: string;
+  componentName: string;
+  category: string;
+};
+
+function walkComponents(componentsDir: string): ComponentFile[] {
+  const out: ComponentFile[] = [];
+  const categories = readdirSync(componentsDir).filter((entry) => {
+    return statSync(resolve(componentsDir, entry)).isDirectory();
+  });
+  for (const category of categories) {
+    const dir = resolve(componentsDir, category);
+    for (const fileName of readdirSync(dir)) {
+      if (!fileName.endsWith('.tsx')) continue;
+      if (fileName.endsWith('.stories.tsx')) continue;
+      const componentName = fileName.slice(0, -'.tsx'.length);
+      out.push({
+        filePath: resolve(dir, fileName),
+        componentName,
+        category,
+      });
+    }
+  }
+  return out;
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Header comment + Figma node parsing
+ * ───────────────────────────────────────────────────────────── */
+
+/**
+ * Extracts the file's "header" comment for the description / Figma node
+ * lookup. We accept the first comment block that appears in the file
+ * before the first non-comment, non-import statement — kb-ui has three
+ * conventions in the wild:
+ *
+ *   1. `//` line cluster starting at line 1 (e.g. `nav/SideNavRail.tsx`).
+ *   2. A `/* ... *​/` block at line 1 (e.g. `content/ArticleBody.tsx`).
+ *   3. A `/* ... *​/` or `/​** ... *​/` block sitting BETWEEN imports
+ *      and the first `export` (e.g. `content/AICard.tsx`,
+ *      `brand/AiIcon.tsx`).
+ *
+ * Anything inside a function body or after the first export is ignored.
+ * Returns the comment contents stripped of comment markers (and JSDoc
+ * `*` line decoration), or `null` if no qualifying comment is found.
+ */
+function readLeadingComment(source: string): string | null {
+  const lines = source.split('\n');
+  if (lines.length === 0) return null;
+
+  // Case A: `//` line cluster starting at line 1.
+  if (lines[0].trimStart().startsWith('//')) {
+    const buf: string[] = [];
+    for (const raw of lines) {
+      const trimmed = raw.trimStart();
+      if (trimmed.startsWith('//')) {
+        buf.push(trimmed.replace(/^\/\/\s?/, ''));
+        continue;
+      }
+      break;
+    }
+    if (buf.length > 0) return buf.join('\n');
+  }
+
+  // Case B / C: scan forward for the first `/* ... */` block that
+  // sits before the first export. This captures both line-1 blocks
+  // and post-import blocks like AICard's `/* ─── AICard ─── */`.
+  const firstExportIdx = (() => {
+    const idx = source.search(/^\s*export\b/m);
+    return idx === -1 ? source.length : idx;
+  })();
+
+  let cursor = 0;
+  while (cursor < firstExportIdx) {
+    const start = source.indexOf('/*', cursor);
+    if (start === -1 || start >= firstExportIdx) break;
+    const end = source.indexOf('*/', start + 2);
+    if (end === -1) break;
+    const inner = source.slice(start + 2, end);
+    const cleaned = inner
+      .split('\n')
+      .map((l) => l.replace(/^\s*\*\s?/, '').replace(/^\s+/, ''))
+      // Drop pure box-drawing decorator lines like `─────────────`.
+      .filter((l) => !/^[─\-—*\s]+$/.test(l))
+      .join('\n')
+      .trim();
+    if (cleaned) return cleaned;
+    cursor = end + 2;
+  }
+
+  return null;
+}
+
+/**
+ * Find the JSDoc block immediately preceding `export function ${name}` or
+ * `export const ${name} =`. Returns the cleaned text or `null`.
+ *
+ * Used as a fallback for files (e.g. `brand/AiIcon.tsx`) where the prose
+ * + Figma reference live on the function instead of at file top.
+ */
+function readComponentJsDoc(source: string, componentName: string): string | null {
+  // Match `export function Name(` or `export const Name =` or
+  // `export const Name: <type> =`. We don't need to be exhaustive — the
+  // canonical kb-ui pattern is `export function ComponentName(`.
+  const declRe = new RegExp(
+    `^\\s*export\\s+(?:function|const)\\s+${componentName}\\b`,
+    'm',
+  );
+  const declMatch = declRe.exec(source);
+  if (!declMatch) return null;
+  const declStart = declMatch.index;
+
+  // Walk backward from the declaration, skipping whitespace, looking for
+  // the closing `*/` of a JSDoc block.
+  let cursor = declStart - 1;
+  while (cursor >= 0 && /\s/.test(source[cursor])) cursor -= 1;
+  if (cursor < 1 || source[cursor] !== '/' || source[cursor - 1] !== '*') {
+    return null;
+  }
+  // Found `*/` at `cursor`. Find the matching `/*` opening.
+  const openIdx = source.lastIndexOf('/*', cursor - 2);
+  if (openIdx === -1) return null;
+  // Require a real JSDoc block (`/**`) — not a `/* ----- divider ----- */`
+  // pseudo-section break. Avoids picking up the `/* ---- main component ---- */`
+  // line that sits above some `export function` declarations in kb-ui.
+  if (source[openIdx + 2] !== '*') return null;
+
+  const inner = source.slice(openIdx + 2, cursor - 1);
+  const cleaned = inner
+    .split('\n')
+    .map((l) => l.replace(/^\s*\*\s?/, '').replace(/^\s+/, ''))
+    .filter((l) => !/^[─\-—*\s]+$/.test(l))
+    .join('\n')
+    .trim();
+  return cleaned || null;
+}
+
+/**
+ * Pull the first Figma reference out of a header comment. Two patterns:
+ *   - `Figma: <fileKey>#<nodeId>` (canonical, e.g. content/* and overlays/*)
+ *   - `Figma <fileKey> ... node <nodeId>` (older nav/* prose form)
+ *
+ * Returns `${fileKey}#${nodeId}` or `null`.
+ */
+function parseFigmaNode(comment: string | null): string | null {
+  if (!comment) return null;
+
+  // Canonical short form: `Figma: <fileKey>#<nodeId>` (allow surrounding
+  // backticks/whitespace).
+  const short = comment.match(/Figma:\s*`?([A-Za-z0-9]{15,})`?\s*#\s*`?(\d+:\d+)`?/);
+  if (short) return `${short[1]}#${short[2]}`;
+
+  // Loose form: `Figma <fileKey> ... <nodeId>` — the file key and node id
+  // can sit a few words / lines apart in the same comment block (e.g.
+  // `brand/AiIcon.tsx` writes `Figma file: <key>` then a few lines later
+  // `Vector node: I<NN:NN>;...`). We deliberately stop at a `.` so we
+  // don't leak into the next sentence.
+  const loose = comment.match(
+    /Figma\s+(?:file\s*:?\s*)?`?([A-Za-z0-9]{15,})`?[^.]*?`?(\d+:\d+)`?/is,
+  );
+  if (loose) return `${loose[1]}#${loose[2]}`;
+
+  return null;
+}
+
+/**
+ * First sentence of the comment block, capped at 200 chars. Strips JSDoc
+ * `*` markers and trims. Returns `null` if no usable text.
+ */
+function parseDescription(comment: string | null): string | null {
+  if (!comment) return null;
+  // Drop lines that are obviously metadata-only (Figma refs, file headers).
+  const meaningful = comment
+    .split('\n')
+    .filter((line) => {
+      const t = line.trim();
+      if (!t) return false;
+      if (/^Figma:?\s/.test(t)) return false;
+      // skip pure URL/file id lines
+      if (/^[A-Za-z0-9]+#\d+:\d+\s*$/.test(t)) return false;
+      return true;
+    })
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!meaningful) return null;
+
+  // First sentence: up to first period followed by space/end, or 200 chars.
+  const sentenceMatch = meaningful.match(/^(.+?[.!?])(\s|$)/);
+  const text = (sentenceMatch ? sentenceMatch[1] : meaningful).trim();
+  return text.length > 200 ? `${text.slice(0, 197)}...` : text;
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Props extraction (TypeScript compiler API)
+ * ───────────────────────────────────────────────────────────── */
+
+const COMPILER_OPTIONS: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ES2020,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  jsx: ts.JsxEmit.ReactJSX,
+  strict: true,
+  lib: ['lib.es2020.d.ts', 'lib.dom.d.ts'],
+  esModuleInterop: true,
+  allowSyntheticDefaultImports: true,
+  skipLibCheck: true,
+  noEmit: true,
+};
+
+/**
+ * Walks the AST of a TypeNode and collects the property signatures the
+ * AUTHOR wrote — including those reachable through intersections with
+ * other LOCAL type aliases in the same file. Crucially, this stops at
+ * imported types (e.g. `React.HTMLAttributes<HTMLElement>`), so we don't
+ * dump every DOM attribute into the prop list.
+ */
+function collectAuthoredPropSignatures(
+  typeNode: ts.TypeNode,
+  sourceFile: ts.SourceFile,
+  out: ts.PropertySignature[],
+  visited: Set<string>,
+): void {
+  if (ts.isTypeLiteralNode(typeNode)) {
+    for (const member of typeNode.members) {
+      if (ts.isPropertySignature(member)) out.push(member);
+    }
+    return;
+  }
+
+  if (ts.isIntersectionTypeNode(typeNode)) {
+    for (const sub of typeNode.types) {
+      collectAuthoredPropSignatures(sub, sourceFile, out, visited);
+    }
+    return;
+  }
+
+  if (ts.isParenthesizedTypeNode(typeNode)) {
+    collectAuthoredPropSignatures(typeNode.type, sourceFile, out, visited);
+    return;
+  }
+
+  if (ts.isTypeReferenceNode(typeNode)) {
+    // Resolve only references to LOCAL aliases/interfaces in the same file.
+    const refName = ts.isIdentifier(typeNode.typeName) ? typeNode.typeName.text : null;
+    if (!refName) return;
+    if (visited.has(refName)) return;
+    visited.add(refName);
+    for (const stmt of sourceFile.statements) {
+      if (ts.isInterfaceDeclaration(stmt) && stmt.name.text === refName) {
+        for (const member of stmt.members) {
+          if (ts.isPropertySignature(member)) out.push(member);
+        }
+        // Honour `extends X, Y` clauses on local interfaces.
+        if (stmt.heritageClauses) {
+          for (const clause of stmt.heritageClauses) {
+            for (const heritageType of clause.types) {
+              const exprType = heritageType.expression;
+              if (ts.isIdentifier(exprType)) {
+                const fakeRef = ts.factory.createTypeReferenceNode(exprType.text);
+                collectAuthoredPropSignatures(fakeRef, sourceFile, out, visited);
+              }
+            }
+          }
+        }
+        return;
+      }
+      if (ts.isTypeAliasDeclaration(stmt) && stmt.name.text === refName) {
+        collectAuthoredPropSignatures(stmt.type, sourceFile, out, visited);
+        return;
+      }
+    }
+    // Reference resolves to an imported / external type (e.g.
+    // `React.HTMLAttributes<...>`). Intentionally NOT expanded — those
+    // props are passed through via `...rest` and aren't part of the
+    // component's documented surface.
+    return;
+  }
+}
+
+/**
+ * Extract the props of a component from one source file. Strategy:
+ *   1. Find a top-level `${ComponentName}Props` interface or type alias.
+ *   2. Failing that, fall back to the component function's first
+ *      parameter type annotation.
+ *   3. Walk the AUTHOR-written property signatures (no DOM attribute
+ *      blow-up from intersected React types).
+ *
+ * On any thrown error, returns `[]` (caller logs the warning).
+ */
+function extractPropsForFile(filePath: string, componentName: string): ComponentPropSpec[] {
+  const program = ts.createProgram([filePath], COMPILER_OPTIONS);
+  const checker = program.getTypeChecker();
+  const sourceFile = program.getSourceFile(filePath);
+  if (!sourceFile) return [];
+
+  const targetTypeName = `${componentName}Props`;
+
+  // 1. Find the canonical Props declaration.
+  let propsTypeNode: ts.TypeNode | null = null;
+  for (const stmt of sourceFile.statements) {
+    if (ts.isInterfaceDeclaration(stmt) && stmt.name.text === targetTypeName) {
+      // Synthesise a type-reference node so the same walker handles it.
+      propsTypeNode = ts.factory.createTypeReferenceNode(targetTypeName);
+      break;
+    }
+    if (ts.isTypeAliasDeclaration(stmt) && stmt.name.text === targetTypeName) {
+      propsTypeNode = stmt.type;
+      break;
+    }
+  }
+
+  // 2. Fallback: parameter type on the component function/const.
+  if (!propsTypeNode) {
+    for (const stmt of sourceFile.statements) {
+      if (ts.isFunctionDeclaration(stmt) && stmt.name?.text === componentName) {
+        const param = stmt.parameters[0];
+        if (param?.type) propsTypeNode = param.type;
+        break;
+      }
+      if (ts.isVariableStatement(stmt)) {
+        for (const decl of stmt.declarationList.declarations) {
+          if (
+            ts.isIdentifier(decl.name) &&
+            decl.name.text === componentName &&
+            decl.initializer &&
+            (ts.isArrowFunction(decl.initializer) ||
+              ts.isFunctionExpression(decl.initializer))
+          ) {
+            const param = decl.initializer.parameters[0];
+            if (param?.type) propsTypeNode = param.type;
+            break;
+          }
+        }
+      }
+      if (propsTypeNode) break;
+    }
+  }
+
+  if (!propsTypeNode) return [];
+
+  const propSignatures: ts.PropertySignature[] = [];
+  collectAuthoredPropSignatures(propsTypeNode, sourceFile, propSignatures, new Set());
+
+  // De-dupe by name (intersection of two locally-authored types could
+  // hypothetically declare the same prop twice — first wins).
+  const out: ComponentPropSpec[] = [];
+  const seen = new Set<string>();
+  for (const sig of propSignatures) {
+    if (!sig.name || !ts.isIdentifier(sig.name)) continue;
+    const name = sig.name.text;
+    if (!name || name.startsWith('__') || seen.has(name)) continue;
+    seen.add(name);
+
+    const optional = sig.questionToken !== undefined;
+
+    let tsType = 'unknown';
+    if (sig.type) {
+      const resolved = checker.getTypeAtLocation(sig.type);
+      tsType = checker.typeToString(
+        resolved,
+        sig,
+        ts.TypeFormatFlags.NoTruncation |
+          ts.TypeFormatFlags.UseFullyQualifiedType |
+          ts.TypeFormatFlags.InTypeAlias,
+      );
+    }
+
+    // Pull JSDoc directly off the property signature so we get the
+    // author's comment regardless of whether the symbol was reachable
+    // through an intersection.
+    const jsDocs = ts.getJSDocCommentsAndTags(sig);
+    let description: string | null = null;
+    for (const doc of jsDocs) {
+      if (ts.isJSDoc(doc) && doc.comment) {
+        description = typeof doc.comment === 'string'
+          ? doc.comment.trim()
+          : doc.comment.map((c) => ('text' in c ? c.text : '')).join('').trim();
+        if (description) break;
+      }
+    }
+
+    out.push({ name, tsType, optional, description: description || null });
+  }
+
+  return out;
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Story-file siblings
+ * ───────────────────────────────────────────────────────────── */
+
+function findStoryFiles(componentDir: string, componentName: string): string[] {
+  const entries = readdirSync(componentDir);
+  const out: string[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith('.stories.tsx')) continue;
+    // Basename match on "${ComponentName}.stories.tsx" — this is the
+    // convention across kb-ui and is sufficient for #8 scope.
+    if (entry === `${componentName}.stories.tsx`) {
+      out.push(entry);
+    }
+  }
+  return out;
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Public API
+ * ───────────────────────────────────────────────────────────── */
+
+export function buildComponentIndex(): ComponentIndex {
+  const kbUiSrc = resolveKbUiSrc();
+  const componentsDir = resolve(kbUiSrc, 'components');
+  const files = walkComponents(componentsDir);
+
+  const index: ComponentIndex = new Map();
+
+  for (const file of files) {
+    let props: ComponentPropSpec[] = [];
+    try {
+      props = extractPropsForFile(file.filePath, file.componentName);
+    } catch (err) {
+      // Don't fail the whole index over one bad parse.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[kb-mcp] Failed to extract props for ${file.componentName} (${file.filePath}): ${(err as Error).message}`,
+      );
+      props = [];
+    }
+
+    let source = '';
+    try {
+      source = readFileSync(file.filePath, 'utf8');
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[kb-mcp] Failed to read ${file.filePath}: ${(err as Error).message}`,
+      );
+    }
+
+    const headerComment = readLeadingComment(source);
+    // Fall back to the JSDoc attached to the component function/const
+    // declaration itself when the file has no top-of-file comment block
+    // (e.g. `brand/AiIcon.tsx`, where the prose lives on the function).
+    const componentJsDoc = readComponentJsDoc(source, file.componentName);
+    const description = parseDescription(headerComment) ?? parseDescription(componentJsDoc);
+    const figmaNode = parseFigmaNode(headerComment) ?? parseFigmaNode(componentJsDoc);
+    const storyFiles = findStoryFiles(dirname(file.filePath), file.componentName);
+
+    const spec: ComponentSpec = {
+      name: file.componentName,
+      category: file.category,
+      filePath: file.filePath,
+      description,
+      figmaNode,
+      props,
+      storyFiles,
+      importStatement: `import { ${file.componentName} } from '@hiver/kb-ui';`,
+    };
+
+    index.set(file.componentName, spec);
+  }
+
+  return index;
+}
+
+// Suppress unused-import warning for `basename`/`sep` if minified — kept here
+// in case future polish wants relative-path display (out of scope for #8).
+void basename;
+void sep;

--- a/packages/kb-mcp/src/index/token-index.ts
+++ b/packages/kb-mcp/src/index/token-index.ts
@@ -1,0 +1,336 @@
+// Parses kb-ui's design tokens from BOTH `tokens.css` and `tokens.ts`,
+// merges them by value-equality, and returns a `Map<string, TokenSpec>`
+// keyed by canonical token name (CSS form preferred when both exist).
+//
+// Used by future MCP tools (issues #9, #10) to resolve token names,
+// list available tokens by category, and surface inline documentation.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import ts from 'typescript';
+import type { TokenIndex, TokenSpec } from './types.js';
+
+const require = createRequire(import.meta.url);
+
+/* ─────────────────────────────────────────────────────────────
+ * kb-ui source resolution
+ * ───────────────────────────────────────────────────────────── */
+
+function resolveKbUiSrc(): string {
+  // Resolve through the package's main entry, then walk up to the package
+  // root. We can't `require.resolve('@hiver/kb-ui/package.json')` directly
+  // because kb-ui's `exports` map doesn't expose `./package.json`.
+  const mainEntry = require.resolve('@hiver/kb-ui');
+  let root = dirname(mainEntry);
+  for (let i = 0; i < 5; i += 1) {
+    if (existsSync(resolve(root, 'package.json'))) break;
+    root = dirname(root);
+  }
+  const src = resolve(root, 'src');
+  if (!existsSync(src)) {
+    throw new Error(
+      `kb-ui source files not found at ${src} — kb-mcp currently requires the workspace install of @hiver/kb-ui (issue #8 scope). Production support tracked separately.`,
+    );
+  }
+  return src;
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * tokens.css parser
+ * ───────────────────────────────────────────────────────────── */
+
+/**
+ * Section-header pattern: `/​* ── Section Name ── *​/` with variable
+ * trailing dashes (and either ASCII `-`, en-dash, or em-dash).
+ *
+ * We match anything between a leading dash run and an optional trailing
+ * dash run, ignoring whitespace.
+ */
+const SECTION_HEADER_RE = /\/\*\s*[─\-—]+\s*([^─\-—*][^*]*?)\s*[─\-—]*\s*\*\//;
+
+/**
+ * Token line pattern: `--name: value;` optionally followed by `/* description *​/`.
+ */
+const TOKEN_LINE_RE = /^\s*(--[a-z0-9-]+)\s*:\s*([^;]+);\s*(?:\/\*\s*(.+?)\s*\*\/)?/i;
+
+export function parseTokensCss(filePath: string): TokenSpec[] {
+  const source = readFileSync(filePath, 'utf8');
+  const lines = source.split('\n');
+
+  const out: TokenSpec[] = [];
+  // Track tokens we've already seen so a duplicate from the second
+  // (`@theme`) block doesn't overwrite the description from `:root`.
+  const seen = new Set<string>();
+
+  let currentSection: string | null = null;
+
+  for (const rawLine of lines) {
+    // Section header? Capture name and continue (don't try to parse as token).
+    const sectionMatch = rawLine.match(SECTION_HEADER_RE);
+    if (sectionMatch) {
+      const name = sectionMatch[1]
+        .trim()
+        // Strip stray leading/trailing dash runs that survived the regex.
+        .replace(/^[─\-—\s]+|[─\-—\s]+$/g, '');
+      if (name) currentSection = name;
+      continue;
+    }
+
+    // Token line?
+    const tokenMatch = rawLine.match(TOKEN_LINE_RE);
+    if (tokenMatch) {
+      const name = tokenMatch[1];
+      const value = tokenMatch[2].trim();
+      const description = tokenMatch[3]?.trim() ?? null;
+      if (seen.has(name)) continue;
+      seen.add(name);
+      out.push({
+        name,
+        value,
+        category: currentSection,
+        source: 'css',
+        description,
+        cssCustomProperty: name,
+        jsTokenPath: null,
+      });
+    }
+  }
+
+  return out;
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * tokens.ts parser (TypeScript AST)
+ * ───────────────────────────────────────────────────────────── */
+
+type JsLeaf = {
+  /** Dotted path, e.g. `color.canvas`. */
+  path: string;
+  /** Top-level segment, e.g. `color`. */
+  topLevel: string;
+  /** String form of the literal value. */
+  value: string;
+};
+
+function flattenObjectLiteral(
+  obj: ts.ObjectLiteralExpression,
+  prefix: string[],
+  topLevel: string,
+  out: JsLeaf[],
+  warnings: string[],
+): void {
+  for (const prop of obj.properties) {
+    if (!ts.isPropertyAssignment(prop)) {
+      // Skip shorthand / spread / methods — none of those appear in tokens.ts
+      // today, but log if the file changes.
+      warnings.push(`unsupported property kind at ${prefix.join('.')}: ${ts.SyntaxKind[prop.kind]}`);
+      continue;
+    }
+
+    let key: string;
+    if (ts.isIdentifier(prop.name)) {
+      key = prop.name.text;
+    } else if (ts.isStringLiteral(prop.name) || ts.isNoSubstitutionTemplateLiteral(prop.name)) {
+      key = prop.name.text;
+    } else {
+      warnings.push(`unsupported key kind at ${prefix.join('.')}`);
+      continue;
+    }
+
+    const newPath = [...prefix, key];
+    const newTopLevel = topLevel || key;
+    const init = prop.initializer;
+
+    if (ts.isObjectLiteralExpression(init)) {
+      flattenObjectLiteral(init, newPath, newTopLevel, out, warnings);
+      continue;
+    }
+
+    let value: string | null = null;
+    if (ts.isStringLiteral(init) || ts.isNoSubstitutionTemplateLiteral(init)) {
+      value = init.text;
+    } else if (ts.isNumericLiteral(init)) {
+      value = init.text;
+    } else if (
+      init.kind === ts.SyntaxKind.TrueKeyword ||
+      init.kind === ts.SyntaxKind.FalseKeyword
+    ) {
+      value = init.getText();
+    } else {
+      warnings.push(`non-literal value at ${newPath.join('.')}: ${ts.SyntaxKind[init.kind]}`);
+      continue;
+    }
+
+    out.push({
+      path: newPath.join('.'),
+      topLevel: newTopLevel,
+      value,
+    });
+  }
+}
+
+export function parseTokensTs(filePath: string): TokenSpec[] {
+  const source = readFileSync(filePath, 'utf8');
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.ES2020,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TS,
+  );
+
+  // Locate `export const tokens = { ... }` (also accept a bare `as const`).
+  let tokensInit: ts.ObjectLiteralExpression | null = null;
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isVariableStatement(stmt)) continue;
+    const isExport = stmt.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+    if (!isExport) continue;
+    for (const decl of stmt.declarationList.declarations) {
+      if (
+        ts.isIdentifier(decl.name) &&
+        decl.name.text === 'tokens' &&
+        decl.initializer
+      ) {
+        let init = decl.initializer;
+        // `tokens = { ... } as const` wraps the literal in a TypeAssertion /
+        // AsExpression — unwrap.
+        while (ts.isAsExpression(init) || ts.isTypeAssertionExpression(init)) {
+          init = init.expression;
+        }
+        if (ts.isObjectLiteralExpression(init)) {
+          tokensInit = init;
+        }
+        break;
+      }
+    }
+    if (tokensInit) break;
+  }
+
+  if (!tokensInit) return [];
+
+  const leaves: JsLeaf[] = [];
+  const warnings: string[] = [];
+  flattenObjectLiteral(tokensInit, [], '', leaves, warnings);
+
+  if (warnings.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(`[kb-mcp] tokens.ts parse warnings: ${warnings.join('; ')}`);
+  }
+
+  return leaves.map<TokenSpec>((leaf) => ({
+    name: leaf.path,
+    value: leaf.value,
+    category: leaf.topLevel,
+    source: 'js',
+    description: null,
+    cssCustomProperty: null,
+    jsTokenPath: leaf.path,
+  }));
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Merge: CSS is canonical, JS leaves backfill `jsTokenPath`
+ * ───────────────────────────────────────────────────────────── */
+
+/**
+ * Convert a dotted JS path (e.g. `color.aiAddition`) to its CSS-conventional
+ * twin name (e.g. `--color-ai-addition`). Used as a tie-breaker when several
+ * CSS tokens share the same value — we want `color.aiAddition` to bind to
+ * `--color-ai-addition`, not the first-encountered `--color-success-text`
+ * that happens to have the same hex.
+ */
+function jsPathToCssName(path: string): string {
+  const kebab = path
+    .replace(/[A-Z]/g, (ch) => `-${ch.toLowerCase()}`)
+    .replace(/\./g, '-');
+  return `--${kebab}`;
+}
+
+/**
+ * Tokens are matched on **value equality** after trimming, with a preferred
+ * tie-breaker: when several CSS tokens share the same value, prefer the one
+ * whose name matches the JS path's kebab-cased form (e.g.
+ * `color.aiAddition` → `--color-ai-addition`). This avoids the trap where
+ * `color.aiAddition` (#086e3f) would otherwise collapse onto
+ * `--color-success-text` (also #086e3f) just because it appeared first.
+ *
+ * If a JS path has no matching CSS twin, it's kept as a `'js'`-source entry
+ * under its dotted-path key so none of the dotted paths are silently dropped.
+ */
+function mergeTokens(cssTokens: TokenSpec[], jsTokens: TokenSpec[]): TokenIndex {
+  const index: TokenIndex = new Map();
+
+  // Seed with CSS tokens (canonical).
+  for (const css of cssTokens) {
+    index.set(css.name, { ...css });
+  }
+
+  // Build value -> [css names...] for fast matching with a tie-breaker.
+  const cssByValue = new Map<string, string[]>();
+  for (const css of cssTokens) {
+    const key = css.value.trim();
+    const list = cssByValue.get(key);
+    if (list) list.push(css.name);
+    else cssByValue.set(key, [css.name]);
+  }
+
+  // Track which CSS tokens already absorbed a JS path so duplicate JS
+  // entries with the same value don't all collapse onto one CSS token.
+  const cssAbsorbed = new Set<string>();
+
+  for (const js of jsTokens) {
+    const matchKey = js.value.trim();
+    const candidates = cssByValue.get(matchKey) ?? [];
+    const preferred = jsPathToCssName(js.name);
+
+    // Tie-break: pick the CSS token whose name matches the kebab-cased JS
+    // path; otherwise fall back to the first unabsorbed candidate.
+    let chosen: string | null = null;
+    if (candidates.includes(preferred) && !cssAbsorbed.has(preferred)) {
+      chosen = preferred;
+    } else {
+      for (const candidate of candidates) {
+        if (!cssAbsorbed.has(candidate)) {
+          chosen = candidate;
+          break;
+        }
+      }
+    }
+
+    if (chosen) {
+      const existing = index.get(chosen);
+      if (existing) existing.jsTokenPath = js.jsTokenPath;
+      cssAbsorbed.add(chosen);
+      continue;
+    }
+
+    // No CSS twin — keep as JS-only entry under its dotted path.
+    if (!index.has(js.name)) {
+      index.set(js.name, { ...js });
+    }
+  }
+
+  return index;
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Public API
+ * ───────────────────────────────────────────────────────────── */
+
+export function buildTokenIndex(): TokenIndex {
+  const kbUiSrc = resolveKbUiSrc();
+  const cssPath = resolve(kbUiSrc, 'tokens.css');
+  const tsPath = resolve(kbUiSrc, 'tokens.ts');
+
+  if (!existsSync(cssPath)) {
+    throw new Error(`kb-ui tokens.css not found at ${cssPath}`);
+  }
+  if (!existsSync(tsPath)) {
+    throw new Error(`kb-ui tokens.ts not found at ${tsPath}`);
+  }
+
+  const cssTokens = parseTokensCss(cssPath);
+  const jsTokens = parseTokensTs(tsPath);
+  return mergeTokens(cssTokens, jsTokens);
+}

--- a/packages/kb-mcp/src/index/types.ts
+++ b/packages/kb-mcp/src/index/types.ts
@@ -1,0 +1,94 @@
+// Shared types for the kb-mcp index modules.
+//
+// These describe the in-memory shape of the component / token index
+// that future MCP tools (issues #9, #10) will consume. They are kept
+// intentionally JSON-serialisable: every field is a primitive, an
+// array of primitives, or `null` — no TS AST nodes, no functions,
+// no Maps inside specs.
+
+/**
+ * A single prop on a kb-ui component.
+ *
+ * `tsType` is a human-readable string (e.g. `"\"primary\" | \"secondary\""`
+ * or `"(id: string) => void"`), not a TS AST node — kept stringly so the
+ * index is JSON-serialisable and easy to surface through MCP tools.
+ */
+export type ComponentPropSpec = {
+  name: string;
+  tsType: string;
+  optional: boolean;
+  /** JSDoc text attached to the prop, if any (no `*` markers). */
+  description: string | null;
+};
+
+export type ComponentSpec = {
+  /** Component name as exported (e.g. `KBBreadcrumbBar`). */
+  name: string;
+  /** Folder under `src/components/` (e.g. `nav`, `shell`, `content`). */
+  category: string;
+  /** Absolute path to the source `.tsx` file. */
+  filePath: string;
+  /**
+   * Single-line description. First sentence of the file's leading
+   * comment block, or `null` if no leading comment.
+   */
+  description: string | null;
+  /**
+   * Figma reference parsed from the file header
+   * (e.g. `9aGp5t9fH1d0PXi4LMhOdb#74:8871`), or `null`.
+   */
+  figmaNode: string | null;
+  /**
+   * Props parsed from the component's `Props` type/interface.
+   * Empty array if no props type was found OR if extraction threw
+   * (the failure is logged to stderr; the spec still ships).
+   */
+  props: ComponentPropSpec[];
+  /**
+   * Sibling `.stories.tsx` files (just basenames,
+   * e.g. `["SideNavRail.stories.tsx"]`).
+   */
+  storyFiles: string[];
+  /**
+   * The recommended import statement,
+   * e.g. `import { KBBreadcrumbBar } from '@hiver/kb-ui';`.
+   */
+  importStatement: string;
+};
+
+export type TokenSource = 'css' | 'js';
+
+export type TokenSpec = {
+  /**
+   * The token's canonical name. For CSS tokens, the variable name with
+   * the `--` prefix (e.g. `--color-canvas`). For JS-only tokens (declared
+   * in `tokens.ts` but not in CSS), the dotted JS path (e.g.
+   * `color.canvas`). If a token exists in both, the CSS form is the
+   * canonical key and the `jsTokenPath` field carries the dotted path.
+   */
+  name: string;
+  /** Resolved value (e.g. `#f5f5f5`, `12px`, `Inter, sans-serif`). */
+  value: string;
+  /**
+   * Section comment from `tokens.css` (e.g. `Surfaces`, `Text`,
+   * `Spacing`). For JS-only tokens, derived from the top-level
+   * `tokens.color.*` namespace. `null` if no group could be inferred.
+   */
+  category: string | null;
+  /**
+   * Where the token was found.
+   * - `'css'` if CSS-defined, OR if defined in BOTH css and js
+   *   (the CSS form is canonical).
+   * - `'js'` if only declared in `tokens.ts`.
+   */
+  source: TokenSource;
+  /** Inline comment on the CSS line (e.g. `page/canvas background`), or `null`. */
+  description: string | null;
+  /** CSS custom property form, present iff the token is in `tokens.css`. */
+  cssCustomProperty: string | null;
+  /** Dotted JS path, present iff the token is reachable via the `tokens` JS export. */
+  jsTokenPath: string | null;
+};
+
+export type ComponentIndex = Map<string, ComponentSpec>;
+export type TokenIndex = Map<string, TokenSpec>;

--- a/packages/kb-mcp/tsup.config.ts
+++ b/packages/kb-mcp/tsup.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  // The bin entrypoint plus the standalone indexers.
+  // The indexers aren't re-exported from `src/index.ts` yet (tools wire up in #9);
+  // listing them here keeps them importable as `dist/index/*.js` for smoke tests.
+  entry: [
+    'src/index.ts',
+    'src/index/component-index.ts',
+    'src/index/token-index.ts',
+  ],
   format: ['esm'],
   target: 'node18',
   platform: 'node',
@@ -9,6 +16,12 @@ export default defineConfig({
   splitting: false,
   sourcemap: true,
   clean: true,
+  // Only the bin entry needs the shebang — adding it to the indexer modules
+  // would break ESM imports. tsup applies the banner to every entry, so we
+  // strip the shebang from non-bin outputs in a postbuild step rather than
+  // here. Simpler: keep the banner only for the bin file by post-processing
+  // is overkill — Node tolerates a leading `#!` line in any ESM module when
+  // imported (it's treated like a comment), so leave the banner global.
   banner: {
     js: '#!/usr/bin/env node',
   },


### PR DESCRIPTION
## Summary

Phase 9.2 — in-memory data structures the upcoming MCP tools (#9, #10) will read. **No tools wired yet** — indices are smoke-tested standalone.

## Indices

### Component index (36 entries)
`buildComponentIndex(): Map<string, ComponentSpec>` walks `@hiver/kb-ui`'s source via the workspace symlink and extracts per component: `name`, `category`, `description`, `figmaNode`, `props` (via TypeScript compiler API), `storyFiles`, `importStatement`. Sample (truncated):

```json
{
  "name": "KBBreadcrumbBar", "category": "shell",
  "description": "54px-tall bar that sits above the KB content area.",
  "props": [
    { "name": "items", "tsType": "KBBreadcrumbItem[]", "optional": false, "description": "Path items; last entry is treated as the current page." },
    { "name": "variant", "tsType": "\"category\" | \"editor\"", "optional": true, ... }
    /* ... 9 more */
  ],
  "storyFiles": ["KBBreadcrumbBar.stories.tsx"],
  "importStatement": "import { KBBreadcrumbBar } from '@hiver/kb-ui';"
}
```

### Token index (76 entries)
`buildTokenIndex(): Map<string, TokenSpec>` parses `tokens.css` (section comments → category, inline `/* */` → description) and `tokens.ts` (AST flatten), merged by value equality with a kebab-case tie-breaker.

```json
{
  "name": "--color-canvas", "value": "#f5f5f5", "category": "Surfaces",
  "source": "css", "description": "page/canvas background",
  "cssCustomProperty": "--color-canvas", "jsTokenPath": "color.canvas"
}
```

## Smart deviations from the brief

- **Walk author-written `PropertySignature` nodes** instead of `checker.getPropertiesOfType` — kb-ui components like `AICard` extend `React.HTMLAttributes<HTMLElement>`, which would have spammed 271 props. Now reports 9.
- **Header-comment reader** extended to find JSDoc blocks after imports (kb-ui uses both styles).
- **Token tie-breaker:** when CSS tokens share a value, prefer the one whose name kebab-matches the JS path (`color.aiAddition` → `--color-ai-addition`, not the alphabetically-first match).
- **kb-ui resolution** via `require.resolve('@hiver/kb-ui')` + walk-up (kb-ui's `exports` map doesn't expose `./package.json`).

## Test plan

- [x] `npm run --workspace=packages/kb-mcp typecheck` clean
- [x] `npm run --workspace=packages/kb-mcp build` clean (dist/index/*.js emitted)
- [x] Component index smoke: `size: 36`, sample shows full ComponentSpec shape
- [x] Token index smoke: `size: 76`, `--color-canvas` resolves with `jsTokenPath: color.canvas`
- [x] `npm run --workspace=packages/kb-ui build-storybook` clean (Rule #5 end-state)

## Files

- `packages/kb-mcp/src/index/types.ts` (NEW)
- `packages/kb-mcp/src/index/component-index.ts` (NEW)
- `packages/kb-mcp/src/index/token-index.ts` (NEW)
- `packages/kb-mcp/package.json` (typescript moved devDeps → deps)
- `packages/kb-mcp/tsup.config.ts` (entry list expanded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)