### PR TITLE
feat(kb-ui): Phase 14.1b + 14.1c — remaining 6 primitives in real context

### DIFF
--- a/packages/kb-ui/src/components/primitives/Avatar.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Avatar.stories.tsx
@@ -5,23 +5,48 @@ import { Avatar } from './Avatar';
 const meta: Meta<typeof Avatar> = {
   title: 'Components/Primitives/Avatar',
   component: Avatar,
-  parameters: { layout: 'centered' },
+  parameters: { layout: 'padded' },
   globals: { backgrounds: { value: 'white' } },
-  args: {
-    initials: 'VK',
-    showStatus: false,
-  },
-  render: (args) => <Avatar {...args} />,
 };
 export default meta;
 
-export const Default: StoryObj<typeof Avatar> = {};
-
-export const WithImage: StoryObj<typeof Avatar> = {
-  name: 'With Image',
-  args: {
+const PEOPLE: Array<{
+  name: string;
+  initials: string;
+  src?: string;
+}> = [
+  {
+    name: 'Varun Kelkar',
+    initials: 'VK',
     src: 'https://i.pravatar.cc/64?img=12',
-    name: 'Anjali Kumar',
-    initials: 'AK',
   },
+  { name: 'Ananya Kapoor', initials: 'AK' },
+  { name: 'Maya Rao', initials: 'MR' },
+  { name: 'Tanvi Shah', initials: 'TS' },
+];
+
+function AvatarPlayground() {
+  return (
+    <div className="flex gap-6 font-sans">
+      {PEOPLE.map((person) => (
+        <div
+          key={person.name}
+          className="flex flex-col items-center gap-2"
+        >
+          <Avatar
+            name={person.name}
+            initials={person.initials}
+            src={person.src}
+          />
+          <span className="text-[12px] leading-[18px] text-[#64758b]">
+            {person.name}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export const Playground: StoryObj<typeof Avatar> = {
+  render: () => <AvatarPlayground />,
 };

--- a/packages/kb-ui/src/components/primitives/Badge.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Badge.stories.tsx
@@ -5,14 +5,50 @@ import { Badge } from './Badge';
 const meta: Meta<typeof Badge> = {
   title: 'Components/Primitives/Badge',
   component: Badge,
-  parameters: { layout: 'centered' },
+  parameters: { layout: 'padded' },
   globals: { backgrounds: { value: 'white' } },
-  args: {
-    variant: 'published',
-    children: 'Published',
-  },
-  render: (args) => <Badge {...args} />,
 };
 export default meta;
 
-export const Default: StoryObj<typeof Badge> = {};
+const ARTICLES: Array<{
+  title: string;
+  status: 'Published' | 'Draft' | 'Archived';
+  variant: 'published' | 'draft' | 'neutral';
+}> = [
+  {
+    title: 'How to reset your password',
+    status: 'Published',
+    variant: 'published',
+  },
+  { title: 'Setting up SSO', status: 'Draft', variant: 'draft' },
+  {
+    title: 'Migrating from Confluence',
+    status: 'Archived',
+    variant: 'neutral',
+  },
+  {
+    title: 'Hiver KB onboarding checklist',
+    status: 'Published',
+    variant: 'published',
+  },
+];
+
+function BadgePlayground() {
+  return (
+    <div className="flex w-full max-w-md flex-col gap-3 font-sans">
+      {ARTICLES.map((article) => (
+        <div
+          key={article.title}
+          className="flex items-center justify-between"
+        >
+          <span className="text-[14px] text-[#0f172a]">{article.title}</span>
+          <Badge variant={article.variant}>{article.status}</Badge>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export const Playground: StoryObj<typeof Badge> = {
+  render: () => <BadgePlayground />,
+};

--- a/packages/kb-ui/src/components/primitives/Breadcrumb.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Breadcrumb.stories.tsx
@@ -1,37 +1,30 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { RiBookmarkLine } from '@remixicon/react';
 import '../../tokens.css';
 import { Breadcrumb } from './Breadcrumb';
 
 const meta: Meta<typeof Breadcrumb> = {
   title: 'Components/Primitives/Breadcrumb',
   component: Breadcrumb,
-  parameters: { layout: 'centered' },
+  parameters: { layout: 'padded' },
   globals: { backgrounds: { value: 'white' } },
-  args: {
-    items: [
-      { id: 'home', label: 'Home', onClick: () => {} },
-      { id: 'gs', label: 'Getting Started', onClick: () => {} },
-      { id: 'inst', label: 'Installation', onClick: () => {} },
-      { id: 'qs', label: 'Quick Start' },
-    ],
-  },
-  render: (args) => <Breadcrumb {...args} />,
 };
 export default meta;
 
-export const Default: StoryObj<typeof Breadcrumb> = {};
+function BreadcrumbPlayground() {
+  return (
+    <div className="font-sans">
+      <Breadcrumb
+        items={[
+          { id: 'home', label: 'Home', onClick: () => {} },
+          { id: 'help', label: 'Help center', onClick: () => {} },
+          { id: 'gs', label: 'Getting started', onClick: () => {} },
+          { id: 'qs', label: 'Quick start' },
+        ]}
+      />
+    </div>
+  );
+}
 
-export const CustomHomeIconAndSeparator: StoryObj<typeof Breadcrumb> = {
-  name: 'Custom Home Icon and Separator',
-  args: {
-    items: [
-      { id: 'home', label: 'Home', onClick: () => {} },
-      { id: 'gs', label: 'Getting Started', onClick: () => {} },
-      { id: 'inst', label: 'Installation', onClick: () => {} },
-      { id: 'qs', label: 'Quick Start' },
-    ],
-    homeIcon: <RiBookmarkLine className="h-4 w-4" />,
-    separator: <span className="text-[#94a3b8]">{'>'}</span>,
-  },
+export const Playground: StoryObj<typeof Breadcrumb> = {
+  render: () => <BreadcrumbPlayground />,
 };

--- a/packages/kb-ui/src/components/primitives/Card.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Card.stories.tsx
@@ -1,26 +1,40 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import '../../tokens.css';
 import { Card } from './Card';
+import { Button } from './Button';
 
 const meta: Meta<typeof Card> = {
   title: 'Components/Primitives/Card',
   component: Card,
-  parameters: { layout: 'centered' },
+  parameters: { layout: 'padded' },
   globals: { backgrounds: { value: 'white' } },
-  args: {
-    padding: 'md',
-    as: 'div',
-  },
-  render: (args) => (
-    <Card {...args} style={{ width: 360 }}>
-      <div className="text-[14px] font-medium text-text-secondary">Card title</div>
-      <div className="mt-1 text-[14px] text-text-muted">
-        Default `md` padding (24 px). The chrome is `rounded-[12px]` + `border-card-border` +
-        `bg-white` — the canonical KB surface.
-      </div>
-    </Card>
-  ),
 };
 export default meta;
 
-export const Default: StoryObj<typeof Card> = {};
+function CardPlayground() {
+  return (
+    <div className="font-sans">
+      <Card padding="md" style={{ width: 420 }}>
+        <h3 className="text-[16px] font-semibold leading-6 text-[#0f172a]">
+          Reset your password
+        </h3>
+        <p className="text-[14px] leading-5 text-[#64758b] mt-2">
+          Step-by-step guide to recover access if you've forgotten your credentials.
+          Updated for 2026.
+        </p>
+        <div className="mt-4 flex items-center gap-3">
+          <Button variant="primary" onClick={() => {}}>
+            Read article
+          </Button>
+          <Button variant="ghost" onClick={() => {}}>
+            Share
+          </Button>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export const Playground: StoryObj<typeof Card> = {
+  render: () => <CardPlayground />,
+};

--- a/packages/kb-ui/src/components/primitives/Divider.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Divider.stories.tsx
@@ -1,17 +1,42 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import '../../tokens.css';
 import { Divider } from './Divider';
+import { Card } from './Card';
 
 const meta: Meta<typeof Divider> = {
   title: 'Components/Primitives/Divider',
   component: Divider,
-  parameters: { layout: 'centered' },
+  parameters: { layout: 'padded' },
   globals: { backgrounds: { value: 'white' } },
-  args: {
-    subtle: false,
-  },
-  render: (args) => <Divider {...args} />,
 };
 export default meta;
 
-export const Default: StoryObj<typeof Divider> = {};
+const SECTIONS: Array<{ label: string; value: string }> = [
+  { label: 'Author', value: 'Varun Kelkar' },
+  { label: 'Category', value: 'Managing emails' },
+  { label: 'Visibility', value: 'Public' },
+];
+
+function DividerPlayground() {
+  return (
+    <Card padding="md" className="w-80 font-sans">
+      {SECTIONS.map((section, index) => (
+        <div key={section.label}>
+          <div className="py-3">
+            <div className="text-[12px] leading-[18px] text-[#64758b]">
+              {section.label}
+            </div>
+            <div className="text-[14px] leading-[20px] text-[#0f172a]">
+              {section.value}
+            </div>
+          </div>
+          {index < SECTIONS.length - 1 && <Divider />}
+        </div>
+      ))}
+    </Card>
+  );
+}
+
+export const Playground: StoryObj<typeof Divider> = {
+  render: () => <DividerPlayground />,
+};

--- a/packages/kb-ui/src/components/primitives/Dropdown.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Dropdown.stories.tsx
@@ -1,33 +1,36 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import * as React from 'react';
 import '../../tokens.css';
 import { Dropdown } from './Dropdown';
 
 const meta: Meta<typeof Dropdown> = {
   title: 'Components/Primitives/Dropdown',
   component: Dropdown,
-  parameters: { layout: 'centered' },
+  parameters: { layout: 'padded' },
   globals: { backgrounds: { value: 'white' } },
-  args: {
-    label: 'Category',
-    value: 'Hiver in Incognito',
-    placeholder: '',
-    disabled: false,
-  },
-  render: (args) => <Dropdown {...args} />,
 };
 export default meta;
 
-export const Default: StoryObj<typeof Dropdown> = {};
+function DropdownPlayground() {
+  const [selected, setSelected] = React.useState<string>('Newest first');
 
-export const WithMenu: StoryObj<typeof Dropdown> = {
-  name: 'With Menu',
-  args: {
-    label: 'Sort by',
-    options: [
-      { value: 'newest', label: 'Newest first' },
-      { value: 'oldest', label: 'Oldest first' },
-      { value: 'popular', label: 'Most popular' },
-    ],
-    onSelect: (v: string) => console.log(v),
-  },
+  return (
+    <div className="w-80 font-sans">
+      <Dropdown
+        label="Sort by"
+        value={selected}
+        options={[
+          { value: 'Newest first', label: 'Newest first' },
+          { value: 'Oldest first', label: 'Oldest first' },
+          { value: 'Most popular', label: 'Most popular' },
+          { value: 'Least popular', label: 'Least popular' },
+        ]}
+        onSelect={(v) => setSelected(v)}
+      />
+    </div>
+  );
+}
+
+export const Playground: StoryObj<typeof Dropdown> = {
+  render: () => <DropdownPlayground />,
 };


### PR DESCRIPTION
Rolls the Phase 14.1a Button/TextInput pattern across the remaining 6 primitives. Each story now shows the component in its natural production habitat with real interactivity from the component itself — no useState gimmicks.

- **Avatar** — row of 4 real users (1 with image src, 3 with initials), names beneath
- **Badge** — list of 4 article rows with status badges in context
- **Divider** — sits between 3 metadata sections inside a real Card (auto-constrains width)
- **Breadcrumb** — 4-item navigation path with real onClick on non-current items
- **Card** — real card with heading, description, and 2 working Buttons inside
- **Dropdown** — real Radix menu with useState; clicking selects, displayed value updates

All 6: single \`Playground\` export, \`parameters: { layout: 'padded' }\`, \`globals.backgrounds: 'white'\`, no args/argTypes.

Test plan:
- [x] typecheck + build-storybook + boot
- [ ] Eyeball preview URL — every primitive should feel like a working component, not a screenshot