### PR TITLE
feat: install as a Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,30 @@
+{
+  "name": "test-kb-ui",
+  "owner": {
+    "name": "geekv30",
+    "url": "https://github.com/geekv30"
+  },
+  "plugins": [
+    {
+      "name": "kb-mcp",
+      "source": "./plugins/kb-mcp",
+      "description": "MCP server for the @test-kb-ui/kb-ui component library. Turns plain-English PRDs into starting React compositions, with reads for components, design tokens, and pattern stories.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Hiver"
+      },
+      "homepage": "https://github.com/geekv30/kb",
+      "repository": "https://github.com/geekv30/kb",
+      "license": "MIT",
+      "keywords": [
+        "mcp",
+        "design-system",
+        "components",
+        "kb-ui",
+        "react",
+        "tailwind"
+      ],
+      "category": "productivity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@
 npm install @test-kb-ui/kb-ui
 ```
 
+## Use it from Claude Code
+
+This repo ships as a Claude Code plugin — installing it wires the kb-mcp server straight into your CLI, so you can ask Claude for a kb-ui composition from a plain-English PRD.
+
+```bash
+/plugin marketplace add geekv30/kb
+/plugin install kb-mcp@test-kb-ui
+```
+
+Then, in any Claude Code session: *"Build me a settings page where admins manage AI gap rules — propose a kb-ui composition."*
+
 ## Quickstart
 
 ```tsx

--- a/plugins/kb-mcp/.claude-plugin/plugin.json
+++ b/plugins/kb-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "kb-mcp",
+  "version": "1.0.0",
+  "description": "MCP server for the @test-kb-ui/kb-ui component library. Turns plain-English PRDs into starting React compositions, with reads for components, design tokens, and pattern stories.",
+  "author": {
+    "name": "Hiver"
+  },
+  "homepage": "https://github.com/geekv30/kb",
+  "repository": "https://github.com/geekv30/kb",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "design-system",
+    "components",
+    "kb-ui",
+    "react",
+    "tailwind"
+  ]
+}

--- a/plugins/kb-mcp/.mcp.json
+++ b/plugins/kb-mcp/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "test-kb-ui": {
+      "command": "npx",
+      "args": ["-y", "@test-kb-ui/kb-mcp"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a Claude Code marketplace at \`.claude-plugin/marketplace.json\` and a single plugin entry under \`plugins/kb-mcp/\`.
- Plugin's \`.mcp.json\` points to \`npx -y @test-kb-ui/kb-mcp\` so the latest server is pulled from npm on install.
- README gets a \"Use it from Claude Code\" section with the two-step install.

## Install (after merge)

\`\`\`
/plugin marketplace add geekv30/kb
/plugin install kb-mcp@test-kb-ui
\`\`\`

## Test plan

- [x] All 3 JSON files parse clean
- [x] Storybook smoke build clean (rule #5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)