### PR TITLE
feat(kb-ui): Phase 14.2 — 18 content components refined to Playground pattern

### DIFF
--- a/packages/kb-ui/src/components/content/AIConversationLogEntry.stories.tsx
+++ b/packages/kb-ui/src/components/content/AIConversationLogEntry.stories.tsx
@@ -1,14 +1,13 @@
-import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import {
-  RiQuestionLine,
-  RiSparkling2Line,
-  RiPriceTag3Line,
-} from '@remixicon/react';
 import '../../tokens.css';
 import { AIConversationLogEntry } from './AIConversationLogEntry';
-import { ConversationRow } from './AIConversationLogEntryAtoms';
 import type { ConversationSource } from '../overlays/SourcesSideSheet';
+
+/* ─────────────────────────────────────────────────────────────
+ * AIConversationLogEntry Playground — single conversation row,
+ * wrapped in the same card chrome the entry ships inside in
+ * production (the parent AIConversationLogsCard supplies it).
+ * ───────────────────────────────────────────────────────────── */
 
 const SAMPLE_SOURCES: ConversationSource[] = [
   {
@@ -37,59 +36,28 @@ const SAMPLE_SOURCES: ConversationSource[] = [
 const meta: Meta<typeof AIConversationLogEntry> = {
   title: 'Components/AI/AI Conversation Log Entry',
   component: AIConversationLogEntry,
-  parameters: { layout: 'centered' },
-  args: {
-    question: "How do I reset my password if I can't access my recovery email?",
-    timestamp: 'Mar 31, 2:23 PM',
-    feedback: 'positive',
-    answer:
-      'Outlined the 3-step account recovery process via billing info and support contact.',
-    sourceCount: 3,
-    sources: SAMPLE_SOURCES,
-    answerDisabled: false,
-    showViewAll: false,
-  },
-  render: (args) => (
-    <div className="w-[850px] rounded-[12px] border border-card-border bg-white px-5">
-      <AIConversationLogEntry {...args} />
-    </div>
-  ),
+  parameters: { layout: 'padded' },
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof AIConversationLogEntry> = {};
+function AIConversationLogEntryPlayground() {
+  return (
+    <div className="w-[850px] rounded-[12px] border border-card-border bg-white px-5">
+      <AIConversationLogEntry
+        question="How do I reset my password if I can't access my recovery email?"
+        timestamp="Mar 31, 2:23 PM"
+        feedback="positive"
+        answer="Outlined the 3-step account recovery process via billing info and support contact."
+        sourceCount={3}
+        sources={SAMPLE_SOURCES}
+        answerDisabled={false}
+        showViewAll={false}
+      />
+    </div>
+  );
+}
 
-export const CustomRows: StoryObj<typeof AIConversationLogEntry> = {
-  name: 'Custom Rows',
-  args: {
-    question: "How do I reset my password if I can't access my recovery email?",
-    timestamp: 'Mar 31, 2:23 PM',
-    feedback: 'positive',
-    answer:
-      'Outlined the 3-step account recovery process via billing info and support contact.',
-    sourceCount: 3,
-    sources: SAMPLE_SOURCES,
-    answerDisabled: false,
-    showViewAll: false,
-    rows: [
-      <ConversationRow
-        key="row-question"
-        icon={<RiQuestionLine className="h-4 w-4 text-[#475569]" />}
-      >
-        What's the company refund policy?
-      </ConversationRow>,
-      <ConversationRow
-        key="row-answer"
-        icon={<RiSparkling2Line className="h-4 w-4 text-[#7c3aed]" />}
-      >
-        Refunds are processed within 5-7 business days.
-      </ConversationRow>,
-      <ConversationRow
-        key="row-cost"
-        icon={<RiPriceTag3Line className="h-4 w-4 text-[#475569]" />}
-      >
-        Cost: $0.0024 (210 input + 80 output tokens)
-      </ConversationRow>,
-    ],
-  },
+export const Playground: StoryObj<typeof AIConversationLogEntry> = {
+  render: () => <AIConversationLogEntryPlayground />,
 };

--- a/packages/kb-ui/src/components/content/AIConversationLogsCard.stories.tsx
+++ b/packages/kb-ui/src/components/content/AIConversationLogsCard.stories.tsx
@@ -5,6 +5,16 @@ import { AIConversationLogsCard } from './AIConversationLogsCard';
 import { AIConversationLogEntry } from './AIConversationLogEntry';
 import type { ConversationSource } from '../overlays/SourcesSideSheet';
 
+/* ─────────────────────────────────────────────────────────────
+ * AIConversationLogsCard Playground — full conversation log
+ * with five realistic entries (positive feedback, duplicates,
+ * a ticket-created tail, a follow-up, and a negative-feedback
+ * disabled-answer row). Toolbar is overridden via the
+ * `toolbar` slot to demonstrate the extension point. The sort
+ * dropdown is wired to local state so selecting a new option
+ * updates the trigger label live.
+ * ───────────────────────────────────────────────────────────── */
+
 const SAMPLE_SOURCES: ConversationSource[] = [
   {
     id: '1',
@@ -39,79 +49,21 @@ const SORT_OPTIONS = [
 const meta: Meta<typeof AIConversationLogsCard> = {
   title: 'Components/AI/AI Conversation Logs Card',
   component: AIConversationLogsCard,
-  parameters: { layout: 'centered' },
-  args: {
-    sortOptions: SORT_OPTIONS,
-    sortBy: 'recent',
-    ticketCreatedFilter: false,
-  },
-  render: (args) => (
-    <div className="w-[890px] bg-[#f8fafc] p-4">
-      <AIConversationLogsCard {...args}>
-        <AIConversationLogEntry
-          question="How do I reset my password if I can't access my recovery email?"
-          timestamp="Mar 31, 2:23 PM"
-          feedback="positive"
-          answer="Outlined the 3-step account recovery process via billing info and support contact."
-          sourceCount={3}
-          sources={SAMPLE_SOURCES}
-        />
-        <AIConversationLogEntry
-          question="How do I reset my password if I can't access my recovery email?"
-          timestamp="Mar 31, 2:23 PM"
-          feedback="positive"
-          answer="Outlined the 3-step account recovery process via billing info and support contact."
-          sourceCount={3}
-          sources={SAMPLE_SOURCES}
-        />
-        <AIConversationLogEntry
-          question="Why was I charged twice this month?"
-          timestamp="Mar 30, 1:23 PM"
-          feedback={null}
-          answer="Explained duplicate charge scenarios and how to report via the billing dashboard. Included 5–7 day refund timeline as well as an apology for the duplicate charge."
-          sourceCount={3}
-          sources={SAMPLE_SOURCES}
-          tail={{ kind: 'ticket-created' }}
-        />
-        <AIConversationLogEntry
-          question="How do I set up Slack notifications for my team?"
-          timestamp="Mar 28, 2:23 PM"
-          feedback={null}
-          answer="Walked through the Slack integration setup, notification scope settings, and OAuth re-authorization steps"
-          sourceCount={3}
-          sources={SAMPLE_SOURCES}
-          followUp={{
-            question: 'How do i do this and that?',
-            answer: 'Explained about the OAuth setup',
-            sourceCount: 3,
-            sources: SAMPLE_SOURCES,
-            tail: { kind: 'source-clicked' },
-          }}
-          showViewAll
-        />
-        <AIConversationLogEntry
-          question="Does Hiver have HIPAA compliance?"
-          timestamp="Mar 27, 2:23 PM"
-          feedback="negative"
-          answer="AI could not provide an answer"
-          answerDisabled
-          sourceCount={0}
-          tail={{ kind: 'source-clicked', actor: 'the user' }}
-        />
-      </AIConversationLogsCard>
-    </div>
-  ),
+  parameters: { layout: 'padded' },
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof AIConversationLogsCard> = {};
+function AIConversationLogsCardPlayground() {
+  const [sortBy, setSortBy] = React.useState('recent');
 
-export const CustomToolbar: StoryObj<typeof AIConversationLogsCard> = {
-  name: 'Custom Toolbar',
-  render: (args) => (
-    <div className="w-[890px] bg-[#f8fafc] p-4">
+  return (
+    <div className="w-[890px]">
       <AIConversationLogsCard
-        {...args}
+        sortOptions={SORT_OPTIONS}
+        sortBy={sortBy}
+        onSortChange={setSortBy}
+        ticketCreatedFilter={false}
         toolbar={
           <span className="text-[12px] font-medium text-[#475569]">
             Filtered: Last 7 days
@@ -170,5 +122,9 @@ export const CustomToolbar: StoryObj<typeof AIConversationLogsCard> = {
         />
       </AIConversationLogsCard>
     </div>
-  ),
+  );
+}
+
+export const Playground: StoryObj<typeof AIConversationLogsCard> = {
+  render: () => <AIConversationLogsCardPlayground />,
 };

--- a/packages/kb-ui/src/components/content/AIGapSuggestionCard.stories.tsx
+++ b/packages/kb-ui/src/components/content/AIGapSuggestionCard.stories.tsx
@@ -1,20 +1,19 @@
-import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import '../../tokens.css';
 import { AIGapSuggestionCard } from './AIGapSuggestionCard';
 import type { AISuggestion } from './ai-suggestion-types';
 
-const CANVAS: React.CSSProperties = {
-  background: '#f5f5f5',
-  padding: 32,
-  minHeight: 260,
-};
+/* ─────────────────────────────────────────────────────────────
+ * AIGapSuggestionCard Playground — sidebar rail with three
+ * stacked cards covering the full surface area:
+ *   1. Active   — default extension, mobile password reset
+ *   2. Accepted — terminal state for a removal suggestion
+ *   3. Active   — every extension slot used (meta chip,
+ *                 custom action, custom decision labels)
+ * 354px rail width matches the editor's right rail in prod.
+ * ───────────────────────────────────────────────────────────── */
 
-const RAIL: React.CSSProperties = {
-  width: 354,
-};
-
-const DEFAULT_SUGGESTION: AISuggestion = {
+const SUGGESTION_ADDITION: AISuggestion = {
   id: 'sug-1',
   type: 'addition',
   title: 'Mobile app password reset instructions',
@@ -23,56 +22,84 @@ const DEFAULT_SUGGESTION: AISuggestion = {
   sourceCount: 4,
 };
 
+const SUGGESTION_REMOVAL: AISuggestion = {
+  id: 'sug-2',
+  type: 'removal',
+  title: 'Outdated Confluence migration steps',
+  description:
+    'Remove the legacy Confluence-to-Hiver migration paragraph — content moved to a dedicated guide last quarter.',
+  sourceCount: 2,
+};
+
+const SUGGESTION_FLAGGED: AISuggestion = {
+  id: 'sug-3',
+  type: 'addition',
+  title: 'Two-factor authentication setup walkthrough',
+  description:
+    'Add a step-by-step walkthrough for configuring 2FA across both web and mobile clients.',
+  sourceCount: 7,
+};
+
 const meta: Meta<typeof AIGapSuggestionCard> = {
   title: 'Components/AI/AI Gap Suggestion Card',
   component: AIGapSuggestionCard,
   parameters: { layout: 'padded' },
-  args: {
-    suggestion: DEFAULT_SUGGESTION,
-    state: 'active',
-    onPrev: () => {},
-    onNext: () => {},
-    onOpenSources: () => {},
-    onAccept: () => {},
-    onReject: () => {},
-    onUndo: () => {},
-  },
-  render: (args) => (
-    <div style={CANVAS}>
-      <div style={RAIL}>
-        <AIGapSuggestionCard {...args} />
-      </div>
-    </div>
-  ),
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof AIGapSuggestionCard> = {};
-
-export const CustomActionsMetaAndLabels: StoryObj<typeof AIGapSuggestionCard> = {
-  name: 'Custom Actions, Meta & Labels',
-  render: (args) => (
-    <div style={CANVAS}>
-      <div style={RAIL}>
-        <AIGapSuggestionCard
-          {...args}
-          meta={
-            <span className="inline-flex h-[20px] items-center rounded-full bg-[#fef3c7] px-2 text-[11px] font-medium text-[#92400e]">
-              FLAGGED
-            </span>
-          }
-          actions={
-            <button
-              type="button"
-              onClick={() => {}}
-              className="text-[12px] font-medium text-[#475569] underline"
-            >
-              Flag for compliance review
-            </button>
-          }
-          decisionLabels={{ accepted: 'APPROVED', dismissed: 'REJECTED' }}
-        />
-      </div>
+function AIGapSuggestionCardPlayground() {
+  return (
+    <div className="w-[354px] flex flex-col gap-4">
+      <AIGapSuggestionCard
+        suggestion={SUGGESTION_ADDITION}
+        state="active"
+        onPrev={() => {}}
+        onNext={() => {}}
+        onOpenSources={() => {}}
+        onAccept={() => {}}
+        onReject={() => {}}
+        onUndo={() => {}}
+      />
+      <AIGapSuggestionCard
+        suggestion={SUGGESTION_REMOVAL}
+        state="accepted"
+        onPrev={() => {}}
+        onNext={() => {}}
+        onOpenSources={() => {}}
+        onAccept={() => {}}
+        onReject={() => {}}
+        onUndo={() => {}}
+      />
+      <AIGapSuggestionCard
+        suggestion={SUGGESTION_FLAGGED}
+        state="active"
+        onPrev={() => {}}
+        onNext={() => {}}
+        onOpenSources={() => {}}
+        onAccept={() => {}}
+        onReject={() => {}}
+        onUndo={() => {}}
+        meta={
+          <span className="inline-flex h-[20px] items-center rounded-full bg-[#fef3c7] px-2 text-[11px] font-medium text-[#92400e]">
+            FLAGGED
+          </span>
+        }
+        actions={
+          <button
+            type="button"
+            onClick={() => {}}
+            className="text-[12px] font-medium text-[#475569] underline"
+          >
+            Flag for compliance review
+          </button>
+        }
+        decisionLabels={{ accepted: 'APPROVED', dismissed: 'REJECTED' }}
+      />
     </div>
-  ),
+  );
+}
+
+export const Playground: StoryObj<typeof AIGapSuggestionCard> = {
+  render: () => <AIGapSuggestionCardPlayground />,
 };

--- a/packages/kb-ui/src/components/content/AISuggestionsCard.stories.tsx
+++ b/packages/kb-ui/src/components/content/AISuggestionsCard.stories.tsx
@@ -1,78 +1,67 @@
-import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import '../../tokens.css';
 import { AISuggestionsCard } from './AISuggestionsCard';
 import { Button } from '../primitives/Button';
 
-/**
- * The rail is intended to live in a 320–380px column. The preview
- * canvas mimics the editor's right rail to keep widths realistic.
- */
-const CANVAS: React.CSSProperties = {
-  background: '#f5f5f5',
-  padding: 32,
-  minHeight: 420,
-};
-
-const RAIL: React.CSSProperties = {
-  width: 354,
-};
+/* ─────────────────────────────────────────────────────────────
+ * AISuggestionsCard Playground — full sidebar rail demo.
+ *
+ * Renders all three modes the rail actually ships in:
+ *   1. `pre-review` (default title)        — 5 pending suggestions
+ *   2. `terminal`   (custom terminal label) — count 0, all caught up
+ *   3. `pre-review` with custom title + cta — compliance review
+ *
+ * Stacked in a 354px-wide rail container — the same width the
+ * editor's right rail uses in production.
+ * ───────────────────────────────────────────────────────────── */
 
 const SUMMARY =
-  'Refining the article with updated instruction set, updating link and by removing legacy instructions';
+  'Refining the article with an updated instruction set, replacing the legacy mobile-app URL, and removing outdated recovery-email steps.';
 
 const meta: Meta<typeof AISuggestionsCard> = {
   title: 'Components/AI/AI Suggestions Card',
   component: AISuggestionsCard,
   parameters: { layout: 'padded' },
-  args: {
-    mode: 'pre-review',
-    count: 3,
-    summary: SUMMARY,
-    onReview: () => {},
-    onPrev: () => {},
-    onNext: () => {},
-  },
-  render: (args) => (
-    <div style={CANVAS}>
-      <div style={RAIL}>
-        <AISuggestionsCard {...args} />
-      </div>
-    </div>
-  ),
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof AISuggestionsCard> = {};
-
-export const CustomTitleAndCta: StoryObj<typeof AISuggestionsCard> = {
-  name: 'Custom Title & CTA',
-  render: () => (
-    <div style={CANVAS}>
-      <div style={{ ...RAIL, display: 'flex', flexDirection: 'column', gap: 16 }}>
-        <AISuggestionsCard
-          mode="pre-review"
-          count={3}
-          summary={SUMMARY}
-          onPrev={() => {}}
-          onNext={() => {}}
-          title="Compliance Suggestions"
-          cta={
-            <Button variant="ghost" onClick={() => {}}>
-              Open compliance review
-            </Button>
-          }
-        />
-        <AISuggestionsCard
-          mode="terminal"
-          count={3}
-          summary={SUMMARY}
-          onPrev={() => {}}
-          onNext={() => {}}
-          title="Compliance Suggestions"
-          terminalLabel="All checked"
-        />
-      </div>
+function AISuggestionsCardPlayground() {
+  return (
+    <div className="w-[354px] flex flex-col gap-4">
+      <AISuggestionsCard
+        mode="pre-review"
+        count={5}
+        summary={SUMMARY}
+        onReview={() => {}}
+        onPrev={() => {}}
+        onNext={() => {}}
+      />
+      <AISuggestionsCard
+        mode="terminal"
+        count={0}
+        summary={SUMMARY}
+        terminalLabel="All caught up"
+        onPrev={() => {}}
+        onNext={() => {}}
+      />
+      <AISuggestionsCard
+        mode="pre-review"
+        count={3}
+        summary={SUMMARY}
+        title="Compliance Suggestions"
+        cta={
+          <Button variant="ghost" onClick={() => {}}>
+            Open compliance review
+          </Button>
+        }
+        onPrev={() => {}}
+        onNext={() => {}}
+      />
     </div>
-  ),
+  );
+}
+
+export const Playground: StoryObj<typeof AISuggestionsCard> = {
+  render: () => <AISuggestionsCardPlayground />,
 };

--- a/packages/kb-ui/src/components/content/AnalyticsAreaChart.stories.tsx
+++ b/packages/kb-ui/src/components/content/AnalyticsAreaChart.stories.tsx
@@ -1,53 +1,77 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import '../../tokens.css';
 import { AnalyticsAreaChart } from './AnalyticsAreaChart';
+import { Card } from '../primitives/Card';
 
-/*
- * Hardcoded analytics data. 7 weekday points, but Figma renders
- * only mon/tue/wed/fri/sat/sun ticks — "thu" omitted to match the
- * design (intentional weekday gap, not a data omission).
+/* 30-day daily article-views series for a Hiver KB org.
+ * - Weekdays trend ~4600–7400 with mid-week peaks (Tue–Wed).
+ * - Weekends drop to ~2400–3300 (B2B usage profile).
+ * - Slight upward trend across the month (org adoption growing).
+ * - `unique` tracks ~38–42% of total views.
+ *
+ * Dates are Apr 1 (Wed) → Apr 30 (Thu), 2026.
  */
 const articleViewsData = [
-  { x: 'mon', views: 4200, unique: 1800 },
-  { x: 'tue', views: 5300, unique: 2200 },
-  { x: 'wed', views: 5100, unique: 2400 },
-  { x: 'fri', views: 7400, unique: 2900 },
-  { x: 'sat', views: 8900, unique: 3300 },
-  { x: 'sun', views: 9600, unique: 3500 },
+  { x: 'Apr 1', views: 4800, unique: 1920 },
+  { x: 'Apr 2', views: 5100, unique: 2040 },
+  { x: 'Apr 3', views: 4600, unique: 1850 },
+  { x: 'Apr 4', views: 2700, unique: 1080 },
+  { x: 'Apr 5', views: 2400, unique: 980 },
+  { x: 'Apr 6', views: 5200, unique: 2080 },
+  { x: 'Apr 7', views: 6100, unique: 2440 },
+  { x: 'Apr 8', views: 6400, unique: 2560 },
+  { x: 'Apr 9', views: 5800, unique: 2320 },
+  { x: 'Apr 10', views: 4900, unique: 1960 },
+  { x: 'Apr 11', views: 2900, unique: 1160 },
+  { x: 'Apr 12', views: 2600, unique: 1040 },
+  { x: 'Apr 13', views: 5500, unique: 2200 },
+  { x: 'Apr 14', views: 6300, unique: 2520 },
+  { x: 'Apr 15', views: 6800, unique: 2720 },
+  { x: 'Apr 16', views: 6500, unique: 2600 },
+  { x: 'Apr 17', views: 5200, unique: 2080 },
+  { x: 'Apr 18', views: 3100, unique: 1240 },
+  { x: 'Apr 19', views: 2800, unique: 1120 },
+  { x: 'Apr 20', views: 5900, unique: 2360 },
+  { x: 'Apr 21', views: 6700, unique: 2680 },
+  { x: 'Apr 22', views: 7200, unique: 2880 },
+  { x: 'Apr 23', views: 6900, unique: 2760 },
+  { x: 'Apr 24', views: 5600, unique: 2240 },
+  { x: 'Apr 25', views: 3300, unique: 1320 },
+  { x: 'Apr 26', views: 3000, unique: 1200 },
+  { x: 'Apr 27', views: 6200, unique: 2480 },
+  { x: 'Apr 28', views: 7100, unique: 2840 },
+  { x: 'Apr 29', views: 7400, unique: 2960 },
+  { x: 'Apr 30', views: 7000, unique: 2800 },
 ];
 
 const meta: Meta<typeof AnalyticsAreaChart> = {
   title: 'Components/Charts & Stats/Analytics Area Chart',
   component: AnalyticsAreaChart,
   parameters: { layout: 'padded' },
-  args: {
-    data: articleViewsData,
-    xKey: 'x',
-    series: [
-      { name: 'Total Views', dataKey: 'views', variant: 'views' },
-      { name: 'Unique Views', dataKey: 'unique', variant: 'unique' },
-    ],
-    yTicks: [0, 3000, 6000, 9000, 12000],
-    showLegend: true,
-  },
-  render: (args) => (
-    <div style={{ width: 720 }} className="bg-white p-6">
-      <AnalyticsAreaChart {...args} />
-    </div>
-  ),
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof AnalyticsAreaChart> = {};
+function AnalyticsAreaChartPlayground() {
+  return (
+    <Card padding="md" style={{ width: 720 }}>
+      <h3 className="text-[14px] font-semibold text-[#0f172a] mb-4">
+        Article views — last 30 days
+      </h3>
+      <AnalyticsAreaChart
+        data={articleViewsData}
+        xKey="x"
+        series={[
+          { name: 'Total Views', dataKey: 'views', variant: 'views' },
+          { name: 'Unique Views', dataKey: 'unique', variant: 'unique' },
+        ]}
+        yTicks={[0, 2000, 4000, 6000, 8000, 10000]}
+        showLegend={true}
+      />
+    </Card>
+  );
+}
 
-export const CustomPalette: StoryObj<typeof AnalyticsAreaChart> = {
-  name: 'Custom Palette',
-  args: {
-    data: articleViewsData,
-    xKey: 'x',
-    series: [{ name: 'Churn', dataKey: 'views', variant: 'churn' }],
-    seriesPalette: { churn: '#ef4444' },
-    yTicks: [0, 3000, 6000, 9000, 12000],
-    showLegend: true,
-  },
+export const Playground: StoryObj<typeof AnalyticsAreaChart> = {
+  render: () => <AnalyticsAreaChartPlayground />,
 };

--- a/packages/kb-ui/src/components/content/AnalyticsChartCard.stories.tsx
+++ b/packages/kb-ui/src/components/content/AnalyticsChartCard.stories.tsx
@@ -1,29 +1,73 @@
+import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import '../../tokens.css';
 import { AnalyticsAreaChart } from './AnalyticsAreaChart';
 import { AnalyticsChartCard } from './AnalyticsChartCard';
+import { DateRangePill, type DateRange } from './DateRangePill';
 
+/* 30-day daily article-views series — shared shape with the
+ * AnalyticsAreaChart story. Apr 1 (Wed) → Apr 30 (Thu), 2026.
+ *
+ * Weekday peaks (Tue–Wed mid-month), B2B weekend dips, slight upward
+ * trend across the month. `unique` ≈ 38–42% of `views`.
+ */
 const articleViewsData = [
-  { x: 'mon', views: 4200, unique: 1800 },
-  { x: 'tue', views: 5300, unique: 2200 },
-  { x: 'wed', views: 5100, unique: 2400 },
-  { x: 'fri', views: 7400, unique: 2900 },
-  { x: 'sat', views: 8900, unique: 3300 },
-  { x: 'sun', views: 9600, unique: 3500 },
+  { x: 'Apr 1', views: 4800, unique: 1920 },
+  { x: 'Apr 2', views: 5100, unique: 2040 },
+  { x: 'Apr 3', views: 4600, unique: 1850 },
+  { x: 'Apr 4', views: 2700, unique: 1080 },
+  { x: 'Apr 5', views: 2400, unique: 980 },
+  { x: 'Apr 6', views: 5200, unique: 2080 },
+  { x: 'Apr 7', views: 6100, unique: 2440 },
+  { x: 'Apr 8', views: 6400, unique: 2560 },
+  { x: 'Apr 9', views: 5800, unique: 2320 },
+  { x: 'Apr 10', views: 4900, unique: 1960 },
+  { x: 'Apr 11', views: 2900, unique: 1160 },
+  { x: 'Apr 12', views: 2600, unique: 1040 },
+  { x: 'Apr 13', views: 5500, unique: 2200 },
+  { x: 'Apr 14', views: 6300, unique: 2520 },
+  { x: 'Apr 15', views: 6800, unique: 2720 },
+  { x: 'Apr 16', views: 6500, unique: 2600 },
+  { x: 'Apr 17', views: 5200, unique: 2080 },
+  { x: 'Apr 18', views: 3100, unique: 1240 },
+  { x: 'Apr 19', views: 2800, unique: 1120 },
+  { x: 'Apr 20', views: 5900, unique: 2360 },
+  { x: 'Apr 21', views: 6700, unique: 2680 },
+  { x: 'Apr 22', views: 7200, unique: 2880 },
+  { x: 'Apr 23', views: 6900, unique: 2760 },
+  { x: 'Apr 24', views: 5600, unique: 2240 },
+  { x: 'Apr 25', views: 3300, unique: 1320 },
+  { x: 'Apr 26', views: 3000, unique: 1200 },
+  { x: 'Apr 27', views: 6200, unique: 2480 },
+  { x: 'Apr 28', views: 7100, unique: 2840 },
+  { x: 'Apr 29', views: 7400, unique: 2960 },
+  { x: 'Apr 30', views: 7000, unique: 2800 },
 ];
 
 const meta: Meta<typeof AnalyticsChartCard> = {
   title: 'Components/Charts & Stats/Analytics Chart Card',
   component: AnalyticsChartCard,
-  parameters: { layout: 'padded', backgrounds: { default: 'app' } },
-  args: {
-    title: 'Article views over time',
-    infoTooltip: 'Total and unique views per day across the selected range.',
-    subtitle: '',
-  },
-  render: (args) => (
-    <div className="bg-[#f8fafc] p-6" style={{ width: 720 }}>
-      <AnalyticsChartCard {...args}>
+  parameters: { layout: 'padded' },
+  globals: { backgrounds: { value: 'canvas' } },
+};
+export default meta;
+
+function AnalyticsChartCardPlayground() {
+  // Wire a real interactive DateRangePill into headerRight so the
+  // composition demo isn't just static — the manager can click the
+  // pill and watch the selection toggle. Chart data stays at 30 days
+  // regardless of pill state; this story showcases composition, not
+  // data filtering.
+  const [range, setRange] = React.useState<DateRange>('30d');
+
+  return (
+    <div style={{ width: 720 }}>
+      <AnalyticsChartCard
+        title="Article views over time"
+        subtitle="Total and unique views across all knowledge-base articles, broken down per day."
+        infoTooltip="Drag the date range pill in the upper-right to compare windows. Hover any point for exact counts."
+        headerRight={<DateRangePill value={range} onChange={setRange} />}
+      >
         <AnalyticsAreaChart
           data={articleViewsData}
           xKey="x"
@@ -31,12 +75,14 @@ const meta: Meta<typeof AnalyticsChartCard> = {
             { name: 'Total Views', dataKey: 'views', variant: 'views' },
             { name: 'Unique Views', dataKey: 'unique', variant: 'unique' },
           ]}
-          yTicks={[0, 3000, 6000, 9000, 12000]}
+          yTicks={[0, 2000, 4000, 6000, 8000, 10000]}
+          showLegend={true}
         />
       </AnalyticsChartCard>
     </div>
-  ),
-};
-export default meta;
+  );
+}
 
-export const Default: StoryObj<typeof AnalyticsChartCard> = {};
+export const Playground: StoryObj<typeof AnalyticsChartCard> = {
+  render: () => <AnalyticsChartCardPlayground />,
+};

--- a/packages/kb-ui/src/components/content/AnalyticsDonutChart.stories.tsx
+++ b/packages/kb-ui/src/components/content/AnalyticsDonutChart.stories.tsx
@@ -1,31 +1,36 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import '../../tokens.css';
 import { AnalyticsDonutChart } from './AnalyticsDonutChart';
+import { Card } from '../primitives/Card';
 
-// 6 segments — matches Figma Views-by-Category 1974:53988 (verified via get_variable_defs).
 const categoryData = [
-  { label: 'Category 1', value: 28 },
-  { label: 'Category 2', value: 22 },
-  { label: 'Category 3', value: 18 },
-  { label: 'Category 4', value: 14 },
-  { label: 'Category 5', value: 10 },
-  { label: 'Category 6', value: 8 },
+  { label: 'Getting Started', value: 28 },
+  { label: 'Account & Billing', value: 22 },
+  { label: 'Integrations', value: 18 },
+  { label: 'Email Workflow', value: 14 },
+  { label: 'Reporting & Analytics', value: 10 },
+  { label: 'Other', value: 8 },
 ];
 
 const meta: Meta<typeof AnalyticsDonutChart> = {
   title: 'Components/Charts & Stats/Analytics Donut Chart',
   component: AnalyticsDonutChart,
   parameters: { layout: 'padded' },
-  args: {
-    data: categoryData,
-    showLegend: true,
-  },
-  render: (args) => (
-    <div className="bg-white p-6">
-      <AnalyticsDonutChart {...args} />
-    </div>
-  ),
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof AnalyticsDonutChart> = {};
+function AnalyticsDonutChartPlayground() {
+  return (
+    <Card padding="md" style={{ width: 560 }}>
+      <h3 className="text-[14px] font-semibold text-[#0f172a] mb-3">
+        Views by Category — last 30 days
+      </h3>
+      <AnalyticsDonutChart data={categoryData} showLegend={true} />
+    </Card>
+  );
+}
+
+export const Playground: StoryObj<typeof AnalyticsDonutChart> = {
+  render: () => <AnalyticsDonutChartPlayground />,
+};

--- a/packages/kb-ui/src/components/content/ArticleBody.stories.tsx
+++ b/packages/kb-ui/src/components/content/ArticleBody.stories.tsx
@@ -2,87 +2,97 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import '../../tokens.css';
 import { ArticleBody } from './ArticleBody';
 
+/* ─────────────────────────────────────────────────────────────
+ * ArticleBody Playground — fully populated article using every
+ * region slot (header, beforeS1, s1, betweenS1AndS2, s2.before/
+ * after, betweenS2AndS3, s3, afterS3) with realistic shared-inbox
+ * content lifted straight from the Hiver KB.
+ * ───────────────────────────────────────────────────────────── */
+
 const meta: Meta<typeof ArticleBody> = {
   title: 'Components/Article/Article Body',
   component: ArticleBody,
   parameters: { layout: 'padded' },
-  args: {
-    decisions: { s1: 'inactive', s2: 'inactive', s3: 'inactive' },
-    regions: {
-      header: (
-        <>
-          <h1 style={{ margin: 0, marginBottom: 8 }}>
-            Setting up shared inboxes in Hiver
-          </h1>
-          <p style={{ margin: 0, color: '#666' }}>
-            Last updated by Priya Menon — April 2026
-          </p>
-        </>
-      ),
-      beforeS1: (
-        <p>
-          Shared inboxes let your team collaborate on a single email address —
-          like support@ or billing@ — directly inside Gmail. Every teammate sees
-          the same conversations, can claim ownership, and reply on behalf of
-          the group without forwarding threads back and forth.
-        </p>
-      ),
-      s1: (
-        <p>
-          Hiver also supports nested shared inboxes, so larger teams can split a
-          parent inbox (e.g. support@) into focused sub-queues like
-          billing-support@ or onboarding@ without leaving Gmail.
-        </p>
-      ),
-      betweenS1AndS2: (
-        <p>
-          To create a shared inbox, open the Hiver sidebar and click the plus
-          icon next to "Shared Inboxes." You'll be prompted to enter the email
-          address you want to share.
-        </p>
-      ),
-      s2: {
-        before: (
-          <p>
-            Once the inbox is created, only the admin who set it up can see
-            incoming conversations until teammates are added manually.
-          </p>
-        ),
-        after: (
-          <p>
-            Once the inbox is created, every teammate you invite gets immediate
-            access to incoming conversations — no manual sync step required.
-          </p>
-        ),
-      },
-      betweenS2AndS3: (
-        <p>
-          Invite teammates from the inbox settings panel. They'll receive an
-          email invitation and, once accepted, the shared inbox will appear in
-          their Gmail sidebar alongside their personal mail.
-        </p>
-      ),
-      s3: (
-        <p>
-          Note: shared inboxes created before March 2024 used a legacy
-          permissions model and may need to be migrated manually from the admin
-          console before new teammates can be added.
-        </p>
-      ),
-      afterS3: (
-        <p>
-          That's it — your team is ready to triage email together. For more on
-          assigning conversations and SLAs, see the Collaboration guide.
-        </p>
-      ),
-    },
-  },
-  render: (args) => (
-    <div style={{ background: '#f5f5f5', padding: 32 }}>
-      <ArticleBody {...args} />
-    </div>
-  ),
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof ArticleBody> = {};
+function ArticleBodyPlayground() {
+  return (
+    <ArticleBody
+      decisions={{ s1: 'inactive', s2: 'inactive', s3: 'inactive' }}
+      regions={{
+        header: (
+          <>
+            <h1 style={{ margin: 0, marginBottom: 8 }}>
+              Setting up shared inboxes in Hiver
+            </h1>
+            <p style={{ margin: 0, color: '#666' }}>
+              Last updated by Priya Menon — April 2026
+            </p>
+          </>
+        ),
+        beforeS1: (
+          <p>
+            Shared inboxes let your team collaborate on a single email address —
+            like support@ or billing@ — directly inside Gmail. Every teammate sees
+            the same conversations, can claim ownership, and reply on behalf of
+            the group without forwarding threads back and forth.
+          </p>
+        ),
+        s1: (
+          <p>
+            Hiver also supports nested shared inboxes, so larger teams can split a
+            parent inbox (e.g. support@) into focused sub-queues like
+            billing-support@ or onboarding@ without leaving Gmail.
+          </p>
+        ),
+        betweenS1AndS2: (
+          <p>
+            To create a shared inbox, open the Hiver sidebar and click the plus
+            icon next to "Shared Inboxes." You'll be prompted to enter the email
+            address you want to share.
+          </p>
+        ),
+        s2: {
+          before: (
+            <p>
+              Once the inbox is created, only the admin who set it up can see
+              incoming conversations until teammates are added manually.
+            </p>
+          ),
+          after: (
+            <p>
+              Once the inbox is created, every teammate you invite gets immediate
+              access to incoming conversations — no manual sync step required.
+            </p>
+          ),
+        },
+        betweenS2AndS3: (
+          <p>
+            Invite teammates from the inbox settings panel. They'll receive an
+            email invitation and, once accepted, the shared inbox will appear in
+            their Gmail sidebar alongside their personal mail.
+          </p>
+        ),
+        s3: (
+          <p>
+            Note: shared inboxes created before March 2024 used a legacy
+            permissions model and may need to be migrated manually from the admin
+            console before new teammates can be added.
+          </p>
+        ),
+        afterS3: (
+          <p>
+            That's it — your team is ready to triage email together. For more on
+            assigning conversations and SLAs, see the Collaboration guide.
+          </p>
+        ),
+      }}
+    />
+  );
+}
+
+export const Playground: StoryObj<typeof ArticleBody> = {
+  render: () => <ArticleBodyPlayground />,
+};

--- a/packages/kb-ui/src/components/content/ArticleSettingsPanel.stories.tsx
+++ b/packages/kb-ui/src/components/content/ArticleSettingsPanel.stories.tsx
@@ -17,11 +17,22 @@ import {
 } from './ArticleSettingsPanelAtoms';
 import { Avatar } from '../primitives/Avatar';
 
-const CANVAS: React.CSSProperties = {
-  background: '#f5f5f5',
-  padding: 32,
-  minHeight: 820,
-};
+/* ─────────────────────────────────────────────────────────────
+ * ArticleSettingsPanel Playground — exercises the full new
+ * composition API on `ArticleSettingsPanel`:
+ *   1. `sections`   — replace the 8 built-in fields with a hand-
+ *                     composed list using lifted atoms (FieldBox,
+ *                     ChevronSuffix, Placeholder, CharCounter,
+ *                     TagChip, AddChipButton). Eight match the
+ *                     built-in defaults; the ninth adds an "SEO
+ *                     Description" textarea section the panel has
+ *                     no built-in equivalent for.
+ *   2. `headerSlot` — a "Custom layout" pill on the right of the
+ *                     panel header.
+ *   3. `footerSlot` — a single muted line below the divider.
+ * Multiple fields are wired to React.useState so the editing
+ * affordances (slug/seoTitle counters, tag chips) are live.
+ * ───────────────────────────────────────────────────────────── */
 
 const populatedSettings: ArticleSettings = {
   author: { name: 'Varun Kelkar', initials: 'VK' },
@@ -38,42 +49,15 @@ const populatedSettings: ArticleSettings = {
   ],
 };
 
+const customSettings: ArticleSettings = populatedSettings;
+
 const meta: Meta<typeof ArticleSettingsPanel> = {
   title: 'Components/Article/Article Settings Panel',
   component: ArticleSettingsPanel,
   parameters: { layout: 'padded' },
-  args: {
-    value: populatedSettings,
-    defaultCollapsed: false,
-  },
-  render: (args) => (
-    <div style={CANVAS}>
-      <ArticleSettingsPanel {...args} />
-    </div>
-  ),
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
-
-export const Default: StoryObj<typeof ArticleSettingsPanel> = {};
-
-/* ─────────────────────────────────────────────────────────────
- * Custom SEO Section
- *
- * Demonstrates the full new composition API on `ArticleSettingsPanel`:
- *   1. `sections`  — replace the 8 built-in fields with a hand-composed list
- *                    that uses the lifted atoms (FieldBox, ChevronSuffix,
- *                    Placeholder, CharCounter, TagChip, AddChipButton). Eight
- *                    of these match the built-in defaults; the ninth adds a
- *                    new "SEO Description" textarea section that the panel
- *                    has no built-in equivalent for.
- *   2. `headerSlot` — a small text-only "Custom layout" pill rendered on the
- *                     right side of the panel header.
- *   3. `footerSlot` — a single muted line below the divider explaining that
- *                     SEO fields are auto-checked on publish.
- *
- * The panel chrome (border, shadow, padding, header, divider) is rendered by
- * the panel itself and is byte-identical to the Default story.
- * ───────────────────────────────────────────────────────────── */
 
 function CustomSeoDescriptionSection({
   value,
@@ -96,9 +80,7 @@ function CustomSeoDescriptionSection({
   );
 }
 
-const customSettings: ArticleSettings = populatedSettings;
-
-function CustomSeoSectionRender() {
+function ArticleSettingsPanelPlayground() {
   const [seoDescription, setSeoDescription] = React.useState('');
   const [tags, setTags] = React.useState<string[]>(customSettings.tags ?? []);
   const [slug, setSlug] = React.useState<string>(customSettings.slug ?? '');
@@ -280,19 +262,16 @@ function CustomSeoSectionRender() {
   );
 
   return (
-    <div style={CANVAS}>
-      <ArticleSettingsPanel
-        value={customSettings}
-        defaultCollapsed={false}
-        sections={sections}
-        headerSlot={headerPill}
-        footerSlot={footerNote}
-      />
-    </div>
+    <ArticleSettingsPanel
+      value={customSettings}
+      defaultCollapsed={false}
+      sections={sections}
+      headerSlot={headerPill}
+      footerSlot={footerNote}
+    />
   );
 }
 
-export const CustomSEOSection: StoryObj<typeof ArticleSettingsPanel> = {
-  name: 'Custom SEO Section',
-  render: () => <CustomSeoSectionRender />,
+export const Playground: StoryObj<typeof ArticleSettingsPanel> = {
+  render: () => <ArticleSettingsPanelPlayground />,
 };

--- a/packages/kb-ui/src/components/content/ContentEditor.stories.tsx
+++ b/packages/kb-ui/src/components/content/ContentEditor.stories.tsx
@@ -4,6 +4,14 @@ import '../../tokens.css';
 import { ContentEditor, DEFAULT_TOOLBAR_ITEMS, type ToolbarItemDef } from './ContentEditor';
 import type { SlashCommand } from './SlashCommandMenu';
 
+/* ─────────────────────────────────────────────────────────────
+ * ContentEditor Playground — single richest demo of the editor:
+ * a fully-populated Tiptap article (SAMPLE_HTML) PLUS a custom
+ * toolbar (bold/italic/link + an "uppercase selection" magic
+ * action) PLUS a custom slash command (Callout). Demonstrates
+ * the editor with content AND extension hooks on one screen.
+ * ───────────────────────────────────────────────────────────── */
+
 const SAMPLE_HTML = `
 <h1>How to Reset Your Password</h1>
 <p>Your Hiver account password can be reset through several methods depending on how you access the platform. This guide covers all available reset options for both standard accounts and SSO-managed accounts.</p>
@@ -56,25 +64,6 @@ console.log(status.expiresAt);</code></pre>
 <blockquote>Passwords must be at least 12 characters and include uppercase, lowercase, a number, and a symbol.</blockquote>
 `.trim();
 
-const meta: Meta<typeof ContentEditor> = {
-  title: 'Components/Article/Content Editor',
-  component: ContentEditor,
-  parameters: { layout: 'padded' },
-  args: {
-    initialContent: SAMPLE_HTML,
-    placeholder: 'Start writing your article…',
-    readOnly: false,
-  },
-  render: (args) => (
-    <div style={{ background: '#f5f5f5', padding: 32, minHeight: 900 }}>
-      <ContentEditor {...args} />
-    </div>
-  ),
-};
-export default meta;
-
-export const Default: StoryObj<typeof ContentEditor> = {};
-
 const customToolbar: ToolbarItemDef[] = [
   ...DEFAULT_TOOLBAR_ITEMS.filter((i) => ['bold', 'italic', 'link'].includes(i.id)),
   {
@@ -113,13 +102,28 @@ const customSlash: SlashCommand[] = [
   },
 ];
 
-export const CustomToolbarAndSlash: StoryObj<typeof ContentEditor> = {
-  name: 'Custom Toolbar and Slash',
-  args: {
-    initialContent: SAMPLE_HTML,
-    placeholder: 'Start writing your article…',
-    readOnly: false,
-    toolbarItems: customToolbar,
-    slashCommands: customSlash,
-  },
+const meta: Meta<typeof ContentEditor> = {
+  title: 'Components/Article/Content Editor',
+  component: ContentEditor,
+  parameters: { layout: 'padded' },
+  globals: { backgrounds: { value: 'canvas' } },
+};
+export default meta;
+
+function ContentEditorPlayground() {
+  return (
+    <div className="min-h-[900px]">
+      <ContentEditor
+        initialContent={SAMPLE_HTML}
+        placeholder="Start writing your article…"
+        readOnly={false}
+        toolbarItems={customToolbar}
+        slashCommands={customSlash}
+      />
+    </div>
+  );
+}
+
+export const Playground: StoryObj<typeof ContentEditor> = {
+  render: () => <ContentEditorPlayground />,
 };

--- a/packages/kb-ui/src/components/content/DataTable.stories.tsx
+++ b/packages/kb-ui/src/components/content/DataTable.stories.tsx
@@ -1,25 +1,22 @@
 import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import '../../tokens.css';
-import { RiFile3Line, RiArrowRightSLine } from '@remixicon/react';
+import { RiFile3Line } from '@remixicon/react';
 import { DataTable, type DataTableColumn } from './DataTable';
 import { Badge } from '../primitives/Badge';
 import { Avatar } from '../primitives/Avatar';
-import { HelpfulnessTag } from './HelpfulnessTag';
+import { Card } from '../primitives/Card';
 
 /* ─────────────────────────────────────────────────────────────
- * DataTable canonical stories — covers every layout shape that
- * the 7 legacy tables previously rendered:
+ * DataTable Playground — full article-management table.
  *
- *   Default                 wrapped + header-divider, h-12 rows,
- *                           default `cellPaddingY={12}`.
- *   No card wrapper         `wrapped={false}` + chrome — matches
- *                           the legacy ArticlesTable / SubCategoriesTable
- *                           rendering used inside the editor.
- *   No header divider       `headerDivider={false}` — matches
- *                           SearchKeywordsTable (Figma `1974:54404`).
- *   With row click          `onRowClick` — surfaces the hover
- *                           pill + cursor.
+ * Renders the canonical "All articles" table with 12 realistic
+ * Hiver KB rows, all four columns (title + file icon, status
+ * badge, author avatar, last-updated date), and a clickable row
+ * handler so the hover pill + cursor surface naturally.
+ *
+ * Wrapped in a real `<Card padding="none">` so the chrome is the
+ * production card chrome, not a hand-rolled bg-white sandbox.
  * ───────────────────────────────────────────────────────────── */
 
 type Article = {
@@ -31,27 +28,18 @@ type Article = {
 };
 
 const ARTICLES: Article[] = [
-  {
-    id: 'a1',
-    title: 'How to set up your first workspace',
-    status: 'published',
-    authorInitials: 'RM',
-    lastUpdated: 'Apr 12, 2026',
-  },
-  {
-    id: 'a2',
-    title: 'Invite teammates and assign roles',
-    status: 'draft',
-    authorInitials: 'SK',
-    lastUpdated: 'Apr 10, 2026',
-  },
-  {
-    id: 'a3',
-    title: 'Understanding your billing cycle',
-    status: 'published',
-    authorInitials: 'JL',
-    lastUpdated: 'Apr 08, 2026',
-  },
+  { id: 'a1',  title: 'How to reset your password',                              status: 'published', authorInitials: 'VK', lastUpdated: 'Apr 28, 2026' },
+  { id: 'a2',  title: 'Setting up SSO with Okta or Google Workspace',            status: 'published', authorInitials: 'AK', lastUpdated: 'Apr 26, 2026' },
+  { id: 'a3',  title: 'Migrating from Confluence to Hiver KB',                   status: 'draft',     authorInitials: 'MR', lastUpdated: 'Apr 25, 2026' },
+  { id: 'a4',  title: 'Enabling two-factor authentication for your team',        status: 'published', authorInitials: 'TS', lastUpdated: 'Apr 22, 2026' },
+  { id: 'a5',  title: 'Bulk-importing contacts via CSV',                         status: 'published', authorInitials: 'VK', lastUpdated: 'Apr 21, 2026' },
+  { id: 'a6',  title: 'Configuring shared inbox routing rules',                  status: 'draft',     authorInitials: 'AK', lastUpdated: 'Apr 19, 2026' },
+  { id: 'a7',  title: 'Managing user permissions and roles',                     status: 'published', authorInitials: 'MR', lastUpdated: 'Apr 17, 2026' },
+  { id: 'a8',  title: 'Connecting Hiver to Slack',                               status: 'published', authorInitials: 'TS', lastUpdated: 'Apr 15, 2026' },
+  { id: 'a9',  title: 'Legacy API removal — migration guide',                    status: 'draft',     authorInitials: 'VK', lastUpdated: 'Apr 14, 2026' },
+  { id: 'a10', title: 'Understanding billing and usage',                         status: 'published', authorInitials: 'AK', lastUpdated: 'Apr 11, 2026' },
+  { id: 'a11', title: 'Customising notification preferences',                    status: 'published', authorInitials: 'MR', lastUpdated: 'Apr 09, 2026' },
+  { id: 'a12', title: 'Exporting analytics reports as CSV or PDF',               status: 'draft',     authorInitials: 'TS', lastUpdated: 'Apr 07, 2026' },
 ];
 
 const articleColumns: DataTableColumn<Article>[] = [
@@ -96,166 +84,31 @@ const articleColumns: DataTableColumn<Article>[] = [
   },
 ];
 
-type AttentionRow = {
-  id: string;
-  title: string;
-  helpfulness: string;
-  variant: 'up' | 'down';
-};
-
-const ATTENTION_ROWS: AttentionRow[] = [
-  { id: '1', title: 'Syncing past emails while creating', helpfulness: '24%', variant: 'down' },
-  { id: '2', title: 'How to Sync Previous Emails Whe...', helpfulness: '31%', variant: 'down' },
-  { id: '3', title: 'Setting Up a New Shared Mailbox:', helpfulness: '91%', variant: 'up' },
-  { id: '4', title: 'Creating a New Shared Mailbox? H...', helpfulness: '95%', variant: 'up' },
-];
-
-const attentionColumns: DataTableColumn<AttentionRow>[] = [
-  {
-    id: 'title',
-    header: 'Article Title',
-    render: (r) => (
-      <div className="flex items-center gap-2 min-w-0 pr-2">
-        <RiFile3Line size={16} className="shrink-0 text-[#64758b]" aria-hidden="true" />
-        <span className="truncate">{r.title}</span>
-      </div>
-    ),
-  },
-  {
-    id: 'helpfulness',
-    header: 'Helpfulness',
-    align: 'right',
-    render: (r) => <HelpfulnessTag value={r.helpfulness} variant={r.variant} />,
-  },
-];
-
-type Keyword = { id: string; keyword: string; count: string };
-const KEYWORDS: Keyword[] = [
-  { id: '1', keyword: '1. password reset', count: '11200' },
-  { id: '2', keyword: '2. billing duplicate charges', count: '1200' },
-  { id: '3', keyword: '3. slack integration', count: '200' },
-];
-
-const keywordColumns: DataTableColumn<Keyword>[] = [
-  { id: 'keyword', header: 'Keywords', render: (r) => r.keyword },
-  { id: 'count', header: 'Search Count', align: 'right', render: (r) => r.count },
-];
-
-type Cat = { id: string; title: string };
-const CATS: Cat[] = [
-  { id: 'c1', title: 'Organize email conversations' },
-  { id: 'c2', title: 'Shared Inbox Management' },
-];
-
 const meta: Meta<typeof DataTable> = {
   title: 'Components/Tables/DataTable',
   component: DataTable as React.ComponentType<unknown>,
-  parameters: { layout: 'padded', backgrounds: { default: 'canvas' } },
-  argTypes: {
-    headerDivider: { control: 'boolean' },
-    wrapped: { control: 'boolean' },
-    cellPaddingY: { control: 'number' },
-  },
+  parameters: { layout: 'padded' },
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-type Story = StoryObj<typeof DataTable>;
+function DataTablePlayground() {
+  return (
+    <Card padding="none" style={{ width: 920 }}>
+      <h3 className="text-[14px] font-medium leading-[20px] text-[#0f172a] px-6 pt-5">
+        All articles
+      </h3>
+      <DataTable
+        rows={ARTICLES}
+        columns={articleColumns}
+        wrapped={false}
+        unwrappedChrome={false}
+        onRowClick={() => {}}
+      />
+    </Card>
+  );
+}
 
-export const Default: Story = {
-  render: () => (
-    <div style={{ background: '#ffffff', padding: 24, minHeight: 360 }}>
-      <div style={{ width: 890 }}>
-        <DataTable
-          rows={ATTENTION_ROWS}
-          columns={attentionColumns}
-          heading={
-            <h3 className="text-[14px] font-medium leading-[20px] text-[#0f172a]">
-              Articles needs attention
-            </h3>
-          }
-        />
-      </div>
-    </div>
-  ),
-};
-
-/** Unwrapped chrome — legacy ArticlesTable / SubCategoriesTable rendering. */
-export const NoCardWrapper: Story = {
-  render: () => (
-    <div style={{ background: '#ffffff', padding: 24, minHeight: 360 }}>
-      <div style={{ width: 880 }}>
-        <DataTable
-          rows={ARTICLES}
-          columns={articleColumns}
-          wrapped={false}
-          headerBackground="#f5f5f5"
-          cellPaddingY={6}
-          onRowClick={() => {
-            // eslint-disable-next-line no-console
-            console.log('row click');
-          }}
-        />
-      </div>
-    </div>
-  ),
-};
-
-/** SearchKeywordsTable — no header divider (just whitespace). */
-export const NoHeaderDivider: Story = {
-  render: () => (
-    <div style={{ background: '#ffffff', padding: 24, minHeight: 360 }}>
-      <div style={{ width: 890 }}>
-        <DataTable
-          rows={KEYWORDS}
-          columns={keywordColumns}
-          headerDivider={false}
-          heading={
-            <h3 className="text-[14px] font-medium leading-[20px] text-[#0f172a]">
-              Top 5 Search Keywords
-            </h3>
-          }
-        />
-      </div>
-    </div>
-  ),
-};
-
-/** Hover + cursor — active row-click handler. */
-export const WithRowClick: Story = {
-  render: () => (
-    <div style={{ background: '#ffffff', padding: 24, minHeight: 360 }}>
-      <div style={{ width: 880 }}>
-        <DataTable
-          rows={CATS}
-          columns={[
-            {
-              id: 'title',
-              header: 'Sub-categories',
-              render: (c) => c.title,
-            },
-            {
-              id: 'chev',
-              header: '',
-              align: 'right',
-              width: 48,
-              render: () => (
-                <RiArrowRightSLine
-                  size={16}
-                  className="text-[#64758b]"
-                  aria-hidden="true"
-                />
-              ),
-            },
-          ]}
-          wrapped={false}
-          headerBackground="#f5f5f5"
-          cellPaddingY={6}
-          onRowClick={(c) => {
-            // eslint-disable-next-line no-console
-            console.log('clicked', c.id);
-          }}
-        />
-      </div>
-    </div>
-  ),
+export const Playground: StoryObj<typeof DataTable> = {
+  render: () => <DataTablePlayground />,
 };

--- a/packages/kb-ui/src/components/content/DateRangePill.stories.tsx
+++ b/packages/kb-ui/src/components/content/DateRangePill.stories.tsx
@@ -1,32 +1,22 @@
+import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import '../../tokens.css';
-import { DateRangePill } from './DateRangePill';
+import { DateRangePill, type DateRange } from './DateRangePill';
 
 const meta: Meta<typeof DateRangePill> = {
   title: 'Components/Layout/Date Range Pill',
   component: DateRangePill,
   parameters: { layout: 'centered' },
-  args: {
-    value: '7d',
-  },
-  render: (args) => (
-    <div className="bg-white p-6">
-      <DateRangePill {...args} />
-    </div>
-  ),
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof DateRangePill> = {};
+function DateRangePillPlayground() {
+  const [value, setValue] = React.useState<DateRange>('7d');
 
-export const CustomPresets: StoryObj<typeof DateRangePill> = {
-  name: 'Custom Presets',
-  args: {
-    value: 'today' as never,
-    presets: [
-      { value: 'today', label: 'Today' },
-      { value: 'yesterday', label: 'Yesterday' },
-      { value: 'this-quarter', label: 'This Quarter' },
-    ],
-  },
+  return <DateRangePill value={value} onChange={(v) => setValue(v)} />;
+}
+
+export const Playground: StoryObj<typeof DateRangePill> = {
+  render: () => <DateRangePillPlayground />,
 };

--- a/packages/kb-ui/src/components/content/HelpfulnessTag.stories.tsx
+++ b/packages/kb-ui/src/components/content/HelpfulnessTag.stories.tsx
@@ -1,16 +1,52 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../tokens.css';
 import { HelpfulnessTag } from './HelpfulnessTag';
+import { Card } from '../primitives/Card';
 
 const meta: Meta<typeof HelpfulnessTag> = {
   title: 'Components/Article/Helpfulness Tag',
   component: HelpfulnessTag,
-  parameters: { layout: 'centered' },
-  args: {
-    value: '91%',
-    variant: 'up',
-  },
-  render: (args) => <HelpfulnessTag {...args} />,
+  parameters: { layout: 'padded' },
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof HelpfulnessTag> = {};
+type ArticleRow = {
+  title: string;
+  value: string;
+  variant: 'up' | 'down';
+};
+
+const ARTICLES: ArticleRow[] = [
+  { title: 'Reset your password', value: '91%', variant: 'up' },
+  { title: 'Setting up SSO with Okta', value: '24%', variant: 'down' },
+  { title: 'Migrating from Confluence to Hiver', value: '72%', variant: 'up' },
+  { title: 'Legacy API removal guide', value: '12%', variant: 'down' },
+  { title: 'Enabling two-factor authentication', value: '88%', variant: 'up' },
+  { title: 'Bulk-importing contacts via CSV', value: '66%', variant: 'up' },
+];
+
+function HelpfulnessTagPlayground() {
+  return (
+    <Card padding="md" style={{ width: 480 }}>
+      <h3 className="text-[14px] font-semibold text-[#0f172a] mb-3">
+        Helpfulness — last 30 days
+      </h3>
+      <ul>
+        {ARTICLES.map((article) => (
+          <li
+            key={article.title}
+            className="flex items-center justify-between py-2"
+          >
+            <span className="text-[14px] text-[#0f172a]">{article.title}</span>
+            <HelpfulnessTag value={article.value} variant={article.variant} />
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+}
+
+export const Playground: StoryObj<typeof HelpfulnessTag> = {
+  render: () => <HelpfulnessTagPlayground />,
+};

--- a/packages/kb-ui/src/components/content/PageHeader.stories.tsx
+++ b/packages/kb-ui/src/components/content/PageHeader.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import '../../tokens.css';
-import { RiBookOpenLine } from '@remixicon/react';
+import { RiBookOpenLine, RiAddLine } from '@remixicon/react';
 import { PageHeader } from './PageHeader';
 import { Button } from '../primitives/Button';
 
@@ -8,32 +8,29 @@ const meta: Meta<typeof PageHeader> = {
   title: 'Components/Layout/Page Header',
   component: PageHeader,
   parameters: { layout: 'padded' },
-  args: {
-    title: 'Getting Started',
-    subtitle: '12 articles · 3 sub-categories',
-    onNewClick: () => {},
-  },
-  render: (args) => (
-    <div style={{ background: '#f5f5f5', padding: 24, minHeight: 240 }}>
-      <PageHeader
-        {...args}
-        icon={<RiBookOpenLine className="size-[22px] text-blue-500" />}
-      />
-    </div>
-  ),
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof PageHeader> = {};
+function PageHeaderPlayground() {
+  return (
+    <PageHeader
+      title="Getting Started"
+      subtitle="12 articles · 3 sub-categories · Last updated 4 days ago"
+      icon={<RiBookOpenLine className="size-[22px] text-blue-500" />}
+      cta={
+        <Button
+          variant="primary"
+          icon={<RiAddLine size={14} />}
+          onClick={() => {}}
+        >
+          New article
+        </Button>
+      }
+    />
+  );
+}
 
-export const CustomCTA: StoryObj<typeof PageHeader> = {
-  name: 'Custom CTA',
-  render: () => (
-    <div style={{ background: '#f5f5f5', padding: 24, minHeight: 240 }}>
-      <PageHeader
-        title="Compliance Dashboard"
-        cta={<Button variant="primary" onClick={() => {}}>Export report</Button>}
-      />
-    </div>
-  ),
+export const Playground: StoryObj<typeof PageHeader> = {
+  render: () => <PageHeaderPlayground />,
 };

--- a/packages/kb-ui/src/components/content/StatCard.stories.tsx
+++ b/packages/kb-ui/src/components/content/StatCard.stories.tsx
@@ -6,18 +6,23 @@ const meta: Meta<typeof StatCard> = {
   title: 'Components/Charts & Stats/Stat Card',
   component: StatCard,
   parameters: { layout: 'padded' },
-  args: {
-    label: 'Total Views',
-    value: '112,678',
-    trendDelta: '+15%',
-    trendDirection: 'up',
-  },
-  render: (args) => (
-    <div className="bg-white p-6">
-      <StatCard {...args} />
-    </div>
-  ),
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof StatCard> = {};
+function StatCardPlayground() {
+  return (
+    <div className="mx-auto w-full max-w-[320px]">
+      <StatCard
+        label="Total Views"
+        value="112,678"
+        trendDelta="+15.2%"
+        trendDirection="up"
+      />
+    </div>
+  );
+}
+
+export const Playground: StoryObj<typeof StatCard> = {
+  render: () => <StatCardPlayground />,
+};

--- a/packages/kb-ui/src/components/content/StatCardGrid.stories.tsx
+++ b/packages/kb-ui/src/components/content/StatCardGrid.stories.tsx
@@ -1,50 +1,35 @@
+import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import '../../tokens.css';
 import { StatCardGrid } from './StatCardGrid';
-import { Button } from '../primitives/Button';
+import { DateRangePill, type DateRange } from './DateRangePill';
 
 const meta: Meta<typeof StatCardGrid> = {
   title: 'Components/Charts & Stats/Stat Card Grid',
   component: StatCardGrid,
-  parameters: { layout: 'padded', backgrounds: { default: 'app' } },
-  args: {
-    title: 'Support Performance',
-    infoTooltip: 'High-level KB metrics over the selected time range.',
-    stats: [
-      { label: 'Total Views', value: '112,678', trendDelta: '+15%', trendDirection: 'up' },
-      { label: 'Total Searches', value: '321,950', trendDelta: '+15%', trendDirection: 'up' },
-      {
-        label: 'Missed Search Rate',
-        value: '70.2%',
-        trendDelta: '+15%',
-        trendDirection: 'up',
-      },
-      {
-        label: 'AI Deflection Rate',
-        value: '19.8%',
-        trendDelta: '+12%',
-        trendDirection: 'down',
-      },
-    ],
-  },
-  render: (args) => (
-    <div className="bg-[#f8fafc] p-6" style={{ width: 938 }}>
-      <StatCardGrid {...args} />
-    </div>
-  ),
+  parameters: { layout: 'padded' },
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof StatCardGrid> = {};
+function StatCardGridPlayground() {
+  const [range, setRange] = React.useState<DateRange>('30d');
 
-export const CustomHeaderSlot: StoryObj<typeof StatCardGrid> = {
-  name: 'Custom Header Slot',
-  args: {
-    title: 'Engagement',
-    headerRight: (
-      <Button variant="ghost" onClick={() => {}}>
-        View all
-      </Button>
-    ),
-  },
+  return (
+    <StatCardGrid
+      title="Support Performance — Last 30 days"
+      infoTooltip="Volume, search quality, and deflection metrics for your knowledge base across the selected window."
+      stats={[
+        { label: 'Total Views', value: '112,678', trendDelta: '+15%', trendDirection: 'up' },
+        { label: 'Total Searches', value: '321,950', trendDelta: '+8%', trendDirection: 'up' },
+        { label: 'Missed Search Rate', value: '70.2%', trendDelta: '+2.1%', trendDirection: 'up' },
+        { label: 'AI Deflection Rate', value: '19.8%', trendDelta: '−3%', trendDirection: 'down' },
+      ]}
+      headerRight={<DateRangePill value={range} onChange={(v) => setRange(v)} />}
+    />
+  );
+}
+
+export const Playground: StoryObj<typeof StatCardGrid> = {
+  render: () => <StatCardGridPlayground />,
 };

--- a/packages/kb-ui/src/components/content/SuggestionBlock.stories.tsx
+++ b/packages/kb-ui/src/components/content/SuggestionBlock.stories.tsx
@@ -11,7 +11,7 @@ import { SuggestionBlock } from './SuggestionBlock';
 const CANVAS: React.CSSProperties = {
   background: '#ffffff',
   padding: 32,
-  maxWidth: 620,
+  width: 620,
 };
 
 const BODY_TYPE: React.CSSProperties = {
@@ -40,6 +40,11 @@ const H3: React.CSSProperties = {
 const PARA: React.CSSProperties = {
   ...BODY_TYPE,
   margin: '8px 0 0 0',
+};
+
+const ARTICLE_PARA: React.CSSProperties = {
+  ...BODY_TYPE,
+  margin: '12px 0 0 0',
 };
 
 const LIST: React.CSSProperties = {
@@ -89,21 +94,35 @@ const meta: Meta<typeof SuggestionBlock> = {
   title: 'Components/AI/Suggestion Block',
   component: SuggestionBlock,
   parameters: { layout: 'padded' },
-  args: {
-    type: 'addition',
-  },
-  render: (args) => (
-    <div style={CANVAS}>
-      <SuggestionBlock
-        {...args}
-        oldContent={OLD_CONTENT}
-        newContent={NEW_CONTENT}
-      >
-        {args.type === 'removal' ? REMOVAL_CONTENT : ADDITION_CONTENT}
-      </SuggestionBlock>
-    </div>
-  ),
+  globals: { backgrounds: { value: 'white' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof SuggestionBlock> = {};
+function SuggestionBlockPlayground() {
+  return (
+    <div style={CANVAS}>
+      <h2 style={H2}>Reset Your Password</h2>
+      <p style={ARTICLE_PARA}>
+        If you&apos;ve forgotten your Hiver password, you can reset it in a few
+        steps. The process below covers the standard web flow — additional
+        guidance for our mobile and extension surfaces is included where
+        relevant.
+      </p>
+      <SuggestionBlock type="addition" oldContent={OLD_CONTENT} newContent={NEW_CONTENT}>
+        {ADDITION_CONTENT}
+      </SuggestionBlock>
+      <p style={ARTICLE_PARA}>
+        Once your password is reset, you&apos;ll be signed out of all active
+        sessions across web, mobile, and the Chrome extension. Sign back in with
+        your new credentials to resume.
+      </p>
+      <SuggestionBlock type="removal" oldContent={OLD_CONTENT} newContent={NEW_CONTENT}>
+        {REMOVAL_CONTENT}
+      </SuggestionBlock>
+    </div>
+  );
+}
+
+export const Playground: StoryObj<typeof SuggestionBlock> = {
+  render: () => <SuggestionBlockPlayground />,
+};

--- a/packages/kb-ui/src/components/content/SuggestionCard.stories.tsx
+++ b/packages/kb-ui/src/components/content/SuggestionCard.stories.tsx
@@ -6,74 +6,98 @@ import {
   DEFAULT_SUGGESTION_KINDS,
 } from './SuggestionCard';
 
-// Mirrors the brand-pink constant in SuggestionCard.tsx so custom kinds
-// register glyphs that read as part of the same visual family.
+/* ─────────────────────────────────────────────────────────────
+ * SuggestionCard Playground — vertical column of 5 realistic
+ * AI suggestions. Mixes all three default kinds (article-edit,
+ * move-article, new-article) plus a custom `merge-articles`
+ * kind registered via `kindRegistry`. The last card overrides
+ * the title icon via the `icon` prop to demonstrate that hook.
+ *
+ * No outer card wrapper — the canvas-grey global background
+ * is the page surface, matching how these cards stack inside
+ * the Suggestions rail.
+ * ───────────────────────────────────────────────────────────── */
+
+// Mirrors the brand-pink constant in SuggestionCard.tsx so custom
+// kinds register glyphs that read as part of the same visual family.
 const PINK = '#D92FFF';
 
 const meta: Meta<typeof SuggestionCard> = {
   title: 'Components/AI/Suggestion Card',
   component: SuggestionCard,
   parameters: { layout: 'padded' },
-  args: {
-    title: 'How to reset Password',
-    description: 'Updating reset instructions, legacy URL and removing outdated instructions',
-    kind: 'article-edit',
-    conversationCount: 12,
-    impact: 'high',
-    pathFrom: 'Billing',
-    pathTo: 'Reimbursements',
-    onClick: () => {},
-  },
-  render: (args) => (
-    <div className="bg-white p-6 max-w-[600px]">
-      <SuggestionCard {...args} />
-    </div>
-  ),
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof SuggestionCard> = {};
+function SuggestionCardPlayground() {
+  // Extend the default kind registry with a project-specific
+  // `merge-articles` kind. Spreading DEFAULT_SUGGESTION_KINDS
+  // first preserves the built-ins so cards using `article-edit`
+  // / `move-article` / `new-article` keep their canonical glyphs.
+  const kindRegistry = {
+    ...DEFAULT_SUGGESTION_KINDS,
+    'merge-articles': {
+      label: 'Merge Articles',
+      icon: <RiGitMergeLine size={16} color={PINK} />,
+    },
+  };
 
-// Demonstrates the three new extension hooks: kindRegistry, meta, icon.
-// First card adds a brand-new `merge-articles` kind via kindRegistry +
-// passes a custom `meta` slot. Second card overrides the title icon.
-export const CustomKindAndMeta: StoryObj<typeof SuggestionCard> = {
-  name: 'Custom Kind & Meta',
-  render: () => {
-    const kindRegistry = {
-      ...DEFAULT_SUGGESTION_KINDS,
-      'merge-articles': {
-        label: 'Merge Articles',
-        icon: <RiGitMergeLine size={16} color={PINK} />,
-      },
-    };
+  return (
+    <div className="flex flex-col gap-3 max-w-[640px]">
+      <SuggestionCard
+        title="How to reset your password"
+        description="Updating reset instructions, removing legacy mobile-app URL, and clarifying the recovery email step."
+        kind="article-edit"
+        conversationCount={12}
+        impact="high"
+        onClick={() => {}}
+      />
+      <SuggestionCard
+        title='Move "Billing duplicate charges" to Reimbursements'
+        description="Article currently lives under Billing but 78% of viewers reach it from a Reimbursements search."
+        kind="move-article"
+        pathFrom="Billing"
+        pathTo="Reimbursements"
+        conversationCount={8}
+        impact="medium"
+        onClick={() => {}}
+      />
+      <SuggestionCard
+        title='Merge duplicate "Setting up SSO" articles'
+        description="Two articles cover the same Okta SSO flow — combining them avoids content drift."
+        kind="merge-articles"
+        kindRegistry={kindRegistry}
+        conversationCount={4}
+        impact="medium"
+        meta={
+          <span className="text-[12px] font-medium text-[#475569]">
+            Last edited 3h ago
+          </span>
+        }
+        onClick={() => {}}
+      />
+      <SuggestionCard
+        title='Add a new article: "Bulk-deleting old conversations"'
+        description="No existing article covers this — 23 search misses in the last 14 days."
+        kind="new-article"
+        conversationCount={23}
+        impact="high"
+        onClick={() => {}}
+      />
+      <SuggestionCard
+        title='Refresh AI-suggested rewrites for "Two-factor authentication"'
+        description="Helpfulness dropped from 91% to 64% over the last 30 days."
+        kind="article-edit"
+        icon={<RiSparkling2Line size={18} color={PINK} />}
+        conversationCount={9}
+        impact="high"
+        onClick={() => {}}
+      />
+    </div>
+  );
+}
 
-    return (
-      <div className="bg-white p-6 max-w-[600px] flex flex-col gap-[16px]">
-        <SuggestionCard
-          title="Merge duplicate Password Reset guides"
-          description="Two articles cover the same flow — combining them avoids drift."
-          kind="merge-articles"
-          kindRegistry={kindRegistry}
-          conversationCount={4}
-          impact="medium"
-          meta={
-            <span className="text-[14px] font-medium text-[#475569]">
-              Last edited 3h ago
-            </span>
-          }
-          onClick={() => {}}
-        />
-        <SuggestionCard
-          title="Refresh AI-suggested rewrites"
-          description="Custom title icon override demonstrating the `icon` prop."
-          kind="article-edit"
-          icon={<RiSparkling2Line size={18} color={PINK} />}
-          conversationCount={9}
-          impact="high"
-          onClick={() => {}}
-        />
-      </div>
-    );
-  },
+export const Playground: StoryObj<typeof SuggestionCard> = {
+  render: () => <SuggestionCardPlayground />,
 };


### PR DESCRIPTION
Rolls the Phase 14.1 production-readiness pattern across all 18 content components. Each story now renders a single \`Playground\` with realistic Hiver-KB data on the appropriate canvas (grey for content surfaces, white for inline-in-article components).

**Components refined (18):**
- 14.2a — PageHeader, StatCard, StatCardGrid, DateRangePill
- 14.2b — HelpfulnessTag, SuggestionBlock, AnalyticsDonutChart
- 14.2c — AnalyticsAreaChart, AnalyticsChartCard (30-day time-series)
- 14.2d — DataTable (12 articles), SuggestionCard (5 cards), AISuggestionsCard (3 modes)
- 14.2e — AIConversationLogEntry, AIConversationLogsCard (5 conversations), AIGapSuggestionCard (3 stacked)
- 14.2f — ArticleBody, ArticleSettingsPanel, ContentEditor

**Pattern applied uniformly:**
- Single \`Playground\` named export per file
- Real component composition where possible (StatCardGrid renders a real DateRangePill in headerRight, AnalyticsChartCard composes AnalyticsAreaChart)
- Real \`useState\` wiring for interactive controls (DateRangePill, AIConversationLogsCard sort, ArticleSettingsPanel inputs)
- Rich realistic content — 12 articles, 30-day datasets, real KB category names, real conversation logs with follow-ups and tickets

Test plan:
- [x] typecheck + build-storybook + boot
- [ ] Eyeball preview URL — every content story should feel like a real Hiver KB surface, not a screenshot