### PR TITLE
feat(kb-mcp): wire Tier 1 MCP tools + design overview resource (closes #9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7190,7 +7190,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -7961,7 +7960,9 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "zod": "^3.23.0"
+        "typescript": "^5.4.0",
+        "zod": "^3.23.0",
+        "zod-to-json-schema": "^3.23.0"
       },
       "bin": {
         "kb-mcp": "dist/index.js"
@@ -7969,8 +7970,7 @@
       "devDependencies": {
         "@hiver/kb-ui": "*",
         "@types/node": "^20.0.0",
-        "tsup": "^8.0.0",
-        "typescript": "^5.4.0"
+        "tsup": "^8.0.0"
       },
       "peerDependencies": {
         "@hiver/kb-ui": "*"

--- a/packages/kb-mcp/package.json
+++ b/packages/kb-mcp/package.json
@@ -46,7 +46,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "typescript": "^5.4.0",
-    "zod": "^3.23.0"
+    "zod": "^3.23.0",
+    "zod-to-json-schema": "^3.23.0"
   },
   "devDependencies": {
     "@hiver/kb-ui": "*",

--- a/packages/kb-mcp/src/index.ts
+++ b/packages/kb-mcp/src/index.ts
@@ -1,7 +1,17 @@
 // @hiver/kb-mcp — MCP companion server for @hiver/kb-ui
 //
-// Stdio transport. Issue #7 (Phase 9.1) ships the bare server
-// bootstrap only — tools and resources are registered in #8/#9/#10.
+// Stdio transport. Issue #9 (Phase 9.3) wires up the Tier 1 toolkit:
+//   - list_components       (filter by category)
+//   - get_component_spec    (single component, full props/Figma/etc.)
+//   - list_tokens           (filter by tokens.css section)
+//   - get_token_value       (CSS or dotted JS form)
+//   - get_story_code        (full source by Storybook title)
+// plus one MCP resource:
+//   - kb://design/overview  (full text of design.md)
+//
+// Indices for components/tokens are built ONCE at startup from the
+// workspace install of @hiver/kb-ui (issue #8 module). The server
+// is read-only; no caching beyond the in-memory indices.
 //
 // Run locally for development:
 //   npm run --workspace=packages/kb-mcp build
@@ -12,6 +22,164 @@
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ErrorCode,
+  ListResourcesRequestSchema,
+  ListToolsRequestSchema,
+  McpError,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import type { ZodTypeAny } from 'zod';
+
+import { buildComponentIndex } from './index/component-index.js';
+import { buildTokenIndex } from './index/token-index.js';
+import {
+  listComponents,
+  listComponentsInputSchema,
+} from './tools/list-components.js';
+import {
+  getComponentSpec,
+  getComponentSpecInputSchema,
+} from './tools/get-component-spec.js';
+import { listTokens, listTokensInputSchema } from './tools/list-tokens.js';
+import {
+  getTokenValue,
+  getTokenValueInputSchema,
+} from './tools/get-token-value.js';
+import {
+  getStoryCode,
+  getStoryCodeInputSchema,
+} from './tools/get-story-code.js';
+import {
+  DESIGN_OVERVIEW_MIME,
+  DESIGN_OVERVIEW_NAME,
+  DESIGN_OVERVIEW_URI,
+  readDesignOverview,
+} from './resources/design-overview.js';
+
+/* ─────────────────────────────────────────────────────────────
+ * Path resolution: kb-ui src root + repo root
+ * ─────────────────────────────────────────────────────────────
+ *
+ * `require.resolve('@hiver/kb-ui')` returns the `main` entry —
+ * `.../packages/kb-ui/dist/index.js` in workspace mode. We walk up to
+ * the package directory (containing `package.json`), then into `src/`
+ * for story-file scans. The repo root is two levels above the package
+ * (packages/kb-ui → packages → repo).
+ */
+const require = createRequire(import.meta.url);
+
+function resolveKbUiPaths(): { kbUiPkgDir: string; kbUiSrcRoot: string; repoRoot: string } {
+  const kbUiMain = require.resolve('@hiver/kb-ui');
+  let kbUiPkgDir = dirname(kbUiMain);
+  // Walk up until we find a package.json. Bounded loop for safety.
+  for (let i = 0; i < 5; i += 1) {
+    if (existsSync(resolve(kbUiPkgDir, 'package.json'))) break;
+    const parent = dirname(kbUiPkgDir);
+    if (parent === kbUiPkgDir) {
+      throw new Error('Could not locate @hiver/kb-ui package root.');
+    }
+    kbUiPkgDir = parent;
+  }
+  const kbUiSrcRoot = resolve(kbUiPkgDir, 'src');
+  if (!existsSync(kbUiSrcRoot)) {
+    throw new Error(
+      `@hiver/kb-ui src/ not found at ${kbUiSrcRoot}. kb-mcp currently requires the workspace install (issue #8 scope).`,
+    );
+  }
+  // Workspace layout: <repo>/packages/kb-ui — repo is two levels up.
+  const repoRoot = resolve(kbUiPkgDir, '..', '..');
+  return { kbUiPkgDir, kbUiSrcRoot, repoRoot };
+}
+
+const { kbUiSrcRoot, repoRoot } = resolveKbUiPaths();
+
+/* ─────────────────────────────────────────────────────────────
+ * Build indices once at startup.
+ * ───────────────────────────────────────────────────────────── */
+const componentIndex = buildComponentIndex();
+const tokenIndex = buildTokenIndex();
+
+/* ─────────────────────────────────────────────────────────────
+ * Tool registry
+ * ─────────────────────────────────────────────────────────────
+ *
+ * Each entry pairs the tool's MCP descriptor (name, description,
+ * input schema) with the function that runs it. The CallTool
+ * dispatcher below validates `params.arguments` against the Zod
+ * schema, runs the handler, and JSON-stringifies the result into
+ * an MCP `text` content block.
+ */
+type ToolEntry = {
+  name: string;
+  description: string;
+  inputSchema: ZodTypeAny;
+  handler: (args: unknown) => unknown | Promise<unknown>;
+};
+
+const tools: ToolEntry[] = [
+  {
+    name: 'list_components',
+    description:
+      'List every kb-ui component, optionally filtered by category (folder under src/components/, e.g. "nav", "shell", "content"). Returns name, category, one-line description, and source path for each.',
+    inputSchema: listComponentsInputSchema,
+    handler: (args) => {
+      const parsed = listComponentsInputSchema.parse(args ?? {});
+      return listComponents(componentIndex, parsed);
+    },
+  },
+  {
+    name: 'get_component_spec',
+    description:
+      'Get the full ComponentSpec for a single kb-ui component (props, story files, Figma node, import statement). Pass the exported component name (e.g. "KBBreadcrumbBar"). Case-sensitive.',
+    inputSchema: getComponentSpecInputSchema,
+    handler: (args) => {
+      const parsed = getComponentSpecInputSchema.parse(args ?? {});
+      return getComponentSpec(componentIndex, parsed);
+    },
+  },
+  {
+    name: 'list_tokens',
+    description:
+      'List every kb-ui design token, optionally filtered by category (section in tokens.css, e.g. "Surfaces", "Text", "Spacing"). Returns name, value, and category.',
+    inputSchema: listTokensInputSchema,
+    handler: (args) => {
+      const parsed = listTokensInputSchema.parse(args ?? {});
+      return listTokens(tokenIndex, parsed);
+    },
+  },
+  {
+    name: 'get_token_value',
+    description:
+      'Resolve a single kb-ui design token. Accepts either CSS form ("--color-canvas") or dotted JS path ("color.canvas"). Returns the full TokenSpec.',
+    inputSchema: getTokenValueInputSchema,
+    handler: (args) => {
+      const parsed = getTokenValueInputSchema.parse(args ?? {});
+      return getTokenValue(tokenIndex, parsed);
+    },
+  },
+  {
+    name: 'get_story_code',
+    description:
+      'Return the full source of a kb-ui .stories.tsx file, looked up by the Storybook title in `meta.title` (e.g. "Patterns/Knowledge Base/Category Page", "Components/Navigation/Side Nav Rail").',
+    inputSchema: getStoryCodeInputSchema,
+    handler: async (args) => {
+      const parsed = getStoryCodeInputSchema.parse(args ?? {});
+      return getStoryCode(kbUiSrcRoot, parsed);
+    },
+  },
+];
+
+const toolByName = new Map<string, ToolEntry>(tools.map((t) => [t.name, t]));
+
+/* ─────────────────────────────────────────────────────────────
+ * Server setup + request handlers
+ * ───────────────────────────────────────────────────────────── */
 
 const server = new Server(
   {
@@ -25,6 +193,92 @@ const server = new Server(
     },
   },
 );
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      // zodToJsonSchema returns an object — the MCP Tool schema expects
+      // `{ type: "object", properties: ..., required: ... }`. Strip any
+      // top-level `$schema` for a cleaner envelope.
+      inputSchema: (() => {
+        const json = zodToJsonSchema(t.inputSchema, {
+          $refStrategy: 'none',
+          target: 'jsonSchema7',
+        }) as Record<string, unknown>;
+        delete json.$schema;
+        return json;
+      })(),
+    })),
+  };
+});
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+  const entry = toolByName.get(name);
+  if (!entry) {
+    throw new McpError(
+      ErrorCode.MethodNotFound,
+      `Unknown tool "${name}". Known tools: ${tools.map((t) => t.name).join(', ')}.`,
+    );
+  }
+  try {
+    const result = await entry.handler(args);
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(result, null, 2),
+        },
+      ],
+    };
+  } catch (err) {
+    // Tool handler / Zod validation failures surface to the client as a
+    // tool-result with `isError: true`. Reserved transport-level errors
+    // (McpError) are re-thrown so the SDK formats them as JSON-RPC errors.
+    if (err instanceof McpError) throw err;
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: [{ type: 'text', text: message }],
+      isError: true,
+    };
+  }
+});
+
+server.setRequestHandler(ListResourcesRequestSchema, async () => {
+  return {
+    resources: [
+      {
+        uri: DESIGN_OVERVIEW_URI,
+        name: DESIGN_OVERVIEW_NAME,
+        mimeType: DESIGN_OVERVIEW_MIME,
+        description:
+          'Full text of the kb-ui design system spec (design.md): tokens, typography, spacing, component-by-component Figma references.',
+      },
+    ],
+  };
+});
+
+server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+  const { uri } = request.params;
+  if (uri !== DESIGN_OVERVIEW_URI) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `Unknown resource URI "${uri}". Known: ${DESIGN_OVERVIEW_URI}.`,
+    );
+  }
+  const { mimeType, text } = await readDesignOverview(repoRoot);
+  return {
+    contents: [
+      {
+        uri,
+        mimeType,
+        text,
+      },
+    ],
+  };
+});
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/packages/kb-mcp/src/resources/design-overview.ts
+++ b/packages/kb-mcp/src/resources/design-overview.ts
@@ -1,0 +1,19 @@
+// MCP resource: kb://design/overview
+//
+// Serves the full text of design.md so Claude can ground itself in the
+// design-system foundations without an extra tool round-trip.
+
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+export const DESIGN_OVERVIEW_URI = 'kb://design/overview';
+export const DESIGN_OVERVIEW_NAME = 'Design system overview';
+export const DESIGN_OVERVIEW_MIME = 'text/markdown';
+
+export async function readDesignOverview(
+  repoRoot: string,
+): Promise<{ uri: string; mimeType: string; text: string }> {
+  const path = resolve(repoRoot, 'design.md');
+  const text = await readFile(path, 'utf8');
+  return { uri: DESIGN_OVERVIEW_URI, mimeType: DESIGN_OVERVIEW_MIME, text };
+}

