### PR TITLE
fix(kb-mcp): bundle indices at build time (closes #28)

### DIFF
--- a/packages/kb-mcp/CHANGELOG.md
+++ b/packages/kb-mcp/CHANGELOG.md
@@ -1,0 +1,17 @@
+# @test-kb-ui/kb-mcp changelog
+
+## 1.0.1 — 2026-04-29
+
+Fix: server crashed on startup when installed from npm (workspace-only previously).
+
+- Component, token, and Storybook-pattern indices are now pre-computed at package-build time and shipped as `dist/component-index.json`, `dist/token-index.json`, `dist/stories-index.json`.
+- Runtime loaders (`loadComponentIndex`, `loadTokenIndex`, `loadStoriesIndex`) read the bundled JSON; no `node_modules` walk for kb-ui sources at startup.
+- `npx -y @test-kb-ui/kb-mcp` now works in any fresh directory — Claude Code plugin install, Claude Desktop config, Cursor MCP setup all unblocked.
+
+## 1.0.0 — 2026-04-29
+
+Initial release.
+
+- 6 tools: `list_components`, `get_component_spec`, `list_tokens`, `get_token_value`, `get_story_code`, `recommend_components_for_prd`.
+- 1 resource: `kb://design/overview` (full text of `design.md`).
+- stdio transport; binary `kb-mcp`.

--- a/packages/kb-mcp/package.json
+++ b/packages/kb-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@test-kb-ui/kb-mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "MCP companion server for @test-kb-ui/kb-ui — read components, tokens, and pattern stories from the kb-ui library",
   "license": "MIT",
   "author": "Hiver",
@@ -36,7 +36,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && tsx scripts/build-indices.mjs",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
     "test": "tsx --test test/**/*.test.ts"

--- a/packages/kb-mcp/scripts/build-indices.mjs
+++ b/packages/kb-mcp/scripts/build-indices.mjs
@@ -1,0 +1,65 @@
+// Build-time pre-computation of the component / token / stories indices.
+//
+// Why: at runtime the MCP server can't walk `@test-kb-ui/kb-ui/src/` —
+// the published kb-ui tarball only ships `dist/`. So we run the indexers
+// here, while the workspace install IS available, and serialise the
+// results to JSON in `packages/kb-mcp/dist/`. The runtime loaders
+// (`loadComponentIndex` etc.) just JSON.parse those files. Issue #28.
+//
+// This script is invoked from `package.json`'s `build` script via tsx,
+// so it runs as TypeScript and can import the indexer modules directly.
+
+import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { buildComponentIndex, serializeComponentIndex } from '../src/index/component-index.ts';
+import { buildTokenIndex, serializeTokenIndex } from '../src/index/token-index.ts';
+import { buildStoriesIndex, serializeStoriesIndex } from '../src/index/stories-index.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// scripts/ → packages/kb-mcp → packages → repo
+const PKG_ROOT = resolve(HERE, '..');
+const KB_UI_SRC = resolve(PKG_ROOT, '..', 'kb-ui', 'src');
+const DIST = resolve(PKG_ROOT, 'dist');
+
+if (!existsSync(KB_UI_SRC)) {
+  // eslint-disable-next-line no-console
+  console.error(`[build-indices] kb-ui src not found at ${KB_UI_SRC}.`);
+  process.exit(1);
+}
+
+mkdirSync(DIST, { recursive: true });
+
+// eslint-disable-next-line no-console
+console.log('[build-indices] building component index from', KB_UI_SRC);
+const components = buildComponentIndex(KB_UI_SRC);
+writeFileSync(
+  resolve(DIST, 'component-index.json'),
+  JSON.stringify(serializeComponentIndex(components), null, 2),
+  'utf8',
+);
+// eslint-disable-next-line no-console
+console.log(`[build-indices] wrote ${components.size} components to dist/component-index.json`);
+
+// eslint-disable-next-line no-console
+console.log('[build-indices] building token index');
+const tokens = buildTokenIndex(KB_UI_SRC);
+writeFileSync(
+  resolve(DIST, 'token-index.json'),
+  JSON.stringify(serializeTokenIndex(tokens), null, 2),
+  'utf8',
+);
+// eslint-disable-next-line no-console
+console.log(`[build-indices] wrote ${tokens.size} tokens to dist/token-index.json`);
+
+// eslint-disable-next-line no-console
+console.log('[build-indices] building stories index');
+const stories = buildStoriesIndex(KB_UI_SRC);
+writeFileSync(
+  resolve(DIST, 'stories-index.json'),
+  JSON.stringify(serializeStoriesIndex(stories), null, 2),
+  'utf8',
+);
+// eslint-disable-next-line no-console
+console.log(`[build-indices] wrote ${stories.size} stories to dist/stories-index.json`);

--- a/packages/kb-mcp/src/index.ts
+++ b/packages/kb-mcp/src/index.ts
@@ -6,19 +6,15 @@
 //   - list_tokens           (filter by tokens.css section)
 //   - get_token_value       (CSS or dotted JS form)
 //   - get_story_code        (full source by Storybook title)
+//   - recommend_components_for_prd
 // plus one MCP resource:
 //   - kb://design/overview  (full text of design.md)
 //
-// Indices for components/tokens are built ONCE at startup from the
-// workspace install of @test-kb-ui/kb-ui (issue #8 module). The server
-// is read-only; no caching beyond the in-memory indices.
-//
-// Run locally for development:
-//   npm run --workspace=packages/kb-mcp build
-//   node packages/kb-mcp/dist/index.js
-//
-// Or wired into Claude Code / Desktop / Cursor via the JSON config
-// shipped in #11's README.
+// Indices for components, tokens, and stories are pre-built at
+// PACKAGE-BUILD time (see `scripts/build-indices.mjs`) and shipped as
+// JSON in `dist/`. At runtime we just JSON.parse them — no filesystem
+// scan of `@test-kb-ui/kb-ui/src/` is needed, which is what makes the
+// package work as a plain `npx` install (issue #28).
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -32,12 +28,13 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { existsSync } from 'node:fs';
-import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { ZodTypeAny } from 'zod';
 
-import { buildComponentIndex } from './index/component-index.js';
-import { buildTokenIndex } from './index/token-index.js';
+import { loadComponentIndex } from './index/component-index.js';
+import { loadTokenIndex } from './index/token-index.js';
+import { loadStoriesIndex } from './index/stories-index.js';
 import {
   listComponents,
   listComponentsInputSchema,
@@ -67,47 +64,42 @@ import {
 } from './resources/design-overview.js';
 
 /* ─────────────────────────────────────────────────────────────
- * Path resolution: kb-ui src root + repo root
+ * design.md location
  * ─────────────────────────────────────────────────────────────
  *
- * `require.resolve('@test-kb-ui/kb-ui')` returns the `main` entry —
- * `.../packages/kb-ui/dist/index.js` in workspace mode. We walk up to
- * the package directory (containing `package.json`), then into `src/`
- * for story-file scans. The repo root is two levels above the package
- * (packages/kb-ui → packages → repo).
+ * The bundled-index refactor (issue #28) removed every `node_modules`
+ * lookup at startup, but the `kb://design/overview` resource still wants
+ * to read `design.md`. In a workspace install we walk up from this file
+ * (`packages/kb-mcp/dist/index.js`) to the repo root. In a non-workspace
+ * install no `design.md` is shipped — the resource handler will surface
+ * a clear ENOENT to the client when (and only when) the resource is
+ * actually requested. This is intentionally lazy so it doesn't block
+ * server startup for npm-install consumers who never use the resource.
  */
-const require = createRequire(import.meta.url);
+const HERE = dirname(fileURLToPath(import.meta.url));
 
-function resolveKbUiPaths(): { kbUiPkgDir: string; kbUiSrcRoot: string; repoRoot: string } {
-  const kbUiMain = require.resolve('@test-kb-ui/kb-ui');
-  let kbUiPkgDir = dirname(kbUiMain);
-  // Walk up until we find a package.json. Bounded loop for safety.
-  for (let i = 0; i < 5; i += 1) {
-    if (existsSync(resolve(kbUiPkgDir, 'package.json'))) break;
-    const parent = dirname(kbUiPkgDir);
-    if (parent === kbUiPkgDir) {
-      throw new Error('Could not locate @test-kb-ui/kb-ui package root.');
-    }
-    kbUiPkgDir = parent;
+function resolveDesignOverviewRoot(): string {
+  // Workspace layout: <repo>/packages/kb-mcp/dist/index.js → repo is 3 up.
+  let dir = HERE;
+  for (let i = 0; i < 6; i += 1) {
+    if (existsSync(resolve(dir, 'design.md'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
   }
-  const kbUiSrcRoot = resolve(kbUiPkgDir, 'src');
-  if (!existsSync(kbUiSrcRoot)) {
-    throw new Error(
-      `@test-kb-ui/kb-ui src/ not found at ${kbUiSrcRoot}. kb-mcp currently requires the workspace install (issue #8 scope).`,
-    );
-  }
-  // Workspace layout: <repo>/packages/kb-ui — repo is two levels up.
-  const repoRoot = resolve(kbUiPkgDir, '..', '..');
-  return { kbUiPkgDir, kbUiSrcRoot, repoRoot };
+  // Fall back to whatever 3-up gives — readDesignOverview will throw a
+  // clear ENOENT at request time if the file isn't there.
+  return resolve(HERE, '..', '..', '..');
 }
 
-const { kbUiSrcRoot, repoRoot } = resolveKbUiPaths();
+const designOverviewRoot = resolveDesignOverviewRoot();
 
 /* ─────────────────────────────────────────────────────────────
- * Build indices once at startup.
+ * Load indices once at startup from bundled JSON.
  * ───────────────────────────────────────────────────────────── */
-const componentIndex = buildComponentIndex();
-const tokenIndex = buildTokenIndex();
+const componentIndex = loadComponentIndex();
+const tokenIndex = loadTokenIndex();
+const storiesIndex = loadStoriesIndex();
 
 /* ─────────────────────────────────────────────────────────────
  * Tool registry
@@ -174,7 +166,7 @@ const tools: ToolEntry[] = [
     inputSchema: getStoryCodeInputSchema,
     handler: async (args) => {
       const parsed = getStoryCodeInputSchema.parse(args ?? {});
-      return getStoryCode(kbUiSrcRoot, parsed);
+      return getStoryCode(storiesIndex, parsed);
     },
   },
   {
@@ -184,7 +176,7 @@ const tools: ToolEntry[] = [
     inputSchema: recommendComponentsForPrdInputSchema,
     handler: async (args) => {
       const parsed = recommendComponentsForPrdInputSchema.parse(args ?? {});
-      return recommendComponentsForPrd(componentIndex, parsed, { kbUiSrcRoot });
+      return recommendComponentsForPrd(componentIndex, parsed, { storiesIndex });
     },
   },
 ];
@@ -198,7 +190,7 @@ const toolByName = new Map<string, ToolEntry>(tools.map((t) => [t.name, t]));
 const server = new Server(
   {
     name: '@test-kb-ui/kb-mcp',
-    version: '1.0.0',
+    version: '1.0.1',
   },
   {
     capabilities: {
@@ -282,7 +274,7 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
       `Unknown resource URI "${uri}". Known: ${DESIGN_OVERVIEW_URI}.`,
     );
   }
-  const { mimeType, text } = await readDesignOverview(repoRoot);
+  const { mimeType, text } = await readDesignOverview(designOverviewRoot);
   return {
     contents: [
       {

--- a/packages/kb-mcp/src/index/component-index.ts
+++ b/packages/kb-mcp/src/index/component-index.ts
@@ -1,22 +1,28 @@
 // Walks `@test-kb-ui/kb-ui`'s `src/components/**/*.tsx` and builds an in-memory
 // index of every canonical component (the file-named export). The result is
-// a `Map<string, ComponentSpec>` keyed by component name, ready for future
-// MCP tools (issues #9, #10) to query by name, category, or Figma node.
+// a `Map<string, ComponentSpec>` keyed by component name.
 //
-// Scope notes:
-// - Targets the WORKSPACE install of `@test-kb-ui/kb-ui` (the `node_modules`
-//   symlink to `packages/kb-ui/`). Production tarballs only ship `dist/`,
-//   so this throws a clear error in that mode — handling that case is a
-//   separate, post-#6 polish step.
-// - One file = one canonical component. Helper exports in the same file
-//   are intentionally not indexed; only the export whose name matches the
-//   filename is returned.
-// - Prop extraction uses the TypeScript compiler API. If a single file
-//   fails to parse, that component ships with `props: []` and a stderr
-//   warning; the rest of the index still builds.
+// Two entry points:
+//   - `buildComponentIndex(kbUiSrcRoot?)`: pure indexer — walks the kb-ui
+//     source tree and parses with the TypeScript compiler API. Used at
+//     BUILD time (see `scripts/build-indices.mjs`) and from fixture tests
+//     where the workspace install of `@test-kb-ui/kb-ui` is available.
+//     If `kbUiSrcRoot` is omitted, falls back to resolving the workspace
+//     install via `require.resolve`.
+//   - `loadComponentIndex()`: runtime loader — reads the pre-built
+//     `component-index.json` that ships alongside `dist/index.js`. Used by
+//     the MCP server entrypoint so a plain `npm install` of kb-mcp works
+//     even when kb-ui ships only `dist/`. See issue #28.
+//
+// One file = one canonical component. Helper exports in the same file
+// are intentionally not indexed; only the export whose name matches the
+// filename is returned. Prop extraction uses the TypeScript compiler API.
+// If a single file fails to parse, that component ships with `props: []`
+// and a stderr warning; the rest of the index still builds.
 
 import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs';
 import { dirname, basename, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import ts from 'typescript';
 import type { ComponentIndex, ComponentPropSpec, ComponentSpec } from './types.js';
@@ -24,18 +30,19 @@ import type { ComponentIndex, ComponentPropSpec, ComponentSpec } from './types.j
 const require = createRequire(import.meta.url);
 
 /* ─────────────────────────────────────────────────────────────
- * kb-ui source resolution
+ * kb-ui source resolution (workspace fallback only)
  * ───────────────────────────────────────────────────────────── */
 
-function resolveKbUiSrc(): string {
-  // Resolve through the package's main entry, then walk up to the package
-  // root. We can't `require.resolve('@test-kb-ui/kb-ui/package.json')` directly
-  // because kb-ui's `exports` map doesn't expose `./package.json`.
+/**
+ * Resolve the `src/` root of the workspace install of `@test-kb-ui/kb-ui`.
+ * Used as a fallback when `buildComponentIndex` is called without an
+ * explicit path (e.g. fixture tests). At runtime in non-workspace
+ * installs the kb-ui package only ships `dist/` and this throws — that's
+ * the path `loadComponentIndex` exists to bypass.
+ */
+function resolveWorkspaceKbUiSrc(): string {
   const mainEntry = require.resolve('@test-kb-ui/kb-ui');
-  // mainEntry => `.../node_modules/@test-kb-ui/kb-ui/dist/index.js` (or .mjs).
-  // The package root is the parent of `dist/`.
   let root = dirname(mainEntry);
-  // Walk up until we find a directory containing `package.json`.
   for (let i = 0; i < 5; i += 1) {
     if (existsSync(resolve(root, 'package.json'))) break;
     root = dirname(root);
@@ -43,7 +50,7 @@ function resolveKbUiSrc(): string {
   const src = resolve(root, 'src');
   if (!existsSync(src)) {
     throw new Error(
-      `kb-ui source files not found at ${src} — kb-mcp currently requires the workspace install of @test-kb-ui/kb-ui (issue #8 scope). Production support tracked separately.`,
+      `kb-ui source files not found at ${src} — buildComponentIndex requires the workspace install of @test-kb-ui/kb-ui. At runtime, use loadComponentIndex() to read the pre-built JSON instead.`,
     );
   }
   return src;
@@ -465,9 +472,18 @@ function findStoryFiles(componentDir: string, componentName: string): string[] {
  * Public API
  * ───────────────────────────────────────────────────────────── */
 
-export function buildComponentIndex(): ComponentIndex {
-  const kbUiSrc = resolveKbUiSrc();
-  const componentsDir = resolve(kbUiSrc, 'components');
+/**
+ * Build the component index from kb-ui source. Pure: takes the path,
+ * returns a serialisable Map. Used at build time and from fixture tests.
+ *
+ * @param kbUiSrcRoot - Optional absolute path to kb-ui's `src/` dir.
+ *   If omitted, falls back to `require.resolve('@test-kb-ui/kb-ui')`-based
+ *   workspace lookup. Pass an explicit path in build scripts so the
+ *   resolution doesn't depend on `node_modules` topology.
+ */
+export function buildComponentIndex(kbUiSrcRoot?: string): ComponentIndex {
+  const srcRoot = kbUiSrcRoot ?? resolveWorkspaceKbUiSrc();
+  const componentsDir = resolve(srcRoot, 'components');
   const files = walkComponents(componentsDir);
 
   const index: ComponentIndex = new Map();
@@ -519,6 +535,56 @@ export function buildComponentIndex(): ComponentIndex {
   }
 
   return index;
+}
+
+/**
+ * Convert a `ComponentIndex` (Map) to a JSON-serialisable plain object
+ * keyed by component name. Used by the build script that ships the
+ * pre-computed index alongside `dist/index.js`.
+ */
+export function serializeComponentIndex(
+  index: ComponentIndex,
+): Record<string, ComponentSpec> {
+  return Object.fromEntries(index);
+}
+
+/**
+ * Runtime loader: read the pre-built `component-index.json` that the
+ * build script ships in `dist/`. This is what the MCP server uses in
+ * production — it works regardless of whether `@test-kb-ui/kb-ui` ships
+ * `src/` (which it doesn't on npm).
+ *
+ * The JSON is written to `dist/component-index.json`. Because tsup bundles
+ * each `entry` separately (with `splitting: false`), this loader's
+ * `import.meta.url` may resolve EITHER to `dist/index.js` (when called
+ * from the bin entrypoint) OR to `dist/index/component-index.js` (when
+ * the indexer module is imported directly, e.g. from a smoke test).
+ * We probe both candidate locations rather than committing to one.
+ *
+ * Throws if the JSON file isn't found in either location — that means the
+ * package was built incorrectly (the build script must run before publish).
+ */
+export function loadComponentIndex(): ComponentIndex {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    resolve(here, 'component-index.json'),
+    resolve(here, '..', 'component-index.json'),
+  ];
+  let jsonPath: string | null = null;
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      jsonPath = candidate;
+      break;
+    }
+  }
+  if (!jsonPath) {
+    throw new Error(
+      `kb-mcp pre-built component index not found. Looked in: ${candidates.join(', ')}. Run \`npm run --workspace=packages/kb-mcp build\` to generate it.`,
+    );
+  }
+  const raw = readFileSync(jsonPath, 'utf8');
+  const obj = JSON.parse(raw) as Record<string, ComponentSpec>;
+  return new Map(Object.entries(obj));
 }
 
 // Suppress unused-import warning for `basename`/`sep` if minified — kept here

--- a/packages/kb-mcp/src/index/stories-index.ts
+++ b/packages/kb-mcp/src/index/stories-index.ts
@@ -1,0 +1,195 @@
+// Pre-loaded index of every kb-ui Storybook source file, keyed by
+// `meta.title`. At BUILD time we walk `kbUiSrcRoot/**/*.stories.tsx` and
+// serialise the result to `dist/stories-index.json`; at RUNTIME the MCP
+// server loads the JSON. This is what lets `get_story_code` and the
+// pattern picker in `recommend_components_for_prd` work in non-workspace
+// (npm) installs, where kb-ui ships only `dist/`. See issue #28.
+//
+// Two entry points:
+//   - `buildStoriesIndex(kbUiSrcRoot)`: pure indexer — recursive readdir
+//     for every `*.stories.tsx`, parse the first `title:` literal, keep
+//     full source. Used at build time.
+//   - `loadStoriesIndex()`: runtime loader — reads pre-built JSON from
+//     `dist/`.
+//
+// Pattern (page-level) stories vs component stories are distinguished by
+// whether their relative path lives under `pages/`. Pattern stories are
+// the ones the PRD recommender ranks against; component stories are
+// surfaced by `get_story_code` for any title match.
+
+import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs';
+import { dirname, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type StoryEntry = {
+  /** `meta.title` literal, e.g. `"Patterns/Knowledge Base/Category Page"`. */
+  title: string;
+  /**
+   * Path to the source file. Absolute when built from a workspace install
+   * (and used by tests / dev), or kb-ui-src-relative (e.g.
+   * `pages/KBCategoryPage.stories.tsx`) when loaded from the bundled JSON.
+   * Either form is fine for callers that just want the source — the
+   * `source` field is always self-contained.
+   */
+  filePath: string;
+  /** kb-ui-src-relative path, used to distinguish pages/ from components/. */
+  relativePath: string;
+  /** Full source of the `.stories.tsx` file. */
+  source: string;
+};
+
+export type StoriesIndex = Map<string, StoryEntry>;
+
+/* ─────────────────────────────────────────────────────────────
+ * Build-time
+ * ───────────────────────────────────────────────────────────── */
+
+function walkStoryFiles(dir: string): string[] {
+  const out: string[] = [];
+  const entries = readdirSync(dir);
+  for (const entry of entries) {
+    const full = resolve(dir, entry);
+    let stat;
+    try {
+      stat = statSync(full);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      out.push(...walkStoryFiles(full));
+    } else if (stat.isFile() && entry.endsWith('.stories.tsx')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract `meta.title` from a CSF v3 stories file. Strategy:
+ *
+ *   1. Find a top-level `const meta` declaration (with or without a
+ *      `Meta<>` type annotation).
+ *   2. Take the substring from there to the first `;` at column 0 — that
+ *      is the meta object literal.
+ *   3. Extract the first `title: '...'` inside that range.
+ *
+ * Falls back to the first `title:` literal in the file (legacy behaviour)
+ * only if the structured search fails. This avoids false positives from
+ * fixture-data arrays that have their own `title:` keys, which is
+ * common in kb-ui's pattern stories (e.g. nav item lists).
+ */
+function extractStoryTitle(source: string): string | null {
+  // Match `const meta = ...` or `const meta: Meta<...> = ...`. Anchor on
+  // word boundary so we don't pick up `metadata` or similar.
+  const metaIdx = source.search(/\bconst\s+meta\b\s*[:=]/);
+  if (metaIdx >= 0) {
+    // Slice from the meta declaration to a closing `};` at line start
+    // (CSF convention) — bounded so we don't accidentally swallow the
+    // whole file if the meta block isn't terminated as expected.
+    const tail = source.slice(metaIdx);
+    const end = tail.search(/^\};/m);
+    const metaBlock = end > 0 ? tail.slice(0, end) : tail.slice(0, 4000);
+    const match = metaBlock.match(/title\s*:\s*['"`]([^'"`]+)['"`]/);
+    if (match) return match[1];
+  }
+  // Fallback: file-wide first `title:` literal.
+  const fallback = source.match(/title\s*:\s*['"`]([^'"`]+)['"`]/);
+  return fallback ? fallback[1] : null;
+}
+
+/**
+ * Walk every `.stories.tsx` under `kbUiSrcRoot`, extract `meta.title`,
+ * and return a Map keyed by title. Files without a `title:` literal are
+ * skipped (Storybook config files like `Welcome.stories.tsx` may or may
+ * not declare one). Title collisions log a warning and keep the first.
+ */
+export function buildStoriesIndex(kbUiSrcRoot: string): StoriesIndex {
+  if (!existsSync(kbUiSrcRoot)) {
+    throw new Error(
+      `kb-ui src root not found at ${kbUiSrcRoot} — buildStoriesIndex requires a workspace install.`,
+    );
+  }
+  const files = walkStoryFiles(kbUiSrcRoot);
+  const index: StoriesIndex = new Map();
+  for (const filePath of files) {
+    const source = readFileSync(filePath, 'utf8');
+    const title = extractStoryTitle(source);
+    if (!title) continue;
+    if (index.has(title)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[kb-mcp] duplicate story title "${title}" — keeping ${index.get(title)?.filePath}, skipping ${filePath}`,
+      );
+      continue;
+    }
+    const rel = relative(kbUiSrcRoot, filePath).split(sep).join('/');
+    index.set(title, {
+      title,
+      filePath,
+      relativePath: rel,
+      source,
+    });
+  }
+  return index;
+}
+
+/**
+ * JSON-serialisable form: plain object keyed by title. The build script
+ * passes this to `JSON.stringify` directly.
+ */
+export function serializeStoriesIndex(
+  index: StoriesIndex,
+): Record<string, StoryEntry> {
+  return Object.fromEntries(index);
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Runtime
+ * ───────────────────────────────────────────────────────────── */
+
+/**
+ * Runtime loader: read pre-built `stories-index.json` from `dist/`.
+ * Same dual-location probe pattern as the component / token loaders —
+ * `import.meta.url` resolves differently depending on which entry the
+ * code was bundled into.
+ */
+export function loadStoriesIndex(): StoriesIndex {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    resolve(here, 'stories-index.json'),
+    resolve(here, '..', 'stories-index.json'),
+  ];
+  let jsonPath: string | null = null;
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      jsonPath = candidate;
+      break;
+    }
+  }
+  if (!jsonPath) {
+    throw new Error(
+      `kb-mcp pre-built stories index not found. Looked in: ${candidates.join(', ')}. Run \`npm run --workspace=packages/kb-mcp build\` to generate it.`,
+    );
+  }
+  const raw = readFileSync(jsonPath, 'utf8');
+  const obj = JSON.parse(raw) as Record<string, StoryEntry>;
+  return new Map(Object.entries(obj));
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Helpers
+ * ───────────────────────────────────────────────────────────── */
+
+/**
+ * Filter to just pattern (page-level) stories — those whose source
+ * lives under `pages/`. Used by the PRD recommender's pattern picker.
+ */
+export function listPatternStoryTitles(index: StoriesIndex): string[] {
+  const titles: string[] = [];
+  for (const entry of index.values()) {
+    if (entry.relativePath.startsWith('pages/')) {
+      titles.push(entry.title);
+    }
+  }
+  return titles;
+}

--- a/packages/kb-mcp/src/index/token-index.ts
+++ b/packages/kb-mcp/src/index/token-index.ts
@@ -2,11 +2,17 @@
 // merges them by value-equality, and returns a `Map<string, TokenSpec>`
 // keyed by canonical token name (CSS form preferred when both exist).
 //
-// Used by future MCP tools (issues #9, #10) to resolve token names,
-// list available tokens by category, and surface inline documentation.
+// Two entry points (mirroring component-index.ts):
+//   - `buildTokenIndex(kbUiSrcRoot?)`: pure indexer — reads `tokens.css`
+//     and `tokens.ts` from disk. Used at BUILD time and in fixture tests
+//     where the workspace install of `@test-kb-ui/kb-ui` is available.
+//   - `loadTokenIndex()`: runtime loader — reads pre-built JSON from
+//     `dist/`. Used by the MCP server entrypoint so plain npm installs
+//     work even when kb-ui ships only `dist/`. See issue #28.
 
 import { readFileSync, existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import ts from 'typescript';
 import type { TokenIndex, TokenSpec } from './types.js';
@@ -14,13 +20,10 @@ import type { TokenIndex, TokenSpec } from './types.js';
 const require = createRequire(import.meta.url);
 
 /* ─────────────────────────────────────────────────────────────
- * kb-ui source resolution
+ * kb-ui source resolution (workspace fallback only)
  * ───────────────────────────────────────────────────────────── */
 
-function resolveKbUiSrc(): string {
-  // Resolve through the package's main entry, then walk up to the package
-  // root. We can't `require.resolve('@test-kb-ui/kb-ui/package.json')` directly
-  // because kb-ui's `exports` map doesn't expose `./package.json`.
+function resolveWorkspaceKbUiSrc(): string {
   const mainEntry = require.resolve('@test-kb-ui/kb-ui');
   let root = dirname(mainEntry);
   for (let i = 0; i < 5; i += 1) {
@@ -30,7 +33,7 @@ function resolveKbUiSrc(): string {
   const src = resolve(root, 'src');
   if (!existsSync(src)) {
     throw new Error(
-      `kb-ui source files not found at ${src} — kb-mcp currently requires the workspace install of @test-kb-ui/kb-ui (issue #8 scope). Production support tracked separately.`,
+      `kb-ui source files not found at ${src} — buildTokenIndex requires the workspace install of @test-kb-ui/kb-ui. At runtime, use loadTokenIndex() to read the pre-built JSON instead.`,
     );
   }
   return src;
@@ -318,10 +321,18 @@ function mergeTokens(cssTokens: TokenSpec[], jsTokens: TokenSpec[]): TokenIndex 
  * Public API
  * ───────────────────────────────────────────────────────────── */
 
-export function buildTokenIndex(): TokenIndex {
-  const kbUiSrc = resolveKbUiSrc();
-  const cssPath = resolve(kbUiSrc, 'tokens.css');
-  const tsPath = resolve(kbUiSrc, 'tokens.ts');
+/**
+ * Build the token index from kb-ui source. Pure: takes the path,
+ * returns a serialisable Map.
+ *
+ * @param kbUiSrcRoot - Optional absolute path to kb-ui's `src/` dir.
+ *   If omitted, falls back to the `require.resolve`-based workspace
+ *   lookup. Pass an explicit path in build scripts.
+ */
+export function buildTokenIndex(kbUiSrcRoot?: string): TokenIndex {
+  const srcRoot = kbUiSrcRoot ?? resolveWorkspaceKbUiSrc();
+  const cssPath = resolve(srcRoot, 'tokens.css');
+  const tsPath = resolve(srcRoot, 'tokens.ts');
 
   if (!existsSync(cssPath)) {
     throw new Error(`kb-ui tokens.css not found at ${cssPath}`);
@@ -333,4 +344,42 @@ export function buildTokenIndex(): TokenIndex {
   const cssTokens = parseTokensCss(cssPath);
   const jsTokens = parseTokensTs(tsPath);
   return mergeTokens(cssTokens, jsTokens);
+}
+
+/**
+ * Convert a `TokenIndex` (Map) to a JSON-serialisable plain object
+ * keyed by token name. Used by the build script.
+ */
+export function serializeTokenIndex(
+  index: TokenIndex,
+): Record<string, TokenSpec> {
+  return Object.fromEntries(index);
+}
+
+/**
+ * Runtime loader: read the pre-built `token-index.json` shipped in `dist/`.
+ * See the matching note in `loadComponentIndex` re: why we probe two
+ * candidate locations.
+ */
+export function loadTokenIndex(): TokenIndex {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    resolve(here, 'token-index.json'),
+    resolve(here, '..', 'token-index.json'),
+  ];
+  let jsonPath: string | null = null;
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      jsonPath = candidate;
+      break;
+    }
+  }
+  if (!jsonPath) {
+    throw new Error(
+      `kb-mcp pre-built token index not found. Looked in: ${candidates.join(', ')}. Run \`npm run --workspace=packages/kb-mcp build\` to generate it.`,
+    );
+  }
+  const raw = readFileSync(jsonPath, 'utf8');
+  const obj = JSON.parse(raw) as Record<string, TokenSpec>;
+  return new Map(Object.entries(obj));
 }

--- a/packages/kb-mcp/src/tools/get-story-code.ts
+++ b/packages/kb-mcp/src/tools/get-story-code.ts
@@ -5,13 +5,12 @@
 // "Patterns/AI Optimisation/AI Optimise Hub" or
 // "Components/Layout/AppShell").
 //
-// Implementation: scan packages/kb-ui/src/**/*.stories.tsx for a matching
-// `title:` literal. The repo has ~40 story files; a linear scan at request
-// time is fine for v1.
+// Backed by the pre-built `StoriesIndex` so the tool works in both
+// workspace and npm-install modes (issue #28).
 
 import { z } from 'zod';
-import { readFile, readdir } from 'node:fs/promises';
-import { join } from 'node:path';
+
+import type { StoriesIndex } from '../index/stories-index.js';
 
 export const getStoryCodeInputSchema = z.object({
   storyTitle: z
@@ -30,47 +29,22 @@ export type GetStoryCodeOutput = {
   source: string;
 };
 
-async function walkStoryFiles(dir: string): Promise<string[]> {
-  const entries = await readdir(dir, { withFileTypes: true });
-  const out: string[] = [];
-  for (const e of entries) {
-    const full = join(dir, e.name);
-    if (e.isDirectory()) {
-      out.push(...(await walkStoryFiles(full)));
-    } else if (e.isFile() && e.name.endsWith('.stories.tsx')) {
-      out.push(full);
-    }
-  }
-  return out;
-}
-
 export async function getStoryCode(
-  kbUiSrcRoot: string,
+  storiesIndex: StoriesIndex,
   input: GetStoryCodeInput,
 ): Promise<GetStoryCodeOutput> {
-  const storyFiles = await walkStoryFiles(kbUiSrcRoot);
-
-  // Build a regex that matches `title: '<input>'`, `title: "<input>"`, or
-  // `title: \`<input>\`` with optional surrounding whitespace. Escape user
-  // input so regex metachars in the title (e.g. `/`, `.`) match literally.
-  const escaped = input.storyTitle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const titleRegex = new RegExp(`title\\s*:\\s*['"\`]${escaped}['"\`]`);
-
-  for (const filePath of storyFiles) {
-    const source = await readFile(filePath, 'utf8');
-    if (titleRegex.test(source)) {
-      return { storyTitle: input.storyTitle, filePath, source };
-    }
+  const entry = storiesIndex.get(input.storyTitle);
+  if (entry) {
+    return {
+      storyTitle: entry.title,
+      filePath: entry.filePath,
+      source: entry.source,
+    };
   }
 
   // Helpful error: list a few known titles so the caller can correct itself.
-  const candidates: string[] = [];
-  for (const filePath of storyFiles) {
-    const source = await readFile(filePath, 'utf8');
-    const match = source.match(/title\s*:\s*['"`]([^'"`]+)['"`]/);
-    if (match) candidates.push(match[1]);
-  }
+  const candidates = Array.from(storiesIndex.keys());
   throw new Error(
-    `Story title "${input.storyTitle}" not found among ${storyFiles.length} story files. Known titles include: ${candidates.slice(0, 8).join(' | ')}${candidates.length > 8 ? ' | …' : ''}.`,
+    `Story title "${input.storyTitle}" not found among ${candidates.length} story files. Known titles include: ${candidates.slice(0, 8).join(' | ')}${candidates.length > 8 ? ' | …' : ''}.`,
   );
 }

--- a/packages/kb-mcp/src/tools/recommend-components-for-prd.ts
+++ b/packages/kb-mcp/src/tools/recommend-components-for-prd.ts
@@ -13,10 +13,12 @@
 // reasoning on top of what this tool returns.
 
 import { z } from 'zod';
-import { readdir, readFile } from 'node:fs/promises';
-import { join } from 'node:path';
 
 import type { ComponentIndex } from '../index/types.js';
+import {
+  type StoriesIndex,
+  listPatternStoryTitles as listPatternTitlesFromIndex,
+} from '../index/stories-index.js';
 import { componentKeywords } from '../keywords.js';
 import { compositionTemplates } from '../composition-templates.js';
 import { getStoryCode } from './get-story-code.js';
@@ -177,26 +179,9 @@ function scoreComponent(
  * Pattern picker
  * ───────────────────────────────────────────────────────────── */
 
-async function listPatternStoryTitles(
-  kbUiSrcRoot: string,
-): Promise<string[]> {
-  const pagesDir = join(kbUiSrcRoot, 'pages');
-  let entries: string[] = [];
-  try {
-    entries = await readdir(pagesDir);
-  } catch {
-    return [];
-  }
-  const titles: string[] = [];
-  for (const entry of entries) {
-    if (!entry.endsWith('.stories.tsx')) continue;
-    const source = await readFile(join(pagesDir, entry), 'utf8');
-    // First `title:` literal in the file is the meta title.
-    const match = source.match(/title\s*:\s*['"`]([^'"`]+)['"`]/);
-    if (match) titles.push(match[1]);
-  }
-  return titles;
-}
+// Pattern story titles are pulled from the pre-built StoriesIndex via the
+// helper exported from `index/stories-index.ts`. The legacy filesystem
+// version was removed when we moved to bundled JSON (issue #28).
 
 /** Score a pattern story title using the same tokenization rules. */
 function scoreStoryTitle(
@@ -249,14 +234,14 @@ function pickCompositionSnippet(topComponentNames: string[]): string {
  * Score every component, fetch the best matching pattern story (if any),
  * and assemble a composition snippet.
  *
- * `kbUiSrcRoot` is optional for unit tests — when omitted the function
+ * `storiesIndex` is optional for unit tests — when omitted the function
  * skips the pattern lookup and returns `suggestedPattern: null`. The MCP
- * server entrypoint always passes the resolved kb-ui src root.
+ * server entrypoint always passes the loaded StoriesIndex.
  */
 export async function recommendComponentsForPrd(
   index: ComponentIndex,
   input: RecommendComponentsForPrdInput,
-  options: { kbUiSrcRoot?: string } = {},
+  options: { storiesIndex?: StoriesIndex } = {},
 ): Promise<RecommendComponentsForPrdOutput> {
   const prd = input.prd;
   const prdLower = prd.toLowerCase();
@@ -332,8 +317,8 @@ export async function recommendComponentsForPrd(
 
   /* ── 2. Pattern picker ───────────────────────────────────── */
   let suggestedPattern: SuggestedPattern | null = null;
-  if (options.kbUiSrcRoot) {
-    const titles = await listPatternStoryTitles(options.kbUiSrcRoot);
+  if (options.storiesIndex) {
+    const titles = listPatternTitlesFromIndex(options.storiesIndex);
     let best: { title: string; score: number } | null = null;
     for (const title of titles) {
       const titleScore = scoreStoryTitle(title, prdLower, tokenSet, bigramSet);
@@ -341,7 +326,7 @@ export async function recommendComponentsForPrd(
       if (!best || titleScore > best.score) best = { title, score: titleScore };
     }
     if (best) {
-      const code = await getStoryCode(options.kbUiSrcRoot, {
+      const code = await getStoryCode(options.storiesIndex, {
         storyTitle: best.title,
       });
       suggestedPattern = {


### PR DESCRIPTION
## Summary

- Pre-computes component / token / stories indices at kb-mcp build time, ships as JSON in dist/.
- Runtime loaders read bundled JSON; no node_modules walk for kb-ui sources at startup.
- Bumps kb-mcp to 1.0.1.

## Why

\`npx -y @test-kb-ui/kb-mcp\` crashed on startup because the indexer required \`@test-kb-ui/kb-ui/src/\`, which never ships from npm. Discovered while testing the Claude Code plugin install.

## Test plan

- [x] kb-mcp typecheck + build clean
- [x] 3/3 fixture tests pass
- [x] npm pack -> install in fresh /tmp dir -> server responds to JSON-RPC initialize + tools/list with all 6 tools
- [x] Storybook build clean (rule #5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)