### PR TITLE
feat(kb-mcp): product context surface (Phase 11)

### DIFF
--- a/packages/kb-mcp/CHANGELOG.md
+++ b/packages/kb-mcp/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @test-kb-ui/kb-mcp changelog
 
+## 1.1.0 — 2026-04-29
+
+Added: product-context surface so Claude can scope a PRD before reaching for components.
+
+- New tool `find_relevant_journey` — given a PRD, returns the matching user journey (Browse & Edit, AI Optimise Review, or Analytics Drill) with entry point, landing page, key components, and confidence.
+- New resources: `kb://product/journeys`, `kb://product/information-architecture`, `kb://product/feature-map`. Concise markdown summaries of the product's user journeys, IA, and current capability map.
+- Tool descriptions updated to nudge clients toward scope-first conversation: call `find_relevant_journey` before `recommend_components_for_prd`, read product resources for grounding.
+- README example replaced with a conversational scope → confirm → compose flow.
+
 ## 1.0.1 — 2026-04-29
 
 Fix: server crashed on startup when installed from npm (workspace-only previously).

--- a/packages/kb-mcp/README.md
+++ b/packages/kb-mcp/README.md
@@ -71,42 +71,51 @@ If you prefer editing the config file directly, the same JSON shape used by Clau
 
 | Tool | What it does |
 | --- | --- |
+| `find_relevant_journey` | Scope a PRD to one of the 3 user journeys (Browse & Edit, AI Optimise Review, Analytics Drill). Returns entry point, landing page, key components, and confidence. **Call this first** — it grounds component recommendations in product context. |
 | `list_components` | List every public kb-ui component (name + category + one-line description), optionally filtered by category. |
 | `get_component_spec` | Full TypeScript prop spec, story files, Figma node, and import statement for one component. |
 | `list_tokens` | List every design token in `tokens.css` (color, spacing, radius, typography, etc.), optionally filtered by section. |
 | `get_token_value` | Resolve one token by CSS name (`--color-canvas`) or dotted JS path (`color.canvas`). |
 | `get_story_code` | Return the full source of any pattern story by Storybook title (e.g. `Patterns/Knowledge Base/Category Page`). |
-| `recommend_components_for_prd` | Headline tool. Turn a PRD into a starting composition: top 3-7 components with reasons, the closest pattern story, and a working composition snippet. |
+| `recommend_components_for_prd` | Turn a PRD into a starting composition: top 3-7 components with reasons, the closest pattern story, and a working composition snippet. Best used after `find_relevant_journey` + reading the relevant `kb://product/*` resources. |
 
-The server also exposes a single MCP **resource**:
+The server also exposes MCP **resources**:
 
-- `kb://design/overview` — full text of `design.md` (tokens, typography, spacing, per-component Figma references).
+| Resource | Contents |
+| --- | --- |
+| `kb://design/overview` | Full text of `design.md` — tokens, typography, spacing, per-component Figma references. |
+| `kb://product/journeys` | The 3 primary user journeys with personas, entry points, and where new features attach. |
+| `kb://product/information-architecture` | Sitemap, top-level rail sections, sub-nav per section, shell modes, per-route component composition. |
+| `kb://product/feature-map` | What the product does today by capability area, plus a list of common asks NOT yet built. |
 
-## Example interaction
+## Example interaction (scope first, then components)
 
 You, in Claude Code:
 
-> Build me an article editor for our knowledge base. The user should be able to edit an article body and see AI suggestions reviewed inline next to it.
+> I want to add a date range filter to analytics — last 7, 30, 90 days, custom.
 
-Claude calls `recommend_components_for_prd` with that prompt. The tool returns a JSON envelope something like:
+Claude calls `find_relevant_journey` first. It returns:
 
 ```jsonc
 {
-  "recommendedComponents": [
-    { "name": "AppShell",            "why": "outer chrome (top bar + side nav)" },
-    { "name": "KBBreadcrumbBar",     "why": "in-app breadcrumb above the editor" },
-    { "name": "ContentEditor",       "why": "rich-text editor surface" },
-    { "name": "ArticleBody",         "why": "rendered article preview" },
-    { "name": "AIGapSuggestionCard", "why": "inline AI suggestion card" },
-    { "name": "AISuggestionsCard",   "why": "list of AI-generated edits" },
-    { "name": "SourcesSideSheet",    "why": "right-rail sources reviewer" }
-  ],
-  "suggestedPattern": { "storyTitle": "Patterns/Knowledge Base/Article Editor", "storySource": "..." },
-  "compositionSnippet": "<AppShell> ... </AppShell>"
+  "bestMatch": {
+    "name": "Analytics Drill",
+    "entryPoint": "Rail \"Analytics\" icon -> /analytics/...",
+    "landingPage": "One of 3 tabs: /analytics/article-performance, /analytics/search, /analytics/ai-answer-performance",
+    "keyComponents": ["DateRangePill", "PageHeader", "StatCardGrid", "..."],
+    "confidence": "high"
+  },
+  "guidance": "Strong match for \"Analytics Drill\". Read `kb://product/journeys` for the full journey detail, then confirm scope with the user before recommending components."
 }
 ```
 
-Claude then reads the snippet and the pattern story, and writes a real React file in your repo using those exports — no bespoke components, no hand-rolled chrome.
+Claude reads `kb://product/journeys` + `kb://product/feature-map` and sees that `DateRangePill` already exists but is currently a no-op. It comes back to you:
+
+> This lands on all 3 analytics tabs. The `DateRangePill` component is already in the design system — it's currently a no-op. We'd wire it to filter state. Should the filter persist across tabs, or reset per tab?
+
+You answer. Once scope is confirmed, Claude calls `recommend_components_for_prd` for the actual composition snippet, reads the matching pattern story, and writes a real React file using kb-ui exports — no bespoke chrome.
+
+The MCP doesn't enforce this flow. Claude reasons over the tools and resources naturally. The `find_relevant_journey` tool + `kb://product/*` resources just give Claude enough context to scope before reaching for code.
 
 ## Troubleshooting
 