--- a/packages/kb-mcp/src/tools/get-component-spec.ts
+++ b/packages/kb-mcp/src/tools/get-component-spec.ts
@@ -1,0 +1,33 @@
+// MCP tool: get_component_spec
+//
+// Returns the full ComponentSpec (props, story files, Figma node, import
+// statement) for a single named component. Throws a clear not-found error
+// (caller wraps it in an MCP error envelope) when the name doesn't match.
+
+import { z } from 'zod';
+import type { ComponentIndex, ComponentSpec } from '../index/types.js';
+
+export const getComponentSpecInputSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .describe(
+      'Component name as exported (e.g. "KBBreadcrumbBar"). Case-sensitive.',
+    ),
+});
+
+export type GetComponentSpecInput = z.infer<typeof getComponentSpecInputSchema>;
+
+export function getComponentSpec(
+  index: ComponentIndex,
+  input: GetComponentSpecInput,
+): ComponentSpec {
+  const found = index.get(input.name);
+  if (!found) {
+    const known = Array.from(index.keys()).sort().slice(0, 10).join(', ');
+    throw new Error(
+      `Component "${input.name}" not found in @hiver/kb-ui. Known components include: ${known}${index.size > 10 ? ', …' : ''}.`,
+    );
+  }
+  return found;
+}

