### PR TITLE
fix(kb-ui): Phase 14.0 — repair broken Storybook backgrounds API

### DIFF
--- a/packages/kb-ui/.storybook/preview.ts
+++ b/packages/kb-ui/.storybook/preview.ts
@@ -4,6 +4,9 @@ import '../src/tokens.css';
 const preview: Preview = {
   parameters: {
     layout: 'padded',
+    controls: {
+      expanded: true
+    },
     backgrounds: {
       options: {
         canvas: { name: 'canvas', value: '#f5f5f5' },

--- a/packages/kb-ui/src/components/primitives/Avatar.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Avatar.stories.tsx
@@ -5,16 +5,13 @@ import { Avatar } from './Avatar';
 const meta: Meta<typeof Avatar> = {
   title: 'Components/Primitives/Avatar',
   component: Avatar,
-  parameters: { layout: 'centered', backgrounds: { default: 'white' } },
+  parameters: { layout: 'centered' },
+  globals: { backgrounds: { value: 'white' } },
   args: {
     initials: 'VK',
     showStatus: false,
   },
-  render: (args) => (
-    <div className="bg-white p-4">
-      <Avatar {...args} />
-    </div>
-  ),
+  render: (args) => <Avatar {...args} />,
 };
 export default meta;
 

--- a/packages/kb-ui/src/components/primitives/Badge.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Badge.stories.tsx
@@ -5,16 +5,13 @@ import { Badge } from './Badge';
 const meta: Meta<typeof Badge> = {
   title: 'Components/Primitives/Badge',
   component: Badge,
-  parameters: { layout: 'centered', backgrounds: { default: 'white' } },
+  parameters: { layout: 'centered' },
+  globals: { backgrounds: { value: 'white' } },
   args: {
     variant: 'published',
     children: 'Published',
   },
-  render: (args) => (
-    <div className="bg-white p-4">
-      <Badge {...args} />
-    </div>
-  ),
+  render: (args) => <Badge {...args} />,
 };
 export default meta;
 

--- a/packages/kb-ui/src/components/primitives/Breadcrumb.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Breadcrumb.stories.tsx
@@ -6,7 +6,8 @@ import { Breadcrumb } from './Breadcrumb';
 const meta: Meta<typeof Breadcrumb> = {
   title: 'Components/Primitives/Breadcrumb',
   component: Breadcrumb,
-  parameters: { layout: 'centered', backgrounds: { default: 'white' } },
+  parameters: { layout: 'centered' },
+  globals: { backgrounds: { value: 'white' } },
   args: {
     items: [
       { id: 'home', label: 'Home', onClick: () => {} },
@@ -15,11 +16,7 @@ const meta: Meta<typeof Breadcrumb> = {
       { id: 'qs', label: 'Quick Start' },
     ],
   },
-  render: (args) => (
-    <div className="bg-white p-4">
-      <Breadcrumb {...args} />
-    </div>
-  ),
+  render: (args) => <Breadcrumb {...args} />,
 };
 export default meta;
 

--- a/packages/kb-ui/src/components/primitives/Button.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Button.stories.tsx
@@ -6,17 +6,14 @@ import { Button } from './Button';
 const meta: Meta<typeof Button> = {
   title: 'Components/Primitives/Button',
   component: Button,
-  parameters: { layout: 'centered', backgrounds: { default: 'white' } },
+  parameters: { layout: 'centered' },
+  globals: { backgrounds: { value: 'white' } },
   args: {
     variant: 'primary',
     children: 'New',
     disabled: false,
   },
-  render: (args) => (
-    <div className="bg-white p-6 rounded-lg">
-      <Button {...args} icon={<RiAddLine size={14} />} />
-    </div>
-  ),
+  render: (args) => <Button {...args} icon={<RiAddLine size={14} />} />,
 };
 export default meta;
 

--- a/packages/kb-ui/src/components/primitives/Card.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Card.stories.tsx
@@ -5,7 +5,8 @@ import { Card } from './Card';
 const meta: Meta<typeof Card> = {
   title: 'Components/Primitives/Card',
   component: Card,
-  parameters: { layout: 'centered', backgrounds: { default: 'white' } },
+  parameters: { layout: 'centered' },
+  globals: { backgrounds: { value: 'white' } },
   args: {
     padding: 'md',
     as: 'div',

--- a/packages/kb-ui/src/components/primitives/Divider.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Divider.stories.tsx
@@ -5,15 +5,12 @@ import { Divider } from './Divider';
 const meta: Meta<typeof Divider> = {
   title: 'Components/Primitives/Divider',
   component: Divider,
-  parameters: { layout: 'centered', backgrounds: { default: 'white' } },
+  parameters: { layout: 'centered' },
+  globals: { backgrounds: { value: 'white' } },
   args: {
     subtle: false,
   },
-  render: (args) => (
-    <div className="w-64 p-4 bg-white">
-      <Divider {...args} />
-    </div>
-  ),
+  render: (args) => <Divider {...args} />,
 };
 export default meta;
 

--- a/packages/kb-ui/src/components/primitives/Dropdown.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Dropdown.stories.tsx
@@ -5,18 +5,15 @@ import { Dropdown } from './Dropdown';
 const meta: Meta<typeof Dropdown> = {
   title: 'Components/Primitives/Dropdown',
   component: Dropdown,
-  parameters: { layout: 'centered', backgrounds: { default: 'white' } },
+  parameters: { layout: 'centered' },
+  globals: { backgrounds: { value: 'white' } },
   args: {
     label: 'Category',
     value: 'Hiver in Incognito',
     placeholder: '',
     disabled: false,
   },
-  render: (args) => (
-    <div className="w-80 p-4 bg-white">
-      <Dropdown {...args} />
-    </div>
-  ),
+  render: (args) => <Dropdown {...args} />,
 };
 export default meta;
 

--- a/packages/kb-ui/src/components/primitives/TextInput.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/TextInput.stories.tsx
@@ -5,17 +5,14 @@ import { TextInput } from './TextInput';
 const meta: Meta<typeof TextInput> = {
   title: 'Components/Primitives/TextInput',
   component: TextInput,
-  parameters: { layout: 'centered', backgrounds: { default: 'white' } },
+  parameters: { layout: 'centered' },
+  globals: { backgrounds: { value: 'white' } },
   args: {
     placeholder: 'Enter value...',
     value: '',
     disabled: false,
   },
-  render: (args) => (
-    <div className="w-80 p-4 bg-white">
-      <TextInput {...args} />
-    </div>
-  ),
+  render: (args) => <TextInput {...args} />,
 };
 export default meta;
 


### PR DESCRIPTION
## Summary

Fixes the **screenshot-in-screenshot** look on every primitive story.

**Root cause:** Each primitive story set `parameters: { backgrounds: { default: 'white' } }` — Storybook 7 syntax that's silently ignored in our Storybook 10.3.5. The global default is grey (\`canvas\` / #f5f5f5), so each story compensated with a hand-rolled \`<div className="bg-white p-4">\` wrapper. Result: grey canvas → fake white card → component, looking like a pasted screenshot rather than a live component.

**Fix:**
- Migrate each primitive story to the SB-10-correct \`globals: { backgrounds: { value: 'white' } }\` override.
- Strip the hand-rolled white \`<div>\` wrappers — the canvas itself is now the white surface, and \`layout: 'centered'\` handles centering.
- Add \`parameters.controls.expanded: true\` in \`preview.ts\` so prop descriptions surface inline (groundwork for Phase 14.1's docs treatment).

**Scope:** preview config + the 8 primitive stories. No component source touched, no other story files touched.

## Known visual change

\`Divider\` previously rendered inside a 256-px wrapper. With the wrapper gone, the \`<hr>\` (\`w-full\`) now stretches to the full canvas width. If we'd rather constrain it, we can add a per-story decorator in 14.1.

## Test plan

- [x] \`npm run --workspace=packages/kb-ui typecheck\`
- [x] \`npm run --workspace=packages/kb-ui build-storybook\` — clean, no parameter warnings
- [x] \`npm run --workspace=packages/kb-ui storybook\` boots cleanly
- [ ] Eyeball the per-build Chromatic URL from the CI comment and confirm primitives no longer look like pasted screenshots

## What's next

Phase 14.1 layers on the docs treatment (autodocs + argTypes + variant stories + Figma links) for **two pilot components — Button and StatCard** — so the user can react before we roll out across the rest. Tracked as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)