--- a/packages/kb-mcp/package.json
+++ b/packages/kb-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@test-kb-ui/kb-mcp",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "MCP companion server for @test-kb-ui/kb-ui — read components, tokens, and pattern stories from the kb-ui library",
   "license": "MIT",
   "author": "Hiver",

--- a/packages/kb-mcp/product/feature-map.md
+++ b/packages/kb-mcp/product/feature-map.md
@@ -1,0 +1,108 @@
+# Hiver KB — Feature Map
+
+What the product does today, by capability area. Use this to decide whether a PRD describes:
+- a **net-new** capability (no current home — needs new section/page),
+- an **extension** of an existing capability (slot into an existing component or page),
+- or a **modification** of existing behaviour (change a component's props/states).
+
+## Capability areas
+
+| Area | Routes | Owner persona | Lives in |
+|---|---|---|---|
+| KB browsing | `/kb/...` | Admin / Content Author | Category page, FileExplorerNav |
+| Article authoring | `/kb/.../<slug>/edit` | Content Author | Editor page (`ContentEditor` + `ArticleSettingsPanel`) |
+| AI suggestion review | `/ai-optimise`, `/ai-optimise/<slug>/review` | Admin (reviewer) | Hub + Review pages |
+| Performance analytics | `/analytics/...` | Admin | 3 analytics tabs |
+| Settings | `/settings` | Admin | Placeholder (not yet built) |
+
+## What's built today (capabilities by area)
+
+### KB browsing
+
+| Capability | Where |
+|---|---|
+| Hierarchical category tree (depth 0–3) | `FileExplorerNav` |
+| Category page with sub-categories + article list | `/kb/<slug>`, `PageHeader` + `SubCategoriesTable` + `ArticlesTable` |
+| Article status badges (published / draft) | `Badge` inside `ArticlesTable` |
+| Author avatar per article | `Avatar` inside `ArticlesTable` |
+| Last-updated timestamps | `ArticlesTable` column |
+| Breadcrumb navigation up the tree | `KBBreadcrumbBar` (category variant) |
+| Tree expansion state persistence (session-only) | `MockStore.expandedCategoryIds` (demo); real product would use API |
+
+### Article authoring
+
+| Capability | Where |
+|---|---|
+| Rich text editor (Tiptap) | `ContentEditor` |
+| 14-button BubbleMenu on selection | `ContentEditor` (built-in) |
+| Notion-style slash menu (`/` at line start) | `ContentEditor` (built-in) |
+| H1–H3, lists, links, code blocks, tables, blockquote, HR, AI highlight strips | `ContentEditor` extensions |
+| Settings: author, category, slug, tags, publish date, SEO title, visibility, reviewers | `ArticleSettingsPanel` (8 fields) |
+| Save as draft + Publish actions | `KBBreadcrumbBar` (editor variant) |
+| Cmd+S (save), Cmd+Enter (publish) shortcuts | `useGlobalShortcuts` |
+| Unsaved-changes guard on navigation away | React Router `useBlocker` + `ConfirmDialog` |
+| Create new article ("+ New" CTA) | `PageHeader` button → store mutation + navigate |
+| Discard new draft on close-without-save | Confirm dialog → store removal |
+
+### AI suggestion review
+
+| Capability | Where |
+|---|---|
+| Suggestion hub: card per article with pending suggestions | `/ai-optimise`, `SuggestionCard` × N |
+| Inline suggestion review on article body | `ArticleBody` + `SuggestionBlock` (3 types: addition/replace/removal) |
+| Per-suggestion accept / dismiss / undo | `AIGapSuggestionCard` controls |
+| Reducer state machine across all suggestions on an article | `useAIGapsReducer` |
+| Active suggestion auto-scroll into view | `scrollIntoView` on activeId |
+| Pre-review → reviewing → terminal mode transitions | Reducer mode field |
+| Conversation sources side sheet (4 sources per article) | `SourcesSideSheet` |
+| Keyboard shortcuts: j/k navigate, y/n decide, Esc close sheet | `useGlobalShortcuts` |
+| Publish-disabled until at least one accepted | `KBBreadcrumbBar.publishDisabled` |
+| Per-article reducer state (resume mid-flow across articles) | `MockStore.aiGapsStateByArticle` |
+
+### Performance analytics
+
+| Capability | Where |
+|---|---|
+| Article views + engagement metrics | Tab 1: `StatCardGrid` + `AnalyticsAreaChart` + tables |
+| Articles-needing-attention list (low-helpfulness) | `ArticlesNeedsAttentionTable` |
+| Per-article performance table (views, helpfulness, last updated) | `ArticlePerformanceTable` |
+| Search analytics (volume, missed search) | Tab 2 charts |
+| Top search keywords | `SearchKeywordsTable` |
+| Content gaps (queries without answers) | `ContentGapsTable` |
+| AI answer performance (deflection rate, citation accuracy) | Tab 3 metrics |
+| AI conversation logs | `AIConversationLogsCard` (with `AIConversationLogEntry` rows) |
+| Most-cited articles by AI | `MostCitedArticlesTable` |
+| Drill-down: any article row → that article's editor | All 3 tables |
+| Helpfulness tags (positive / wash / negative trend chips) | `HelpfulnessTag` |
+| Donut chart for helpfulness distribution | `AnalyticsDonutChart` |
+
+## What's NOT built today (common net-new asks)
+
+| Asked-for capability | Status | Closest existing surface |
+|---|---|---|
+| Date range filter on analytics | `DateRangePill` exists but no-op | Wire to query param + filter store |
+| Settings page (any settings) | Placeholder route only | Whole new page; copy `AppShell` + `PageHeader` pattern |
+| Multi-select / bulk actions on articles | Not built | New row-selection mode on `ArticlesTable` |
+| Full-text search across KB | Not built | New search bar + results page |
+| Versioning / history per article | Not built | New side panel + restore action in editor |
+| Public-facing article reader (consumer view) | Out of scope | This library is admin-only |
+| Real-time collab in editor | Not built | Tiptap collab extension is the path |
+| Comments / annotations on articles | Not built | New thread side panel |
+| Export to PDF / CSV | Not built | Net-new |
+| Per-user permissions / RBAC | Not built | Settings + per-article ACL field |
+| Notifications / activity feed | Not built | Net-new |
+| Onboarding tours | Not built | Net-new (overlay) |
+| In-product feedback widget | Not built | Net-new |
+| AI-assisted article generation (not just review) | Not built | New action in editor BubbleMenu / slash menu |
+| Custom analytics dashboards | Not built | Tab 4 + drag-drop dashboard |
+| API integrations (Slack, Jira, etc.) | Not built | Settings page |
+
+## Decision rule for "where does this PRD land?"
+
+1. **Read the PRD.** Identify the core capability the user wants.
+2. **Match to a capability area above.** If multiple, pick the dominant one.
+3. **Check "What's NOT built today".** If listed there, treat as net-new — propose the surface.
+4. **Otherwise:** match to an existing component / page from the area's "What's built today" table. Extension or modification.
+5. **Surface the trade-off:** is this a small slot inside an existing component, a new section on an existing page, or a whole new page/route?
+
+A useful test: if the PRD's user can already get to your proposed landing page via the existing rail/breadcrumb chain, you're slotting into the right place. If not, they need a new entry point — that's a bigger commitment.

--- a/packages/kb-mcp/product/information-architecture.md
+++ b/packages/kb-mcp/product/information-architecture.md
@@ -1,0 +1,89 @@
+# Hiver KB — Information Architecture
+
+How the product's pages, routes, and navigation surfaces relate. Use this to decide *where* a new feature lands.
+
+## Sitemap
+
+```
+/                                                  → redirect to /kb/getting-started
+/kb/:categorySlug                                  → Category page (full shell)
+/kb/:categorySlug/:articleSlug/edit                → Editor page (collapsed shell)
+/ai-optimise                                       → AI Optimise Hub (full shell)
+/ai-optimise/:articleSlug/review                   → AI Gaps interactive review (collapsed shell)
+/analytics                                         → redirect to /analytics/article-performance
+/analytics/article-performance                     → Analytics tab 1 — default
+/analytics/search                                  → Analytics tab 2
+/analytics/ai-answer-performance                   → Analytics tab 3
+/settings                                          → Coming soon placeholder
+*                                                  → 404 (standalone, no shell)
+```
+
+## Top-level sections (rail)
+
+| Route prefix | Section name | Rail-active icon |
+|---|---|---|
+| `/kb/...` | Editor | Editor |
+| `/ai-optimise/...` | AI Optimisation | AI |
+| `/analytics/...` | Analytics | Analytics |
+| `/settings` | Settings | Settings |
+
+## Sub-nav (288px column inside `AppShell.explorer`)
+
+| Section | Sub-nav component | Items |
+|---|---|---|
+| Editor | `FileExplorerNav` | Hierarchical category tree (depth 0–3) + article leaves |
+| AI Optimisation | `AISubNav` | 2 items: AI Centre (no-op), AI Optimise (active) |
+| Analytics | `FileExplorerNav variant="flat"` | 3 flat items: Article Views, Search, AI Answer |
+| Settings | (none — collapsed shell) | — |
+
+## Shell modes
+
+| Mode | When | Components mounted | Components unmounted |
+|---|---|---|---|
+| Full shell | All routes except editor + review | `SideNavRail`, `FileExplorerNav` / `AISubNav`, `KBBreadcrumbBar`, content | — |
+| Collapsed shell | `/kb/.../<slug>/edit`, `/ai-optimise/<slug>/review` | `KBBreadcrumbBar` (editor variant, leading icon = home), content (full viewport) | `SideNavRail`, sub-nav |
+
+`AppShell.sidebarCollapsed=true` flips the layout. `KBBreadcrumbBar` automatically swaps the leading icon.
+
+## Page-by-page composition
+
+| Route | Layout | Primary components |
+|---|---|---|
+| `/kb/<cat>` | Full shell | `PageHeader` + `SubCategoriesTable` (if any) + `ArticlesTable` |
+| `/kb/.../<slug>/edit` | Collapsed shell | `ContentEditor` (left, flex-1) + `ArticleSettingsPanel` (right, 452px) |
+| `/ai-optimise` | Full shell | Page header + `SuggestionCard` × N (one per article with pending suggestions) |
+| `/ai-optimise/<slug>/review` | Collapsed shell | `ArticleBody` + collapsed `ArticleSettingsPanel` (right) + `AISuggestionsCard` + `AIGapSuggestionCard` × 3 + `SourcesSideSheet` (overlay) |
+| `/analytics/article-performance` | Full shell | `PageHeader` + `DateRangePill` + `StatCardGrid` + `AnalyticsAreaChart` + 2-up (`AnalyticsDonutChart` + `ArticlesNeedsAttentionTable`) + `ArticlePerformanceTable` |
+| `/analytics/search` | Full shell | `PageHeader` + 2-up charts + `SearchKeywordsTable` + `ContentGapsTable` |
+| `/analytics/ai-answer-performance` | Full shell | `PageHeader` + AI metrics + deflection chart + `AIConversationLogsCard` + `MostCitedArticlesTable` |
+| `/settings` | Full shell | Centered placeholder |
+| `*` (404) | Standalone | Branded 404 + "Back to home" |
+
+## Breadcrumb derivation
+
+| Route | Breadcrumb segments | Variant |
+|---|---|---|
+| `/kb/<a>/<b>/<c>` | `[a, b, c]` (each clickable) | category |
+| `/kb/.../<slug>/edit` | full ancestor chain + article title (last, font-medium) | editor (Save/Publish/×) |
+| `/ai-optimise` | `[AI Optimise]` | category (single, non-clickable) |
+| `/ai-optimise/<slug>/review` | article ancestor chain + title | editor (publishDisabled until reviewed) |
+| `/analytics/...` | `[Analytics]` | category |
+| `/settings` | `[Settings]` | category |
+
+## URL design rationale
+
+- **Browse paths mirror category hierarchy** — readable, shareable, deep-linkable.
+- **Article paths are flat** — articles have unique slugs globally; survives category re-org.
+- **Analytics tabs are routes** — direct linking + browser back works naturally.
+- **404 is standalone** — no shell wrapper, easier to brand.
+
+## Where to attach a new top-level section
+
+If a new section warrants its own rail icon (rare — only 4 today):
+
+1. Add the route prefix to the rail mapping.
+2. Add a sub-nav component (or `null` for collapsed-only sections).
+3. Add a default landing page (for sections with multiple tabs, redirect to the default).
+4. Update breadcrumb derivation.
+
+Most new features should attach to an *existing* section. Adding a rail icon is a strategic decision, not a feature.

--- a/packages/kb-mcp/product/journeys.md
+++ b/packages/kb-mcp/product/journeys.md
@@ -1,0 +1,108 @@
+# Hiver KB — User Journeys
+
+Three primary journeys in the KB authoring product. Use these to scope where a new feature lands.
+
+| Journey | Persona | Entry point | Landing page | Where new features typically attach |
+|---|---|---|---|---|
+| Browse & Edit (FLAGSHIP) | Admin / Content Author | Rail "Editor" icon → `/kb/...` | Category page → Editor page | New tabs in `ArticleSettingsPanel`; new actions in `KBBreadcrumbBar`; new tables/cards on Category page |
+| AI Optimise Review | Admin reviewing AI-suggested edits | Rail "AI" icon → `/ai-optimise` | Hub page → Interactive review | New suggestion types; new review modes; new sources/citations |
+| Analytics Drill | Admin checking content performance | Rail "Analytics" icon → `/analytics/...` | One of 3 tabs (Article Performance / Search / AI Answer) | New analytics tabs; new tables; new metric cards; new drill-downs |
+
+---
+
+## Journey A — Browse & Edit
+
+**Goal:** browse the KB tree, open or create an article, edit, save, publish.
+
+**Steps (condensed):**
+
+1. Land on `/` → redirect to `/kb/getting-started`. Rail "Editor" active. Explorer shows full category tree.
+2. Click chevrons in `FileExplorerNav` to expand categories → reveal subcategories at depths 1, 2, 3.
+3. Click a category row → navigate to `/kb/<categorySlug>/...`. Content = `PageHeader` + `SubCategoriesTable` + `ArticlesTable`.
+4. Click an article row → navigate to `/kb/.../<articleSlug>/edit`. Shell collapses (rail + explorer unmount). Content = `ContentEditor` (left) + `ArticleSettingsPanel` (right).
+5. Edit body or settings → editor marks dirty → "Save as draft" enables on `KBBreadcrumbBar`.
+6. Cmd+S → save. Cmd+Enter or "Publish" button → publish (status flips, navigates back to category page).
+7. "+ New" on `PageHeader` → creates empty draft, jumps straight into editor.
+8. Close (× or back) on dirty editor → unsaved-changes guard via `ConfirmDialog`.
+
+**Components in this journey:**
+
+`AppShell`, `SideNavRail`, `FileExplorerNav`, `KBBreadcrumbBar`, `PageHeader`, `SubCategoriesTable`, `ArticlesTable`, `ContentEditor`, `ArticleSettingsPanel`, `Avatar`, `Badge`, `Button`, `TextInput`, `Dropdown`.
+
+**Where new features attach:**
+
+| New feature type | Attach to |
+|---|---|
+| New article metadata field (e.g., SEO, audience tag) | New section in `ArticleSettingsPanel` |
+| New article-level action (e.g., archive, duplicate) | New button in `KBBreadcrumbBar` (editor variant) |
+| New category-page widget (e.g., featured articles) | New row of cards above `ArticlesTable` on Category page |
+| New editor capability (e.g., AI inline rewrite) | New BubbleMenu action in `ContentEditor` (or slash menu) |
+| New bulk operation (e.g., multi-select publish) | New row-selection mode on `ArticlesTable` |
+
+---
+
+## Journey B — AI Optimise Review
+
+**Goal:** review AI-generated suggestions for an article, accept some, dismiss others, publish.
+
+**Steps (condensed):**
+
+1. Click "AI" rail icon → `/ai-optimise`. Sub-nav: AI Centre (no-op) + AI Optimise (active). Hub shows 3 `SuggestionCard`s, one per article with pending suggestions.
+2. Click a card → `/ai-optimise/<articleSlug>/review`. Shell collapses. `ArticleBody` renders with inline highlights (s1 green=addition, s2 red+green=replace, s3 red=removal). Right rail: `AISuggestionsCard` (mode='pre-review') + collapsed `ArticleSettingsPanel`.
+3. Click "Review Suggestions (3)" → reducer enters reviewing mode, scrolls to s1, shows `AIGapSuggestionCard` with controls.
+4. ✓ accept (`y` / Enter) → suggestion accepted, body updates, scroll to next. × dismiss (`n`) → reverted, scroll to next. ↶ undo on chip → suggestion → pending.
+5. "📄 N Sources" → `SourcesSideSheet` slides in from right (4 conversation sources per article).
+6. Once all 3 decided → reducer enters terminal mode. `Publish` enables on `KBBreadcrumbBar`.
+7. Click Publish → accepted changes applied permanently, suggestions → published, article → published, navigate to `/ai-optimise`.
+
+**Components in this journey:**
+
+`AppShell` (sidebarCollapsed), `KBBreadcrumbBar` (editor variant, publishDisabled), `AISubNav`, `SuggestionCard`, `ArticleBody`, `SuggestionBlock`, `AISuggestionsCard`, `AIGapSuggestionCard`, `SourcesSideSheet`, `ArticleSettingsPanel`. Reducer: `useAIGapsReducer`.
+
+**Where new features attach:**
+
+| New feature type | Attach to |
+|---|---|
+| New suggestion type (beyond addition/replace/removal) | Extend `SuggestionBlock` + `AIGapSuggestionCard` props |
+| New review surface (e.g., side-by-side diff) | New mode on `AISuggestionsCard` + new layout on review page |
+| New source format (e.g., chat transcript, PDF) | New card type in `SourcesSideSheet` |
+| New keyboard shortcut | Extend reducer + `useGlobalShortcuts` |
+| Per-suggestion comments | New slot inside `AIGapSuggestionCard` |
+
+---
+
+## Journey C — Analytics Drill
+
+**Goal:** check content performance across 3 tabs, optionally drill into a low-performing article.
+
+**Steps (condensed):**
+
+1. Click "Analytics" rail icon → `/analytics/article-performance` (default tab). Sub-nav: 3 flat items.
+2. Tab 1 (Article Performance): `StatCardGrid` + `AnalyticsAreaChart` + 2-up (`AnalyticsDonutChart` + `ArticlesNeedsAttentionTable`) + `ArticlePerformanceTable`.
+3. Tab 2 (Search): 2-up search-volume + missed-search charts + `SearchKeywordsTable` + `ContentGapsTable`.
+4. Tab 3 (AI Answer): AI metrics + deflection chart + `AIConversationLogsCard` + `MostCitedArticlesTable`.
+5. Click any article-row in any table → deep-link to that article's editor (`/kb/.../<articleSlug>/edit`). Rail switches back to "Editor".
+6. `DateRangePill` → no-op for v1.
+
+**Components in this journey:**
+
+`AppShell`, `FileExplorerNav` (variant=flat for sub-nav), `PageHeader`, `DateRangePill`, `StatCard`, `StatCardGrid`, `AnalyticsAreaChart`, `AnalyticsDonutChart`, `AnalyticsChartCard`, `Card`, `HelpfulnessTag`, `ArticlesNeedsAttentionTable`, `ArticlePerformanceTable`, `SearchKeywordsTable`, `ContentGapsTable`, `AIConversationLogEntry`, `AIConversationLogsCard`, `MostCitedArticlesTable`.
+
+**Where new features attach:**
+
+| New feature type | Attach to |
+|---|---|
+| New analytics tab | New route under `/analytics/<slug>`, new entry in flat sub-nav |
+| New metric card | New `StatCard` slot in `StatCardGrid` |
+| New chart | New `AnalyticsChartCard` wrapping a Recharts series |
+| New drill-down (e.g., per-author) | New table component, link to filtered editor view |
+| Date range filter activation | Wire `DateRangePill` onClick to a query param + filter state |
+
+---
+
+## Cross-journey notes
+
+- **Shell mode:** Browse + AI Hub + Analytics use the full `AppShell` (rail + sub-nav + breadcrumb). Editor + AI Review use collapsed shell (`AppShell.sidebarCollapsed=true`).
+- **Persistence:** session-only mock store; refresh wipes state. Real product would persist via API.
+- **Where the "+ New article" entry point lives:** Category page only. Not on AI Hub or Analytics.
+- **Cross-journey deep links:** Analytics tables → Editor. AI Hub → AI Review. No other cross-links today.

--- a/packages/kb-mcp/scripts/build-indices.mjs
+++ b/packages/kb-mcp/scripts/build-indices.mjs
@@ -9,7 +9,7 @@
 // This script is invoked from `package.json`'s `build` script via tsx,
 // so it runs as TypeScript and can import the indexer modules directly.
 
-import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -63,3 +63,17 @@ writeFileSync(
 );
 // eslint-disable-next-line no-console
 console.log(`[build-indices] wrote ${stories.size} stories to dist/stories-index.json`);
+
+// Bundle product context docs (Phase 11).
+const PRODUCT_SRC = resolve(PKG_ROOT, 'product');
+const PRODUCT_DIST = resolve(DIST, 'product');
+mkdirSync(PRODUCT_DIST, { recursive: true });
+for (const name of ['journeys.md', 'information-architecture.md', 'feature-map.md']) {
+  const src = resolve(PRODUCT_SRC, name);
+  if (!existsSync(src)) {
+    console.error(`[build-indices] missing ${src}`);
+    process.exit(1);
+  }
+  writeFileSync(resolve(PRODUCT_DIST, name), readFileSync(src, 'utf8'), 'utf8');
+}
+console.log('[build-indices] bundled 3 product docs to dist/product/');

--- a/packages/kb-mcp/src/index.ts
+++ b/packages/kb-mcp/src/index.ts
@@ -57,11 +57,21 @@ import {
   recommendComponentsForPrdInputSchema,
 } from './tools/recommend-components-for-prd.js';
 import {
+  findRelevantJourney,
+  findRelevantJourneyInputSchema,
+} from './tools/find-relevant-journey.js';
+import {
   DESIGN_OVERVIEW_MIME,
   DESIGN_OVERVIEW_NAME,
   DESIGN_OVERVIEW_URI,
   readDesignOverview,
 } from './resources/design-overview.js';
+import {
+  PRODUCT_MIME,
+  PRODUCT_RESOURCES,
+  isProductResourceUri,
+  readProductResource,
+} from './resources/product-context.js';
 
 /* ─────────────────────────────────────────────────────────────
  * design.md location
@@ -170,9 +180,19 @@ const tools: ToolEntry[] = [
     },
   },
   {
+    name: 'find_relevant_journey',
+    description:
+      'Given a plain-English PRD, return the existing user journey it most likely attaches to (Browse & Edit, AI Optimise Review, or Analytics Drill), with entry point, landing page, key components touched, and confidence. Call this BEFORE recommend_components_for_prd to scope where the feature lands. Pairs with the `kb://product/journeys` resource for full journey detail.',
+    inputSchema: findRelevantJourneyInputSchema,
+    handler: (args) => {
+      const parsed = findRelevantJourneyInputSchema.parse(args ?? {});
+      return findRelevantJourney(parsed);
+    },
+  },
+  {
     name: 'recommend_components_for_prd',
     description:
-      'Turn a plain-English PRD into a starting composition: top 3–7 kb-ui components that match (with one-line reasons), the closest matching pattern story (full source), and a hand-curated composition snippet wiring the picks into an AppShell.',
+      'Turn a plain-English PRD into a starting composition: top 3-7 kb-ui components that match (with one-line reasons), the closest matching pattern story (full source), and a hand-curated composition snippet wiring the picks into an AppShell. Best used AFTER scoping the journey via `find_relevant_journey` and reading the relevant `kb://product/*` resources, so component picks are grounded in product context.',
     inputSchema: recommendComponentsForPrdInputSchema,
     handler: async (args) => {
       const parsed = recommendComponentsForPrdInputSchema.parse(args ?? {});
@@ -262,28 +282,31 @@ server.setRequestHandler(ListResourcesRequestSchema, async () => {
         description:
           'Full text of the kb-ui design system spec (design.md): tokens, typography, spacing, component-by-component Figma references.',
       },
+      ...PRODUCT_RESOURCES.map((r) => ({
+        uri: r.uri,
+        name: r.name,
+        mimeType: PRODUCT_MIME,
+        description: r.description,
+      })),
     ],
   };
 });
 
 server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
   const { uri } = request.params;
-  if (uri !== DESIGN_OVERVIEW_URI) {
-    throw new McpError(
-      ErrorCode.InvalidParams,
-      `Unknown resource URI "${uri}". Known: ${DESIGN_OVERVIEW_URI}.`,
-    );
+  if (uri === DESIGN_OVERVIEW_URI) {
+    const { mimeType, text } = await readDesignOverview(designOverviewRoot);
+    return { contents: [{ uri, mimeType, text }] };
   }
-  const { mimeType, text } = await readDesignOverview(designOverviewRoot);
-  return {
-    contents: [
-      {
-        uri,
-        mimeType,
-        text,
-      },
-    ],
-  };
+  if (isProductResourceUri(uri)) {
+    const { mimeType, text } = await readProductResource(uri);
+    return { contents: [{ uri, mimeType, text }] };
+  }
+  const known = [DESIGN_OVERVIEW_URI, ...PRODUCT_RESOURCES.map((r) => r.uri)].join(', ');
+  throw new McpError(
+    ErrorCode.InvalidParams,
+    `Unknown resource URI "${uri}". Known: ${known}.`,
+  );
 });
 
 const transport = new StdioServerTransport();

--- a/packages/kb-mcp/src/resources/product-context.ts
+++ b/packages/kb-mcp/src/resources/product-context.ts
@@ -1,0 +1,66 @@
+// MCP resources: kb://product/journeys, kb://product/information-architecture, kb://product/feature-map
+//
+// Each serves a concise markdown file from `dist/product/` (bundled at
+// package build time — see scripts/build-indices.mjs). Claude reads
+// these to ground itself in product structure before reaching for
+// component-level tools.
+
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// dist/index.js → resources/product-context.js doesn't exist; tsup bundles
+// everything into dist/index.js. So `HERE` is the dist root. Markdown
+// files sit alongside in dist/product/.
+const PRODUCT_DIR = resolve(HERE, 'product');
+
+export const PRODUCT_MIME = 'text/markdown';
+
+type ProductResource = {
+  uri: string;
+  name: string;
+  description: string;
+  filename: string;
+};
+
+export const PRODUCT_RESOURCES: ProductResource[] = [
+  {
+    uri: 'kb://product/journeys',
+    name: 'User journeys',
+    description:
+      'The 3 primary user journeys in Hiver KB (Browse & Edit, AI Optimise Review, Analytics Drill) with personas, entry points, and where new features typically attach. Read this first when scoping a PRD.',
+    filename: 'journeys.md',
+  },
+  {
+    uri: 'kb://product/information-architecture',
+    name: 'Information architecture',
+    description:
+      'Sitemap, top-level rail sections, sub-nav per section, full-vs-collapsed shell modes, and per-route component composition. Use to decide WHERE a new feature lands in the product.',
+    filename: 'information-architecture.md',
+  },
+  {
+    uri: 'kb://product/feature-map',
+    name: 'Feature map',
+    description:
+      'What the product can do today by capability area, and a list of common asks NOT yet built. Use to decide whether a PRD is net-new, an extension, or a modification.',
+    filename: 'feature-map.md',
+  },
+];
+
+const byUri = new Map(PRODUCT_RESOURCES.map((r) => [r.uri, r]));
+
+export function isProductResourceUri(uri: string): boolean {
+  return byUri.has(uri);
+}
+
+export async function readProductResource(
+  uri: string,
+): Promise<{ uri: string; mimeType: string; text: string }> {
+  const entry = byUri.get(uri);
+  if (!entry) {
+    throw new Error(`Unknown product resource URI "${uri}".`);
+  }
+  const text = await readFile(resolve(PRODUCT_DIR, entry.filename), 'utf8');
+  return { uri, mimeType: PRODUCT_MIME, text };
+}

--- a/packages/kb-mcp/src/tools/find-relevant-journey.ts
+++ b/packages/kb-mcp/src/tools/find-relevant-journey.ts
@@ -1,0 +1,385 @@
+// MCP tool: find_relevant_journey
+//
+// Phase 11.5 — given a plain-English PRD, return the existing user journey
+// it most likely attaches to, the entry point, the landing page, and a
+// short list of components Claude should expect to touch. Hand-curated
+// keyword index per journey (similar shape to ../keywords.ts but smaller).
+//
+// Deterministic + retrieval-based; the MCP client (Claude) does any
+// follow-up reasoning. Pairs naturally with the kb://product/* resources:
+// once Claude has scoped the journey, it can read the matching markdown
+// for full context.
+
+import { z } from 'zod';
+
+export const findRelevantJourneyInputSchema = z.object({
+  prd: z
+    .string()
+    .min(10)
+    .describe(
+      'Plain-English description of the feature you want to scope (1-3 sentences typical).',
+    ),
+});
+
+export type FindRelevantJourneyInput = z.infer<
+  typeof findRelevantJourneyInputSchema
+>;
+
+type Journey = {
+  id: string;
+  name: string;
+  persona: string;
+  entryPoint: string;
+  landingPage: string;
+  keyComponents: string[];
+  keywords: string[];
+};
+
+const JOURNEYS: Journey[] = [
+  {
+    id: 'browse-edit',
+    name: 'Browse & Edit',
+    persona: 'Admin / Content Author',
+    entryPoint: 'Rail "Editor" icon -> /kb/...',
+    landingPage: 'Category page (/kb/<slug>) -> Editor page (/kb/.../<slug>/edit)',
+    keyComponents: [
+      'AppShell',
+      'SideNavRail',
+      'FileExplorerNav',
+      'KBBreadcrumbBar',
+      'PageHeader',
+      'SubCategoriesTable',
+      'ArticlesTable',
+      'ContentEditor',
+      'ArticleSettingsPanel',
+    ],
+    keywords: [
+      'article',
+      'articles',
+      'editor',
+      'edit',
+      'edits',
+      'editing',
+      'category',
+      'categories',
+      'tree',
+      'browse',
+      'navigate',
+      'create',
+      'creation',
+      'author',
+      'authoring',
+      'draft',
+      'publish',
+      'publishing',
+      'tag',
+      'tags',
+      'metadata',
+      'settings panel',
+      'article settings',
+      'kb',
+      'knowledge base',
+      'rich text',
+      'tiptap',
+      'wysiwyg',
+      'slug',
+      'seo title',
+      'visibility',
+      'reviewer',
+      'reviewers',
+      'save',
+      'unsaved',
+      'breadcrumb',
+      'new article',
+      'new draft',
+    ],
+  },
+  {
+    id: 'ai-optimise',
+    name: 'AI Optimise Review',
+    persona: 'Admin (reviewer)',
+    entryPoint: 'Rail "AI" icon -> /ai-optimise',
+    landingPage: 'Hub (/ai-optimise) -> Interactive review (/ai-optimise/<slug>/review)',
+    keyComponents: [
+      'AppShell',
+      'AISubNav',
+      'KBBreadcrumbBar',
+      'SuggestionCard',
+      'ArticleBody',
+      'SuggestionBlock',
+      'AISuggestionsCard',
+      'AIGapSuggestionCard',
+      'SourcesSideSheet',
+      'ArticleSettingsPanel',
+    ],
+    keywords: [
+      'ai',
+      'suggestion',
+      'suggestions',
+      'recommend',
+      'recommendation',
+      'review',
+      'reviewing',
+      'accept',
+      'reject',
+      'dismiss',
+      'undo',
+      'inline',
+      'addition',
+      'replace',
+      'removal',
+      'gap',
+      'gaps',
+      'optimise',
+      'optimize',
+      'optimisation',
+      'optimization',
+      'sources',
+      'source sheet',
+      'side sheet',
+      'side drawer',
+      'drawer',
+      'citation',
+      'citations',
+      'conversation',
+      'conversations',
+      'reducer',
+      'state machine',
+      'review flow',
+      'highlight',
+      'diff',
+    ],
+  },
+  {
+    id: 'analytics',
+    name: 'Analytics Drill',
+    persona: 'Admin',
+    entryPoint: 'Rail "Analytics" icon -> /analytics/...',
+    landingPage:
+      'One of 3 tabs: /analytics/article-performance, /analytics/search, /analytics/ai-answer-performance',
+    keyComponents: [
+      'AppShell',
+      'FileExplorerNav',
+      'PageHeader',
+      'DateRangePill',
+      'StatCard',
+      'StatCardGrid',
+      'AnalyticsAreaChart',
+      'AnalyticsDonutChart',
+      'AnalyticsChartCard',
+      'Card',
+      'HelpfulnessTag',
+      'ArticlesNeedsAttentionTable',
+      'ArticlePerformanceTable',
+      'SearchKeywordsTable',
+      'ContentGapsTable',
+      'AIConversationLogEntry',
+      'AIConversationLogsCard',
+      'MostCitedArticlesTable',
+    ],
+    keywords: [
+      'analytics',
+      'metric',
+      'metrics',
+      'measure',
+      'measures',
+      'kpi',
+      'dashboard',
+      'chart',
+      'charts',
+      'graph',
+      'trend',
+      'performance',
+      'view',
+      'views',
+      'engagement',
+      'helpful',
+      'helpfulness',
+      'search',
+      'keyword',
+      'keywords',
+      'missed search',
+      'content gap',
+      'content gaps',
+      'date range',
+      'time range',
+      'last 30 days',
+      'last 7 days',
+      'deflection',
+      'cited',
+      'most cited',
+      'donut',
+      'area chart',
+      'bar chart',
+      'stat card',
+      'stat grid',
+      'report',
+      'reporting',
+      'drill',
+      'drill down',
+    ],
+  },
+];
+
+const STOPWORDS = new Set([
+  'the',
+  'a',
+  'an',
+  'to',
+  'of',
+  'for',
+  'with',
+  'that',
+  'this',
+  'is',
+  'are',
+  'and',
+  'or',
+  'in',
+  'on',
+  'by',
+  'as',
+  'be',
+  'it',
+  'its',
+  'i',
+  'we',
+  'you',
+  'want',
+  'need',
+  'should',
+  'would',
+]);
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s-]/gu, ' ')
+    .split(/\s+/)
+    .filter((t) => t.length > 0 && !STOPWORDS.has(t));
+}
+
+function bigrams(tokens: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < tokens.length - 1; i += 1) {
+    out.push(`${tokens[i]} ${tokens[i + 1]}`);
+  }
+  return out;
+}
+
+type ScoredJourney = {
+  journey: Journey;
+  score: number;
+  matched: string[];
+};
+
+function scoreJourney(
+  journey: Journey,
+  prdLower: string,
+  tokenSet: Set<string>,
+  bigramSet: Set<string>,
+): ScoredJourney {
+  let score = 0;
+  const matched: string[] = [];
+  for (const kw of journey.keywords) {
+    const k = kw.toLowerCase();
+    const wc = k.split(/\s+/).length;
+    if (wc === 1) {
+      if (tokenSet.has(k)) {
+        score += 1;
+        matched.push(kw);
+      }
+    } else if (wc === 2) {
+      if (bigramSet.has(k) || prdLower.includes(k)) {
+        score += 3;
+        matched.push(kw);
+      }
+    } else if (prdLower.includes(k)) {
+      score += 5;
+      matched.push(kw);
+    }
+  }
+  return { journey, score, matched };
+}
+
+export type FindRelevantJourneyOutput = {
+  bestMatch: {
+    id: string;
+    name: string;
+    persona: string;
+    entryPoint: string;
+    landingPage: string;
+    keyComponents: string[];
+    matchedKeywords: string[];
+    confidence: 'high' | 'medium' | 'low';
+  } | null;
+  alternates: Array<{
+    id: string;
+    name: string;
+    score: number;
+    matchedKeywords: string[];
+  }>;
+  guidance: string;
+};
+
+export function findRelevantJourney(
+  input: FindRelevantJourneyInput,
+): FindRelevantJourneyOutput {
+  const prdLower = input.prd.toLowerCase();
+  const tokens = tokenize(input.prd);
+  const tokenSet = new Set(tokens);
+  const bigramSet = new Set(bigrams(tokens));
+
+  const scored = JOURNEYS.map((j) =>
+    scoreJourney(j, prdLower, tokenSet, bigramSet),
+  ).sort((a, b) => b.score - a.score);
+
+  const top = scored[0];
+  const second = scored[1];
+
+  if (!top || top.score === 0) {
+    return {
+      bestMatch: null,
+      alternates: scored.map((s) => ({
+        id: s.journey.id,
+        name: s.journey.name,
+        score: s.score,
+        matchedKeywords: s.matched,
+      })),
+      guidance:
+        "No journey keywords matched. The PRD may be net-new (no existing entry point) — check `kb://product/feature-map` for the 'NOT built today' list, or read `kb://product/journeys` and `kb://product/information-architecture` to choose where the feature should land.",
+    };
+  }
+
+  const margin = top.score - (second?.score ?? 0);
+  const confidence: 'high' | 'medium' | 'low' =
+    margin >= 3 ? 'high' : margin >= 1 ? 'medium' : 'low';
+
+  return {
+    bestMatch: {
+      id: top.journey.id,
+      name: top.journey.name,
+      persona: top.journey.persona,
+      entryPoint: top.journey.entryPoint,
+      landingPage: top.journey.landingPage,
+      keyComponents: top.journey.keyComponents,
+      matchedKeywords: top.matched,
+      confidence,
+    },
+    alternates: scored
+      .slice(1)
+      .filter((s) => s.score > 0)
+      .map((s) => ({
+        id: s.journey.id,
+        name: s.journey.name,
+        score: s.score,
+        matchedKeywords: s.matched,
+      })),
+    guidance:
+      confidence === 'high'
+        ? `Strong match for "${top.journey.name}". Read \`kb://product/journeys\` for the full journey detail, then confirm scope with the user before recommending components.`
+        : confidence === 'medium'
+          ? `Likely match for "${top.journey.name}", but consider alternates. Ask the user a clarifying question before committing.`
+          : `Weak match — multiple journeys score similarly. Read \`kb://product/journeys\` and ask the user which journey their feature attaches to.`,
+  };
+}


### PR DESCRIPTION
## Summary

- New tool \`find_relevant_journey\` — given a PRD, returns matching journey + entry point + landing page + key components + confidence.
- 3 new MCP resources: \`kb://product/journeys\`, \`kb://product/information-architecture\`, \`kb://product/feature-map\`.
- Tool descriptions softened to nudge clients toward scope-first conversation.
- Bumps kb-mcp to 1.1.0.

## Why

Without product-level context, Claude jumps straight to component recommendations on any PRD. With these resources + the journey-finder tool, Claude can scope where a feature lands, ask clarifying questions, and only then propose components.

No hardcoded conversation flow — just richer ingredients for Claude to reason with.

## Test plan

- [x] kb-mcp typecheck + build clean
- [x] 3/3 fixture tests pass
- [x] JSON-RPC smoke: resources/list returns 4 (1 design + 3 product), resources/read returns each markdown, find_relevant_journey returns Analytics journey for an analytics PRD
- [x] Storybook smoke build clean (rule #5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)