--- a/packages/kb-mcp/src/tools/get-story-code.ts
+++ b/packages/kb-mcp/src/tools/get-story-code.ts
@@ -1,0 +1,76 @@
+// MCP tool: get_story_code
+//
+// Returns the FULL source of a kb-ui .stories.tsx file, looked up by the
+// Storybook title in the story's `meta.title` (e.g.
+// "Patterns/AI Optimisation/AI Optimise Hub" or
+// "Components/Layout/AppShell").
+//
+// Implementation: scan packages/kb-ui/src/**/*.stories.tsx for a matching
+// `title:` literal. The repo has ~40 story files; a linear scan at request
+// time is fine for v1.
+
+import { z } from 'zod';
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export const getStoryCodeInputSchema = z.object({
+  storyTitle: z
+    .string()
+    .min(1)
+    .describe(
+      'The exact `meta.title` string from the story file (e.g. "Patterns/Knowledge Base/Category Page", "Components/Navigation/Side Nav Rail").',
+    ),
+});
+
+export type GetStoryCodeInput = z.infer<typeof getStoryCodeInputSchema>;
+
+export type GetStoryCodeOutput = {
+  storyTitle: string;
+  filePath: string;
+  source: string;
+};
+
+async function walkStoryFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const out: string[] = [];
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) {
+      out.push(...(await walkStoryFiles(full)));
+    } else if (e.isFile() && e.name.endsWith('.stories.tsx')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+export async function getStoryCode(
+  kbUiSrcRoot: string,
+  input: GetStoryCodeInput,
+): Promise<GetStoryCodeOutput> {
+  const storyFiles = await walkStoryFiles(kbUiSrcRoot);
+
+  // Build a regex that matches `title: '<input>'`, `title: "<input>"`, or
+  // `title: \`<input>\`` with optional surrounding whitespace. Escape user
+  // input so regex metachars in the title (e.g. `/`, `.`) match literally.
+  const escaped = input.storyTitle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const titleRegex = new RegExp(`title\\s*:\\s*['"\`]${escaped}['"\`]`);
+
+  for (const filePath of storyFiles) {
+    const source = await readFile(filePath, 'utf8');
+    if (titleRegex.test(source)) {
+      return { storyTitle: input.storyTitle, filePath, source };
+    }
+  }
+
+  // Helpful error: list a few known titles so the caller can correct itself.
+  const candidates: string[] = [];
+  for (const filePath of storyFiles) {
+    const source = await readFile(filePath, 'utf8');
+    const match = source.match(/title\s*:\s*['"`]([^'"`]+)['"`]/);
+    if (match) candidates.push(match[1]);
+  }
+  throw new Error(
+    `Story title "${input.storyTitle}" not found among ${storyFiles.length} story files. Known titles include: ${candidates.slice(0, 8).join(' | ')}${candidates.length > 8 ? ' | …' : ''}.`,
+  );
+}

--- a/packages/kb-mcp/src/tools/get-token-value.ts
+++ b/packages/kb-mcp/src/tools/get-token-value.ts
@@ -1,0 +1,36 @@
+// MCP tool: get_token_value
+//
+// Returns the full TokenSpec for a single named token. Accepts either the
+// CSS form (--color-canvas) or the dotted JS path (color.canvas).
+
+import { z } from 'zod';
+import type { TokenIndex, TokenSpec } from '../index/types.js';
+
+export const getTokenValueInputSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .describe(
+      'Token name. Either CSS form ("--color-canvas") or dotted JS path ("color.canvas").',
+    ),
+});
+
+export type GetTokenValueInput = z.infer<typeof getTokenValueInputSchema>;
+
+export function getTokenValue(
+  index: TokenIndex,
+  input: GetTokenValueInput,
+): TokenSpec {
+  // Direct hit on the canonical key (CSS form is canonical when available).
+  const direct = index.get(input.name);
+  if (direct) return direct;
+
+  // Try the JS-path side: scan for a TokenSpec whose `jsTokenPath` matches.
+  for (const t of index.values()) {
+    if (t.jsTokenPath === input.name) return t;
+  }
+
+  throw new Error(
+    `Token "${input.name}" not found. Try either CSS form (e.g. "--color-canvas") or dotted JS path (e.g. "color.canvas").`,
+  );
+}

--- a/packages/kb-mcp/src/tools/list-components.ts
+++ b/packages/kb-mcp/src/tools/list-components.ts
@@ -1,0 +1,41 @@
+// MCP tool: list_components
+//
+// Returns every kb-ui component, optionally filtered by category
+// (folder name under src/components/). One-line description per entry.
+
+import { z } from 'zod';
+import type { ComponentIndex } from '../index/types.js';
+
+export const listComponentsInputSchema = z.object({
+  category: z
+    .string()
+    .optional()
+    .describe(
+      'Filter by category (folder under src/components/, e.g. "nav", "shell", "content"). Omit to return all.',
+    ),
+});
+
+export type ListComponentsInput = z.infer<typeof listComponentsInputSchema>;
+
+export type ListComponentsOutputEntry = {
+  name: string;
+  category: string;
+  oneLineDescription: string | null;
+  filePath: string;
+};
+
+export function listComponents(
+  index: ComponentIndex,
+  input: ListComponentsInput,
+): ListComponentsOutputEntry[] {
+  const filter = input.category?.toLowerCase();
+  return Array.from(index.values())
+    .filter((c) => !filter || c.category.toLowerCase() === filter)
+    .map((c) => ({
+      name: c.name,
+      category: c.category,
+      oneLineDescription: c.description,
+      filePath: c.filePath,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/packages/kb-mcp/src/tools/list-tokens.ts
+++ b/packages/kb-mcp/src/tools/list-tokens.ts
@@ -1,0 +1,36 @@
+// MCP tool: list_tokens
+//
+// Returns every design token, optionally filtered by category
+// (the section header from tokens.css, e.g. "Surfaces", "Text", "Spacing").
+// Filter is case-insensitive.
+
+import { z } from 'zod';
+import type { TokenIndex } from '../index/types.js';
+
+export const listTokensInputSchema = z.object({
+  category: z
+    .string()
+    .optional()
+    .describe(
+      'Filter by category (section in tokens.css, e.g. "Surfaces", "Text", "Spacing"). Omit to return all. Case-insensitive.',
+    ),
+});
+
+export type ListTokensInput = z.infer<typeof listTokensInputSchema>;
+
+export type ListTokensOutputEntry = {
+  name: string;
+  value: string;
+  category: string | null;
+};
+
+export function listTokens(
+  index: TokenIndex,
+  input: ListTokensInput,
+): ListTokensOutputEntry[] {
+  const filter = input.category?.toLowerCase();
+  return Array.from(index.values())
+    .filter((t) => !filter || t.category?.toLowerCase() === filter)
+    .map((t) => ({ name: t.name, value: t.value, category: t.category }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}


### PR DESCRIPTION
## Summary

Phase 9.3 — `@hiver/kb-mcp` now exposes **5 deterministic-retrieval tools + 1 resource** over stdio, reading the indices built in #8.

After this PR, anyone running an MCP client (Claude Code, Desktop, Cursor) and pointed at `node packages/kb-mcp/dist/index.js` can ask the model "what props does KBBreadcrumbBar take?" or "what's the value of --color-canvas?" and get a structured answer.

## Tools

| Name | Input | Output |
|---|---|---|
| `list_components` | `{ category? }` | 36 entries (filterable by folder: `nav`, `shell`, `content`, etc.) |
| `get_component_spec` | `{ name }` | Full ComponentSpec — props, story files, Figma node, importStatement |
| `list_tokens` | `{ category? }` | 76 entries (filterable by section: "Surfaces", "Text", "Spacing"…) |
| `get_token_value` | `{ name }` | Full TokenSpec — accepts `--color-canvas` or `color.canvas` |
| `get_story_code` | `{ storyTitle }` | Full source of the matching `.stories.tsx`, looked up by `meta.title` |

## Resource

`kb://design/overview` — full text of `design.md` (~393 lines), so Claude grounds itself in the design system without an extra round-trip.

## Implementation notes

- Indices build **once at server startup**; static across requests (~10ms).
- Zod schemas → inline JSON Schema 7 via `zod-to-json-schema` (new dep).
- Tool errors return MCP's `{ content, isError: true }` envelope (validation, not-found); `McpError` reserved for transport-level issues.
- kb-ui source root resolved via `require.resolve('@hiver/kb-ui')` + bounded walk-up.

## Test plan

All verified via raw JSON-RPC blasts to `node dist/index.js`:

- [x] `tools/list` returns all 5 tools with their inline JSON Schemas
- [x] `tools/call list_components { category: "shell" }` → `AppShell` + `KBBreadcrumbBar`
- [x] `resources/list` → `kb://design/overview`
- [x] `resources/read kb://design/overview` → full `design.md`
- [x] `npm run --workspace=packages/kb-mcp typecheck` clean
- [x] `npm run --workspace=packages/kb-mcp build` clean (`dist/index.js` 27.45KB)
- [x] `npm run --workspace=packages/kb-ui build-storybook` clean (Rule #5)

## Files

- `packages/kb-mcp/src/tools/list-components.ts` (NEW)
- `packages/kb-mcp/src/tools/get-component-spec.ts` (NEW)
- `packages/kb-mcp/src/tools/list-tokens.ts` (NEW)
- `packages/kb-mcp/src/tools/get-token-value.ts` (NEW)
- `packages/kb-mcp/src/tools/get-story-code.ts` (NEW)
- `packages/kb-mcp/src/resources/design-overview.ts` (NEW)
- `packages/kb-mcp/src/index.ts` (registration replaces #7 stub)
- `packages/kb-mcp/package.json` (zod-to-json-schema dep)
- `package-lock.json` (auto-update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)