### PR TITLE
chore: rename npm scope @hiver → @test-kb-ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to `@hiver/kb-ui` will be documented in this file.
+All notable changes to `@test-kb-ui/kb-ui` will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
@@ -81,7 +81,7 @@ Initial public release. Built across nine phases (0 through 7.5) culminating in 
 #### Foundations
 
 - Design tokens (`tokens.ts` plus `tokens.css`) — colors (kb palette, AI gaps semantic palette, analytics chart palette), typography, spacing, border radius
-- `import '@hiver/kb-ui/styles'` exposes the canonical Tailwind v4 plus tokens layer
+- `import '@test-kb-ui/kb-ui/styles'` exposes the canonical Tailwind v4 plus tokens layer
 - `cn` utility re-exported for class composition
 
 [1.0.0]: https://github.com/geekv30/kb/releases/tag/v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Read: logs.md       → current status, what's done, what's next
 
 ## ACTIVE PROJECT: Hiver KB Component Library
 
-Build a **pixel-perfect, 1:1 component library** for Hiver's KB product (`app.hiverkb.com`), distributed as the npm package `@hiver/kb-ui`.
+Build a **pixel-perfect, 1:1 component library** for Hiver's KB product (`app.hiverkb.com`), distributed as the npm package `@test-kb-ui/kb-ui`.
 
 **Problem statement in full:** designers, PMs, and engineers should be able to build any new KB feature from a PRD alone — zero bespoke Figma effort, 100% visual cohesion with the product.
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # Hiver KB Component Library
 
-`@hiver/kb-ui` is the React component library that powers Hiver's knowledge base product (`app.hiverkb.com`). It exists so designers, PMs, and engineers can assemble any new KB feature directly from a PRD — every primitive, nav surface, content block, editor, AI gap reviewer, and analytics card needed to match the product is already in the box, with 1:1 Figma fidelity.
+`@test-kb-ui/kb-ui` is the React component library that powers Hiver's knowledge base product (`app.hiverkb.com`). It exists so designers, PMs, and engineers can assemble any new KB feature directly from a PRD — every primitive, nav surface, content block, editor, AI gap reviewer, and analytics card needed to match the product is already in the box, with 1:1 Figma fidelity.
 
-- npm: [`@hiver/kb-ui`](https://www.npmjs.com/package/@hiver/kb-ui)
+- npm: [`@test-kb-ui/kb-ui`](https://www.npmjs.com/package/@test-kb-ui/kb-ui)
 - Demo app: see "Explore" below
 
 ## Install
 
 ```bash
-npm install @hiver/kb-ui
+npm install @test-kb-ui/kb-ui
 ```
 
 ## Quickstart
 
 ```tsx
-import { AppShell, KBBreadcrumbBar, SideNavRail, FileExplorerNav } from '@hiver/kb-ui';
-import '@hiver/kb-ui/styles';
+import { AppShell, KBBreadcrumbBar, SideNavRail, FileExplorerNav } from '@test-kb-ui/kb-ui';
+import '@test-kb-ui/kb-ui/styles';
 
 export function App() {
   return (

--- a/apps/demo/README.md
+++ b/apps/demo/README.md
@@ -1,6 +1,6 @@
-# @hiver/kb-demo
+# @test-kb-ui/kb-demo
 
-A standalone Vite + React 18 application that consumes [`@hiver/kb-ui`](../../packages/kb-ui) the way an external Hiver engineer would — `import { ... } from '@hiver/kb-ui'`. It stitches every pattern shipped in kb-ui's Phases 3–7 into a single navigable product so the library can be experienced end-to-end without opening Storybook. This app is the integration test for the Phase 8 npm publish: if it consumes the workspace package cleanly, downstream users will too.
+A standalone Vite + React 18 application that consumes [`@test-kb-ui/kb-ui`](../../packages/kb-ui) the way an external Hiver engineer would — `import { ... } from '@test-kb-ui/kb-ui'`. It stitches every pattern shipped in kb-ui's Phases 3–7 into a single navigable product so the library can be experienced end-to-end without opening Storybook. This app is the integration test for the Phase 8 npm publish: if it consumes the workspace package cleanly, downstream users will too.
 
 For the full design contract see [`demo-app-prd.md`](../../demo-app-prd.md) (PRD) and [`demo-app-trd.md`](../../demo-app-trd.md) (TRD).
 
@@ -53,11 +53,11 @@ npm run typecheck --workspace=apps/demo
 | Routing | React Router (data router) | ^6.26 |
 | Styling | Tailwind CSS v4 (`@tailwindcss/vite`) | ^4.0 |
 | State | React Context + `useReducer` (custom MockStore) | n/a |
-| Component library | `@hiver/kb-ui` | workspace `*` link |
+| Component library | `@test-kb-ui/kb-ui` | workspace `*` link |
 
-No additional runtime dependencies. Tiptap, Recharts, Radix primitives, and `@remixicon/react` come transitively through `@hiver/kb-ui`.
+No additional runtime dependencies. Tiptap, Recharts, Radix primitives, and `@remixicon/react` come transitively through `@test-kb-ui/kb-ui`.
 
-The kb-ui package is consumed via npm workspaces — there is no build step coupling between the two; the demo simply imports from `@hiver/kb-ui` and Vite resolves it through `node_modules` like any other package.
+The kb-ui package is consumed via npm workspaces — there is no build step coupling between the two; the demo simply imports from `@test-kb-ui/kb-ui` and Vite resolves it through `node_modules` like any other package.
 
 ## Mock data
 

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hiver/kb-demo",
+  "name": "@test-kb-ui/kb-demo",
   "private": true,
   "version": "0.0.0",
   "type": "module",
@@ -10,7 +10,7 @@
     "typecheck": "tsc -b"
   },
   "dependencies": {
-    "@hiver/kb-ui": "*",
+    "@test-kb-ui/kb-ui": "*",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "react-router-dom": "^6.26.0"

--- a/apps/demo/src/components/ConfirmDialog.tsx
+++ b/apps/demo/src/components/ConfirmDialog.tsx
@@ -12,7 +12,7 @@
 // `window.confirm` calls in EditorPage and the AI Gaps breadcrumb.
 
 import * as Dialog from '@radix-ui/react-dialog';
-import { Button } from '@hiver/kb-ui';
+import { Button } from '@test-kb-ui/kb-ui';
 import { cn } from '../lib/cn';
 
 export type ConfirmDialogProps = {

--- a/apps/demo/src/components/EmptyState.tsx
+++ b/apps/demo/src/components/EmptyState.tsx
@@ -5,7 +5,7 @@
 // legitimately be "empty" rather than "loading" or "errored".
 
 import type { ReactNode } from 'react';
-import { Button } from '@hiver/kb-ui';
+import { Button } from '@test-kb-ui/kb-ui';
 import { cn } from '../lib/cn';
 
 export type EmptyStateProps = {

--- a/apps/demo/src/components/RouteErrorBoundary.tsx
+++ b/apps/demo/src/components/RouteErrorBoundary.tsx
@@ -6,7 +6,7 @@
 // muted block so the user can describe what they saw to the team.
 
 import { useRouteError } from 'react-router-dom';
-import { Button } from '@hiver/kb-ui';
+import { Button } from '@test-kb-ui/kb-ui';
 import { RiErrorWarningLine } from '@remixicon/react';
 
 function describe(error: unknown): string {

--- a/apps/demo/src/hooks/useAIGapsForArticle.ts
+++ b/apps/demo/src/hooks/useAIGapsForArticle.ts
@@ -18,7 +18,7 @@ import {
   initialAIGapsState,
   type AIGapsAction,
   type AIGapsState,
-} from '@hiver/kb-ui';
+} from '@test-kb-ui/kb-ui';
 import { useMockStore } from '../store/MockStoreContext';
 
 export type UseAIGapsForArticleResult = readonly [

--- a/apps/demo/src/lib/cn.ts
+++ b/apps/demo/src/lib/cn.ts
@@ -1,8 +1,8 @@
-// Re-export of `cn` from `@hiver/kb-ui`.
+// Re-export of `cn` from `@test-kb-ui/kb-ui`.
 //
 // Demo-side modules import `cn` from this local helper rather than
-// reaching into `@hiver/kb-ui` directly. Two reasons:
+// reaching into `@test-kb-ui/kb-ui` directly. Two reasons:
 //   1. Single import surface — one line to swap if the demo ever wants
 //      its own className merger.
 //   2. Keeps callsites short and readable (`from '../lib/cn'`).
-export { cn } from '@hiver/kb-ui';
+export { cn } from '@test-kb-ui/kb-ui';

--- a/apps/demo/src/routes/CollapsedShellLayout.tsx
+++ b/apps/demo/src/routes/CollapsedShellLayout.tsx
@@ -14,7 +14,7 @@
 
 import { Suspense } from 'react';
 import { Outlet } from 'react-router-dom';
-import { AppShell } from '@hiver/kb-ui';
+import { AppShell } from '@test-kb-ui/kb-ui';
 import { BreadcrumbBar } from '../shell/BreadcrumbBar';
 import { PageProgressBar } from '../components/PageProgressBar';
 import { RouteTransition } from '../components/RouteTransition';

--- a/apps/demo/src/routes/NotFoundPage.tsx
+++ b/apps/demo/src/routes/NotFoundPage.tsx
@@ -7,7 +7,7 @@
 // by the rest of the app.
 
 import { Link } from 'react-router-dom';
-import { CompanyLogo } from '@hiver/kb-ui';
+import { CompanyLogo } from '@test-kb-ui/kb-ui';
 import { routes } from '../lib/routes';
 import { cn } from '../lib/cn';
 

--- a/apps/demo/src/routes/ShellLayout.tsx
+++ b/apps/demo/src/routes/ShellLayout.tsx
@@ -11,7 +11,7 @@
 
 import { Suspense } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
-import { AppShell } from '@hiver/kb-ui';
+import { AppShell } from '@test-kb-ui/kb-ui';
 import { AppRail } from '../shell/AppRail';
 import { EditorExplorer } from '../shell/EditorExplorer';
 import { AnalyticsExplorer } from '../shell/AnalyticsExplorer';

--- a/apps/demo/src/routes/ai-optimise/HubPage.tsx
+++ b/apps/demo/src/routes/ai-optimise/HubPage.tsx
@@ -10,7 +10,7 @@
 
 import { useNavigate } from 'react-router-dom';
 import { RiCheckLine } from '@remixicon/react';
-import { SuggestionCard } from '@hiver/kb-ui';
+import { SuggestionCard } from '@test-kb-ui/kb-ui';
 import { useMockStore } from '../../store/MockStoreContext';
 import {
   selectPendingSuggestionArticles,

--- a/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
+++ b/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
@@ -38,7 +38,7 @@ import {
   type ArticleSuggestionDecision,
   type ArticleSettings as KbUiArticleSettings,
   type ConversationSource as KbUiConversationSource,
-} from '@hiver/kb-ui';
+} from '@test-kb-ui/kb-ui';
 import { useMockStore } from '../../store/MockStoreContext';
 import {
   selectArticleBySlug,

--- a/apps/demo/src/routes/ai-optimise/passwordResetRegions.tsx
+++ b/apps/demo/src/routes/ai-optimise/passwordResetRegions.tsx
@@ -23,7 +23,7 @@
 // mapping for the rationale.
 
 import * as React from 'react';
-import type { ArticleBodyRegions } from '@hiver/kb-ui';
+import type { ArticleBodyRegions } from '@test-kb-ui/kb-ui';
 
 function H1({ children }: { children: React.ReactNode }) {
   return (

--- a/apps/demo/src/routes/analytics/AIAnswerPerformancePage.tsx
+++ b/apps/demo/src/routes/analytics/AIAnswerPerformancePage.tsx
@@ -35,7 +35,7 @@ import {
   DateRangePill,
   StatCardGrid,
   type DataTableColumn,
-} from '@hiver/kb-ui';
+} from '@test-kb-ui/kb-ui';
 import { useMockStore } from '../../store/MockStoreContext';
 import { selectArticleById } from '../../store/selectors';
 import {

--- a/apps/demo/src/routes/analytics/ArticlePerformancePage.tsx
+++ b/apps/demo/src/routes/analytics/ArticlePerformancePage.tsx
@@ -33,7 +33,7 @@ import {
   HelpfulnessTag,
   StatCardGrid,
   type DataTableColumn,
-} from '@hiver/kb-ui';
+} from '@test-kb-ui/kb-ui';
 import { useMockStore } from '../../store/MockStoreContext';
 import { selectArticleById } from '../../store/selectors';
 import {

--- a/apps/demo/src/routes/analytics/SearchPage.tsx
+++ b/apps/demo/src/routes/analytics/SearchPage.tsx
@@ -28,7 +28,7 @@ import {
   DataTable,
   DateRangePill,
   type DataTableColumn,
-} from '@hiver/kb-ui';
+} from '@test-kb-ui/kb-ui';
 import {
   searchFixtures,
   type ContentGapRow,

--- a/apps/demo/src/routes/kb/CategoryPage.tsx
+++ b/apps/demo/src/routes/kb/CategoryPage.tsx
@@ -8,7 +8,7 @@
 // (white card, slate border, 8 px radius, grey #f5f5f5 header,
 // 6 px vertical cell padding, h-12 row height).
 //
-// All visual elements come from `@hiver/kb-ui`. The only bespoke UI is
+// All visual elements come from `@test-kb-ui/kb-ui`. The only bespoke UI is
 // (a) the inline "category not found" state and (b) the inline empty
 // state when the category has neither children nor articles. Both are
 // intentionally simple — Phase 7.5.8 owns the polished empty-state pass.
@@ -28,7 +28,7 @@ import {
   DataTable,
   PageHeader,
   type DataTableColumn,
-} from '@hiver/kb-ui';
+} from '@test-kb-ui/kb-ui';
 import { useMockStore } from '../../store/MockStoreContext';
 import {
   selectArticlesInCategory,

--- a/apps/demo/src/routes/kb/EditorPage.tsx
+++ b/apps/demo/src/routes/kb/EditorPage.tsx
@@ -37,7 +37,7 @@ import {
   type ArticleSettings as KbUiArticleSettings,
   type ArticleSettingsPerson,
   type ArticleVisibility as KbUiArticleVisibility,
-} from '@hiver/kb-ui';
+} from '@test-kb-ui/kb-ui';
 import { useMockStore } from '../../store/MockStoreContext';
 import {
   selectArticleBySlug,

--- a/apps/demo/src/shell/AISubNavbar.tsx
+++ b/apps/demo/src/shell/AISubNavbar.tsx
@@ -10,7 +10,7 @@
 
 import { RiMagicLine } from '@remixicon/react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { AiIcon } from '@hiver/kb-ui';
+import { AiIcon } from '@test-kb-ui/kb-ui';
 import { AISubNav, type AISubNavItem } from './AISubNav';
 import { routes } from '../lib/routes';
 import { useToast } from '../components/Toast';

--- a/apps/demo/src/shell/AnalyticsExplorer.tsx
+++ b/apps/demo/src/shell/AnalyticsExplorer.tsx
@@ -8,7 +8,7 @@
 import { useMemo } from 'react';
 import { RiBarChartBoxLine } from '@remixicon/react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { FileExplorerNav } from '@hiver/kb-ui';
+import { FileExplorerNav } from '@test-kb-ui/kb-ui';
 import { useMockStore } from '../store/MockStoreContext';
 import { selectAnalyticsExplorerItems } from '../store/selectors';
 import { routes } from '../lib/routes';

--- a/apps/demo/src/shell/AppRail.tsx
+++ b/apps/demo/src/shell/AppRail.tsx
@@ -18,7 +18,7 @@ import {
   CompanyLogo,
   SideNavRail,
   type NavRailItem,
-} from '@hiver/kb-ui';
+} from '@test-kb-ui/kb-ui';
 import { useMockStore } from '../store/MockStoreContext';
 import { selectCurrentUser } from '../store/selectors';
 import { DEFAULT_KB_CATEGORY_SLUG, routes } from '../lib/routes';

--- a/apps/demo/src/shell/BreadcrumbBar.tsx
+++ b/apps/demo/src/shell/BreadcrumbBar.tsx
@@ -22,7 +22,7 @@ import {
   isPublishEnabled,
   KBBreadcrumbBar,
   type KBBreadcrumbItem,
-} from '@hiver/kb-ui';
+} from '@test-kb-ui/kb-ui';
 import { useMockStore } from '../store/MockStoreContext';
 import {
   selectArticleBySlug,

--- a/apps/demo/src/shell/EditorExplorer.tsx
+++ b/apps/demo/src/shell/EditorExplorer.tsx
@@ -17,7 +17,7 @@
 
 import { useCallback, useMemo } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { FileExplorerNav, type NavItem } from '@hiver/kb-ui';
+import { FileExplorerNav, type NavItem } from '@test-kb-ui/kb-ui';
 import { useMockStore } from '../store/MockStoreContext';
 import {
   selectArticleBySlug,

--- a/apps/demo/src/store/fixtures/analytics.ts
+++ b/apps/demo/src/store/fixtures/analytics.ts
@@ -20,7 +20,7 @@ import type {
   DonutDatum,
   HelpfulnessVariant,
   StatCardProps,
-} from '@hiver/kb-ui';
+} from '@test-kb-ui/kb-ui';
 
 /* ─────────────────────────────────────────────────────────────
  * Row types (Phase 7.5 migration — moved app-side).

--- a/apps/demo/src/store/reducer.ts
+++ b/apps/demo/src/store/reducer.ts
@@ -6,8 +6,8 @@
 // so it can be reasoned about (and unit-tested in a later phase) on
 // its own.
 
-import { aiGapsReducer, initialAIGapsState } from '@hiver/kb-ui';
-import type { AISuggestion as KbUiAISuggestion } from '@hiver/kb-ui';
+import { aiGapsReducer, initialAIGapsState } from '@test-kb-ui/kb-ui';
+import type { AISuggestion as KbUiAISuggestion } from '@test-kb-ui/kb-ui';
 import type {
   AIGapsAction,
   AIGapsState,

--- a/apps/demo/src/store/selectors.ts
+++ b/apps/demo/src/store/selectors.ts
@@ -5,7 +5,7 @@
 // Memoization can be revisited if a future profiler pass shows
 // hot spots; until then, KISS.
 
-import type { NavItem } from '@hiver/kb-ui';
+import type { NavItem } from '@test-kb-ui/kb-ui';
 import type {
   AISuggestion,
   Article,

--- a/apps/demo/src/store/types.ts
+++ b/apps/demo/src/store/types.ts
@@ -5,10 +5,10 @@
 // strings (no Date objects in the store — keeps the reducer pure and
 // JSON-serialisable for future dev-tools snapshots).
 
-// Re-exported from @hiver/kb-ui after Phase 7.5.1 prep so the demo's
+// Re-exported from @test-kb-ui/kb-ui after Phase 7.5.1 prep so the demo's
 // per-article reducer slots align exactly with what the kb-ui state
 // machine produces.
-import type { AIGapsState, AIGapsAction } from '@hiver/kb-ui';
+import type { AIGapsState, AIGapsAction } from '@test-kb-ui/kb-ui';
 
 export type { AIGapsState, AIGapsAction };
 

--- a/apps/demo/src/tokens.css
+++ b/apps/demo/src/tokens.css
@@ -4,10 +4,10 @@
  * colors, spacing, radii, and the Tailwind v4 source directive
  * identically to how Storybook does in `packages/kb-ui/.storybook/preview.ts`.
  */
-@import '@hiver/kb-ui/styles';
+@import '@test-kb-ui/kb-ui/styles';
 
 /* Tailwind v4's content auto-discovery skips `node_modules` by default.
- * Our shell + nav components live in the `@hiver/kb-ui` package and
+ * Our shell + nav components live in the `@test-kb-ui/kb-ui` package and
  * resolve through the npm-workspace symlink to that package's `dist/`
  * bundle. Without this `@source` directive, arbitrary classes used
  * only inside `dist/` (e.g. `w-[54px]` on `SideNavRail`) get tree-

--- a/apps/demo/vite.config.ts
+++ b/apps/demo/vite.config.ts
@@ -2,11 +2,11 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 
-// Vite config for the @hiver/kb-demo app.
+// Vite config for the @test-kb-ui/kb-demo app.
 //
 // Tailwind v4 is wired through `@tailwindcss/vite` — the same way
 // `packages/kb-ui` wires it (see `packages/kb-ui/.storybook/main.ts`).
-// Keeping the plugin identical here ensures `@hiver/kb-ui/styles` resolves
+// Keeping the plugin identical here ensures `@test-kb-ui/kb-ui/styles` resolves
 // the same token surface in both environments.
 //
 // `manualChunks` splits the heavy transitive deps (Tiptap and Recharts)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
       ]
     },
     "apps/demo": {
-      "name": "@hiver/kb-demo",
+      "name": "@test-kb-ui/kb-demo",
       "version": "0.0.0",
       "dependencies": {
-        "@hiver/kb-ui": "*",
+        "@test-kb-ui/kb-ui": "*",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "react-router-dom": "^6.26.0"
@@ -819,18 +819,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
-    },
-    "node_modules/@hiver/kb-demo": {
-      "resolved": "apps/demo",
-      "link": true
-    },
-    "node_modules/@hiver/kb-mcp": {
-      "resolved": "packages/kb-mcp",
-      "link": true
-    },
-    "node_modules/@hiver/kb-ui": {
-      "resolved": "packages/kb-ui",
-      "link": true
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
@@ -2649,6 +2637,18 @@
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
+    },
+    "node_modules/@test-kb-ui/kb-demo": {
+      "resolved": "apps/demo",
+      "link": true
+    },
+    "node_modules/@test-kb-ui/kb-mcp": {
+      "resolved": "packages/kb-mcp",
+      "link": true
+    },
+    "node_modules/@test-kb-ui/kb-ui": {
+      "resolved": "packages/kb-ui",
+      "link": true
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
@@ -8013,7 +8013,7 @@
       }
     },
     "packages/kb-mcp": {
-      "name": "@hiver/kb-mcp",
+      "name": "@test-kb-ui/kb-mcp",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -8026,17 +8026,17 @@
         "kb-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@hiver/kb-ui": "*",
+        "@test-kb-ui/kb-ui": "*",
         "@types/node": "^20.0.0",
         "tsup": "^8.0.0",
         "tsx": "^4.7.0"
       },
       "peerDependencies": {
-        "@hiver/kb-ui": "*"
+        "@test-kb-ui/kb-ui": "*"
       }
     },
     "packages/kb-ui": {
-      "name": "@hiver/kb-ui",
+      "name": "@test-kb-ui/kb-ui",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/packages/kb-mcp/package.json
+++ b/packages/kb-mcp/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@hiver/kb-mcp",
+  "name": "@test-kb-ui/kb-mcp",
   "version": "1.0.0",
-  "description": "MCP companion server for @hiver/kb-ui — read components, tokens, and pattern stories from the kb-ui library",
+  "description": "MCP companion server for @test-kb-ui/kb-ui — read components, tokens, and pattern stories from the kb-ui library",
   "license": "MIT",
   "author": "Hiver",
   "homepage": "https://github.com/geekv30/kb#readme",
@@ -42,7 +42,7 @@
     "test": "tsx --test test/**/*.test.ts"
   },
   "peerDependencies": {
-    "@hiver/kb-ui": "*"
+    "@test-kb-ui/kb-ui": "*"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
@@ -51,7 +51,7 @@
     "zod-to-json-schema": "^3.23.0"
   },
   "devDependencies": {
-    "@hiver/kb-ui": "*",
+    "@test-kb-ui/kb-ui": "*",
     "@types/node": "^20.0.0",
     "tsup": "^8.0.0",
     "tsx": "^4.7.0"

--- a/packages/kb-mcp/src/composition-templates.ts
+++ b/packages/kb-mcp/src/composition-templates.ts
@@ -8,7 +8,7 @@
 // nothing automatically — the picker falls back to it explicitly.
 //
 // Snippet shape rules:
-//   - Real importable component names from `@hiver/kb-ui`.
+//   - Real importable component names from `@test-kb-ui/kb-ui`.
 //   - 15–40 lines of TSX, syntactically valid, copy-pasteable.
 //   - `// ...` comments where the consumer fills in their own data.
 //   - Column configs / sample data don't have to be runtime-perfect; the
@@ -40,8 +40,8 @@ export const compositionTemplates: CompositionTemplate[] = [
   ContentEditor,
   ArticleSettingsPanel,
   type ArticleSettings,
-} from '@hiver/kb-ui';
-import '@hiver/kb-ui/styles';
+} from '@test-kb-ui/kb-ui';
+import '@test-kb-ui/kb-ui/styles';
 
 const settings: ArticleSettings = {
   // ... fill from your article record (visibility, owner, tags, etc.)
@@ -89,8 +89,8 @@ export function ArticleEditorPage() {
   AISuggestionsCard,
   AIGapSuggestionCard,
   SourcesSideSheet,
-} from '@hiver/kb-ui';
-import '@hiver/kb-ui/styles';
+} from '@test-kb-ui/kb-ui';
+import '@test-kb-ui/kb-ui/styles';
 
 export function AIGapsReviewPage() {
   return (
@@ -135,8 +135,8 @@ export function AIGapsReviewPage() {
   SideNavRail,
   KBBreadcrumbBar,
   SuggestionCard,
-} from '@hiver/kb-ui';
-import '@hiver/kb-ui/styles';
+} from '@test-kb-ui/kb-ui';
+import '@test-kb-ui/kb-ui/styles';
 
 export function AIOptimiseHub() {
   return (
@@ -176,8 +176,8 @@ export function AIOptimiseHub() {
   DateRangePill,
   DataTable,
   type DataTableColumn,
-} from '@hiver/kb-ui';
-import '@hiver/kb-ui/styles';
+} from '@test-kb-ui/kb-ui';
+import '@test-kb-ui/kb-ui/styles';
 
 type ArticleRow = { id: string; title: string; views: number; helpfulness: string };
 
@@ -223,8 +223,8 @@ export function ArticlePerformancePage({ rows }: { rows: ArticleRow[] }) {
   AnalyticsAreaChart,
   DataTable,
   type DataTableColumn,
-} from '@hiver/kb-ui';
-import '@hiver/kb-ui/styles';
+} from '@test-kb-ui/kb-ui';
+import '@test-kb-ui/kb-ui/styles';
 
 type SearchRow = { id: string; keyword: string; searches: number; ctr: string };
 
@@ -265,8 +265,8 @@ export function SearchAnalyticsPage({ rows }: { rows: SearchRow[] }) {
   PageHeader,
   DataTable,
   type DataTableColumn,
-} from '@hiver/kb-ui';
-import '@hiver/kb-ui/styles';
+} from '@test-kb-ui/kb-ui';
+import '@test-kb-ui/kb-ui/styles';
 
 type Article = { id: string; title: string; status: 'published' | 'draft'; updatedAt: string };
 
@@ -305,8 +305,8 @@ export function CategoryPage({ items }: { items: Article[] }) {
   SideNavRail,
   KBBreadcrumbBar,
   Card,
-} from '@hiver/kb-ui';
-import '@hiver/kb-ui/styles';
+} from '@test-kb-ui/kb-ui';
+import '@test-kb-ui/kb-ui/styles';
 
 export function NewKBPage() {
   return (

--- a/packages/kb-mcp/src/index.ts
+++ b/packages/kb-mcp/src/index.ts
@@ -1,4 +1,4 @@
-// @hiver/kb-mcp — MCP companion server for @hiver/kb-ui
+// @test-kb-ui/kb-mcp — MCP companion server for @test-kb-ui/kb-ui
 //
 // Stdio transport. Issue #9 (Phase 9.3) wires up the Tier 1 toolkit:
 //   - list_components       (filter by category)
@@ -10,7 +10,7 @@
 //   - kb://design/overview  (full text of design.md)
 //
 // Indices for components/tokens are built ONCE at startup from the
-// workspace install of @hiver/kb-ui (issue #8 module). The server
+// workspace install of @test-kb-ui/kb-ui (issue #8 module). The server
 // is read-only; no caching beyond the in-memory indices.
 //
 // Run locally for development:
@@ -70,7 +70,7 @@ import {
  * Path resolution: kb-ui src root + repo root
  * ─────────────────────────────────────────────────────────────
  *
- * `require.resolve('@hiver/kb-ui')` returns the `main` entry —
+ * `require.resolve('@test-kb-ui/kb-ui')` returns the `main` entry —
  * `.../packages/kb-ui/dist/index.js` in workspace mode. We walk up to
  * the package directory (containing `package.json`), then into `src/`
  * for story-file scans. The repo root is two levels above the package
@@ -79,21 +79,21 @@ import {
 const require = createRequire(import.meta.url);
 
 function resolveKbUiPaths(): { kbUiPkgDir: string; kbUiSrcRoot: string; repoRoot: string } {
-  const kbUiMain = require.resolve('@hiver/kb-ui');
+  const kbUiMain = require.resolve('@test-kb-ui/kb-ui');
   let kbUiPkgDir = dirname(kbUiMain);
   // Walk up until we find a package.json. Bounded loop for safety.
   for (let i = 0; i < 5; i += 1) {
     if (existsSync(resolve(kbUiPkgDir, 'package.json'))) break;
     const parent = dirname(kbUiPkgDir);
     if (parent === kbUiPkgDir) {
-      throw new Error('Could not locate @hiver/kb-ui package root.');
+      throw new Error('Could not locate @test-kb-ui/kb-ui package root.');
     }
     kbUiPkgDir = parent;
   }
   const kbUiSrcRoot = resolve(kbUiPkgDir, 'src');
   if (!existsSync(kbUiSrcRoot)) {
     throw new Error(
-      `@hiver/kb-ui src/ not found at ${kbUiSrcRoot}. kb-mcp currently requires the workspace install (issue #8 scope).`,
+      `@test-kb-ui/kb-ui src/ not found at ${kbUiSrcRoot}. kb-mcp currently requires the workspace install (issue #8 scope).`,
     );
   }
   // Workspace layout: <repo>/packages/kb-ui — repo is two levels up.
@@ -197,7 +197,7 @@ const toolByName = new Map<string, ToolEntry>(tools.map((t) => [t.name, t]));
 
 const server = new Server(
   {
-    name: '@hiver/kb-mcp',
+    name: '@test-kb-ui/kb-mcp',
     version: '1.0.0',
   },
   {

--- a/packages/kb-mcp/src/index/component-index.ts
+++ b/packages/kb-mcp/src/index/component-index.ts
@@ -1,10 +1,10 @@
-// Walks `@hiver/kb-ui`'s `src/components/**/*.tsx` and builds an in-memory
+// Walks `@test-kb-ui/kb-ui`'s `src/components/**/*.tsx` and builds an in-memory
 // index of every canonical component (the file-named export). The result is
 // a `Map<string, ComponentSpec>` keyed by component name, ready for future
 // MCP tools (issues #9, #10) to query by name, category, or Figma node.
 //
 // Scope notes:
-// - Targets the WORKSPACE install of `@hiver/kb-ui` (the `node_modules`
+// - Targets the WORKSPACE install of `@test-kb-ui/kb-ui` (the `node_modules`
 //   symlink to `packages/kb-ui/`). Production tarballs only ship `dist/`,
 //   so this throws a clear error in that mode — handling that case is a
 //   separate, post-#6 polish step.
@@ -29,10 +29,10 @@ const require = createRequire(import.meta.url);
 
 function resolveKbUiSrc(): string {
   // Resolve through the package's main entry, then walk up to the package
-  // root. We can't `require.resolve('@hiver/kb-ui/package.json')` directly
+  // root. We can't `require.resolve('@test-kb-ui/kb-ui/package.json')` directly
   // because kb-ui's `exports` map doesn't expose `./package.json`.
-  const mainEntry = require.resolve('@hiver/kb-ui');
-  // mainEntry => `.../node_modules/@hiver/kb-ui/dist/index.js` (or .mjs).
+  const mainEntry = require.resolve('@test-kb-ui/kb-ui');
+  // mainEntry => `.../node_modules/@test-kb-ui/kb-ui/dist/index.js` (or .mjs).
   // The package root is the parent of `dist/`.
   let root = dirname(mainEntry);
   // Walk up until we find a directory containing `package.json`.
@@ -43,7 +43,7 @@ function resolveKbUiSrc(): string {
   const src = resolve(root, 'src');
   if (!existsSync(src)) {
     throw new Error(
-      `kb-ui source files not found at ${src} — kb-mcp currently requires the workspace install of @hiver/kb-ui (issue #8 scope). Production support tracked separately.`,
+      `kb-ui source files not found at ${src} — kb-mcp currently requires the workspace install of @test-kb-ui/kb-ui (issue #8 scope). Production support tracked separately.`,
     );
   }
   return src;
@@ -512,7 +512,7 @@ export function buildComponentIndex(): ComponentIndex {
       figmaNode,
       props,
       storyFiles,
-      importStatement: `import { ${file.componentName} } from '@hiver/kb-ui';`,
+      importStatement: `import { ${file.componentName} } from '@test-kb-ui/kb-ui';`,
     };
 
     index.set(file.componentName, spec);

--- a/packages/kb-mcp/src/index/token-index.ts
+++ b/packages/kb-mcp/src/index/token-index.ts
@@ -19,9 +19,9 @@ const require = createRequire(import.meta.url);
 
 function resolveKbUiSrc(): string {
   // Resolve through the package's main entry, then walk up to the package
-  // root. We can't `require.resolve('@hiver/kb-ui/package.json')` directly
+  // root. We can't `require.resolve('@test-kb-ui/kb-ui/package.json')` directly
   // because kb-ui's `exports` map doesn't expose `./package.json`.
-  const mainEntry = require.resolve('@hiver/kb-ui');
+  const mainEntry = require.resolve('@test-kb-ui/kb-ui');
   let root = dirname(mainEntry);
   for (let i = 0; i < 5; i += 1) {
     if (existsSync(resolve(root, 'package.json'))) break;
@@ -30,7 +30,7 @@ function resolveKbUiSrc(): string {
   const src = resolve(root, 'src');
   if (!existsSync(src)) {
     throw new Error(
-      `kb-ui source files not found at ${src} — kb-mcp currently requires the workspace install of @hiver/kb-ui (issue #8 scope). Production support tracked separately.`,
+      `kb-ui source files not found at ${src} — kb-mcp currently requires the workspace install of @test-kb-ui/kb-ui (issue #8 scope). Production support tracked separately.`,
     );
   }
   return src;

--- a/packages/kb-mcp/src/index/types.ts
+++ b/packages/kb-mcp/src/index/types.ts
@@ -51,7 +51,7 @@ export type ComponentSpec = {
   storyFiles: string[];
   /**
    * The recommended import statement,
-   * e.g. `import { KBBreadcrumbBar } from '@hiver/kb-ui';`.
+   * e.g. `import { KBBreadcrumbBar } from '@test-kb-ui/kb-ui';`.
    */
   importStatement: string;
 };

--- a/packages/kb-mcp/src/keywords.ts
+++ b/packages/kb-mcp/src/keywords.ts
@@ -9,7 +9,7 @@
 //   +2  if the component name itself appears in the PRD
 //
 // Coverage rule: every one of the 36 components currently exported by
-// @hiver/kb-ui must have an entry — see test fixtures and the smoke output
+// @test-kb-ui/kb-ui must have an entry — see test fixtures and the smoke output
 // for the live recommendation surface.
 
 export const componentKeywords: Record<string, string[]> = {

--- a/packages/kb-mcp/src/tools/get-component-spec.ts
+++ b/packages/kb-mcp/src/tools/get-component-spec.ts
@@ -26,7 +26,7 @@ export function getComponentSpec(
   if (!found) {
     const known = Array.from(index.keys()).sort().slice(0, 10).join(', ');
     throw new Error(
-      `Component "${input.name}" not found in @hiver/kb-ui. Known components include: ${known}${index.size > 10 ? ', …' : ''}.`,
+      `Component "${input.name}" not found in @test-kb-ui/kb-ui. Known components include: ${known}${index.size > 10 ? ', …' : ''}.`,
     );
   }
   return found;

--- a/packages/kb-mcp/src/tools/recommend-components-for-prd.ts
+++ b/packages/kb-mcp/src/tools/recommend-components-for-prd.ts
@@ -326,7 +326,7 @@ export async function recommendComponentsForPrd(
       category: spec?.category ?? 'unknown',
       why,
       importStatement:
-        spec?.importStatement ?? `import { ${s.name} } from '@hiver/kb-ui';`,
+        spec?.importStatement ?? `import { ${s.name} } from '@test-kb-ui/kb-ui';`,
     };
   });
 

--- a/packages/kb-ui/README.md
+++ b/packages/kb-ui/README.md
@@ -1,18 +1,18 @@
-# @hiver/kb-ui
+# @test-kb-ui/kb-ui
 
 Pixel-perfect React component library for Hiver's knowledge base product — primitives, shell, nav, content, editor, AI gap review surface, and analytics in one package.
 
 ## Install
 
 ```bash
-npm install @hiver/kb-ui
+npm install @test-kb-ui/kb-ui
 ```
 
 ## Quickstart
 
 ```tsx
-import { AppShell, KBBreadcrumbBar, SideNavRail, FileExplorerNav } from '@hiver/kb-ui';
-import '@hiver/kb-ui/styles';
+import { AppShell, KBBreadcrumbBar, SideNavRail, FileExplorerNav } from '@test-kb-ui/kb-ui';
+import '@test-kb-ui/kb-ui/styles';
 
 export function App() {
   return (

--- a/packages/kb-ui/package.json
+++ b/packages/kb-ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hiver/kb-ui",
+  "name": "@test-kb-ui/kb-ui",
   "version": "1.0.0",
   "description": "Hiver KB component library — pixel-perfect React components for app.hiverkb.com",
   "license": "MIT",

--- a/packages/kb-ui/scripts/emit-styles-dts.mjs
+++ b/packages/kb-ui/scripts/emit-styles-dts.mjs
@@ -1,5 +1,5 @@
 // Emits `dist/styles.d.ts` — a side-effect-only type stub for the
-// `@hiver/kb-ui/styles` subpath. Kept out of `tsup.config.ts` because
+// `@test-kb-ui/kb-ui/styles` subpath. Kept out of `tsup.config.ts` because
 // tsup's DTS rollup runs in a worker thread and would race with us.
 import { writeFile, mkdir } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
@@ -9,9 +9,9 @@ const here = dirname(fileURLToPath(import.meta.url));
 const distDir = resolve(here, '..', 'dist');
 const target = resolve(distDir, 'styles.d.ts');
 
-const STYLES_DTS = `// Type declaration stub for the side-effect-only \`@hiver/kb-ui/styles\` subpath.
+const STYLES_DTS = `// Type declaration stub for the side-effect-only \`@test-kb-ui/kb-ui/styles\` subpath.
 // The actual artifact is \`dist/tokens.css\` (CSS variables / @theme tokens) — this
-// file exists so strict-TS consumers can do \`import '@hiver/kb-ui/styles';\`
+// file exists so strict-TS consumers can do \`import '@test-kb-ui/kb-ui/styles';\`
 // without hitting TS2882. There are no runtime exports.
 export {};
 `;

--- a/packages/kb-ui/src/index.ts
+++ b/packages/kb-ui/src/index.ts
@@ -1,4 +1,4 @@
-// @hiver/kb-ui — public API
+// @test-kb-ui/kb-ui — public API
 // Components are exported here as they are built phase by phase.
 
 export { cn } from './utils/cn';

--- a/packages/kb-ui/src/stories/Welcome.stories.tsx
+++ b/packages/kb-ui/src/stories/Welcome.stories.tsx
@@ -53,7 +53,7 @@ function WelcomePage(): JSX.Element {
       </h1>
 
       <p style={{ fontSize: 18, lineHeight: 1.6, color: '#475569', marginTop: 8, marginBottom: 32 }}>
-        <strong style={{ color: '#0f172a' }}>@hiver/kb-ui</strong> is a pixel-perfect, 1:1 React
+        <strong style={{ color: '#0f172a' }}>@test-kb-ui/kb-ui</strong> is a pixel-perfect, 1:1 React
         component library for{' '}
         <a
           href="https://app.hiverkb.com"
@@ -203,7 +203,7 @@ function WelcomePage(): JSX.Element {
         }}
       >
         Built with React 18, TypeScript, Tailwind, and Radix primitives. Distributed as{' '}
-        <code style={{ fontSize: 11 }}>@hiver/kb-ui</code>.
+        <code style={{ fontSize: 11 }}>@test-kb-ui/kb-ui</code>.
       </p>
     </div>
   );

--- a/packages/kb-ui/src/tokens.ts
+++ b/packages/kb-ui/src/tokens.ts
@@ -1,4 +1,4 @@
-// @hiver/kb-ui — design tokens (programmatic access)
+// @test-kb-ui/kb-ui — design tokens (programmatic access)
 // Source of truth mirrored from src/tokens.css. Keep in sync.
 
 export const tokens = {


### PR DESCRIPTION
## Summary

- Renames the npm scope on both publishable packages so they can ship to the user's npm org: `@hiver/kb-ui` → `@test-kb-ui/kb-ui` and `@hiver/kb-mcp` → `@test-kb-ui/kb-mcp`.
- Internal demo workspace also renamed (`@hiver/kb-demo` → `@test-kb-ui/kb-demo`) for consistency; it stays private.
- 48 files touched across active code + active docs. Historical narrative (plan.md, logs.md, design specs, demo PRD/TRD) intentionally left as snapshots.

## Test plan

- [x] kb-ui typecheck + build
- [x] kb-mcp typecheck + build
- [x] kb-mcp recommend tests — 3/3 pass
- [x] demo build clean
- [x] Storybook smoke build (rule #5)
- [x] Demo sign-off harness — 56/56 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)