### PR TITLE
feat(kb-ui): Phase 14.3 — 6 shell/nav/overlays components refined

### DIFF
--- a/packages/kb-ui/src/components/nav/FileExplorerNav.stories.tsx
+++ b/packages/kb-ui/src/components/nav/FileExplorerNav.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import * as React from 'react';
 import '../../tokens.css';
 import { FileExplorerNav, type NavItem } from './FileExplorerNav';
 
@@ -81,39 +82,50 @@ const tree: NavItem[] = [
   },
 ];
 
+// Walk the tree to resolve the active item's title for the right-pane label.
+function findTitle(items: NavItem[], id: string): string | null {
+  for (const item of items) {
+    if (item.id === id) return item.title;
+    if (item.children && item.children.length > 0) {
+      const sub = findTitle(item.children, id);
+      if (sub) return sub;
+    }
+  }
+  return null;
+}
+
+function FileExplorerNavPlayground() {
+  const [activeId, setActiveId] = React.useState<string>('tut-organize');
+  const activeTitle = findTitle(tree, activeId) ?? activeId;
+
+  return (
+    <div className="flex h-screen">
+      <FileExplorerNav
+        theme="light"
+        title="Editor"
+        items={tree}
+        activeId={activeId}
+        onItemClick={(id) => setActiveId(id)}
+        variant="tree"
+        showSearch={true}
+      />
+      <div className="flex-1 bg-[#f5f5f5] flex items-center justify-center">
+        <span className="text-[14px] text-[#64758b]">
+          Editing: {activeTitle}
+        </span>
+      </div>
+    </div>
+  );
+}
+
 const meta: Meta<typeof FileExplorerNav> = {
   title: 'Components/Navigation/FileExplorerNav',
   component: FileExplorerNav,
   parameters: { layout: 'fullscreen' },
-  args: {
-    theme: 'light',
-    title: 'Editor',
-    items: tree,
-    activeId: 'tut-organize',
-    variant: 'tree',
-    showSearch: true,
-  },
-  render: (args) => (
-    <div style={{ height: '100vh', display: 'flex' }}>
-      <FileExplorerNav {...args} />
-    </div>
-  ),
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof FileExplorerNav> = {};
-
-export const CustomRowRenderer: StoryObj<typeof FileExplorerNav> = {
-  name: 'Custom Row Renderer',
-  args: {
-    items: tree,
-    renderItem: (item, depth) => (
-      <div
-        className="px-2 py-1 text-[12px]"
-        style={{ paddingLeft: 8 + depth * 12 }}
-      >
-        {item.title} (custom)
-      </div>
-    ),
-  },
+export const Playground: StoryObj<typeof FileExplorerNav> = {
+  render: () => <FileExplorerNavPlayground />,
 };

--- a/packages/kb-ui/src/components/nav/SideNavRail.stories.tsx
+++ b/packages/kb-ui/src/components/nav/SideNavRail.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import * as React from "react";
 import "../../tokens.css";
 import {
   RiQuillPenLine,
@@ -17,25 +18,39 @@ const items = [
   { id: "settings", icon: <RiSettings5Line size={16} />, label: "Settings" },
 ];
 
+const labelFor = (id: string) =>
+  items.find((it) => it.id === id)?.label ?? id;
+
+function SideNavRailPlayground() {
+  const [activeId, setActiveId] = React.useState<string>("editor");
+
+  return (
+    <div className="flex h-screen">
+      <SideNavRail
+        theme="light"
+        items={items}
+        activeId={activeId}
+        onItemClick={(id) => setActiveId(id)}
+        brandLogo={<CompanyLogo size={24} />}
+        bottomSlot={<Avatar initials="VK" />}
+      />
+      <div className="flex-1 bg-[#f5f5f5] flex items-center justify-center">
+        <span className="text-[14px] text-[#64758b]">
+          Active section: {labelFor(activeId)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
 const meta: Meta<typeof SideNavRail> = {
   title: "Components/Navigation/SideNavRail",
   component: SideNavRail,
   parameters: { layout: "fullscreen" },
-  args: {
-    theme: "light",
-    items,
-    activeId: "editor",
-  },
-  render: (args) => (
-    <div style={{ height: "100vh", display: "flex" }}>
-      <SideNavRail
-        {...args}
-        brandLogo={<CompanyLogo size={24} />}
-        bottomSlot={<Avatar initials="VK" />}
-      />
-    </div>
-  ),
+  globals: { backgrounds: { value: "canvas" } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof SideNavRail> = {};
+export const Playground: StoryObj<typeof SideNavRail> = {
+  render: () => <SideNavRailPlayground />,
+};

--- a/packages/kb-ui/src/components/overlays/SideSheet.stories.tsx
+++ b/packages/kb-ui/src/components/overlays/SideSheet.stories.tsx
@@ -7,40 +7,73 @@ const meta: Meta<typeof SideSheet> = {
   title: 'Components/Overlays/Side Sheet',
   component: SideSheet,
   parameters: { layout: 'fullscreen' },
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof SideSheet> = {
-  render: () => {
-    const [open, setOpen] = React.useState(false);
-    return (
-      <div className="p-6">
-        <button
-          type="button"
-          onClick={() => setOpen(true)}
-          className="rounded-[6px] border border-[#e5e5e5] bg-white px-3 py-2 text-[14px] font-medium text-[#0f172a] hover:bg-[#f8fafc]"
-        >
-          Open side sheet
-        </button>
-        <SideSheet
-          open={open}
-          onOpenChange={setOpen}
-          title="Citations"
-          count={3}
-        >
-          <div className="flex flex-col gap-3">
-            <div className="rounded-[8px] border border-[#e5e5e5] p-3 text-[14px]">
-              Citation 1
-            </div>
-            <div className="rounded-[8px] border border-[#e5e5e5] p-3 text-[14px]">
-              Citation 2
-            </div>
-            <div className="rounded-[8px] border border-[#e5e5e5] p-3 text-[14px]">
-              Citation 3
-            </div>
-          </div>
-        </SideSheet>
-      </div>
-    );
+const SAMPLE_CITATIONS = [
+  {
+    senderName: 'Ava Johnson',
+    timestamp: 'Feb 4, 2:45 PM',
+    subject: "I can't log into my account.",
+    snippet: "I'm experiencing syncing problems on my devices....",
   },
+  {
+    senderName: 'Sophie Lee',
+    timestamp: 'Feb 4, 9:45 PM',
+    subject: "I can't log into my account.",
+    snippet: "I'm having trouble syncing my devices. My data is...",
+  },
+  {
+    senderName: 'Emma Garcia',
+    timestamp: 'Feb 4, 4:45 PM',
+    subject: "I can't log into my account.",
+    snippet: "I'm facing syncing issues on my devices. My data i...",
+  },
+];
+
+function SideSheetPlayground() {
+  const [open, setOpen] = React.useState(true);
+  return (
+    <div className="bg-[#f5f5f5] min-h-screen p-6">
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded-[6px] border border-[#e5e5e5] bg-white px-3 py-2 text-[14px] font-medium text-[#0f172a] hover:bg-[#f8fafc]"
+      >
+        Open side sheet
+      </button>
+      <SideSheet
+        open={open}
+        onOpenChange={setOpen}
+        title="Sources"
+        count={3}
+      >
+        <div className="flex flex-col gap-3">
+          {SAMPLE_CITATIONS.map((citation) => (
+            <div
+              key={citation.senderName}
+              className="rounded-[8px] border border-[#e5e5e5] p-3 flex flex-col gap-1"
+            >
+              <div className="text-[12px] text-[#64758b] flex items-center gap-2">
+                <span>{citation.senderName}</span>
+                <span>·</span>
+                <span>{citation.timestamp}</span>
+              </div>
+              <div className="text-[14px] font-medium text-[#0f172a]">
+                {citation.subject}
+              </div>
+              <div className="text-[13px] text-[#475569] truncate">
+                {citation.snippet}
+              </div>
+            </div>
+          ))}
+        </div>
+      </SideSheet>
+    </div>
+  );
+}
+
+export const Playground: StoryObj<typeof SideSheet> = {
+  render: () => <SideSheetPlayground />,
 };

--- a/packages/kb-ui/src/components/overlays/SourcesSideSheet.stories.tsx
+++ b/packages/kb-ui/src/components/overlays/SourcesSideSheet.stories.tsx
@@ -1,11 +1,7 @@
 import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import '../../tokens.css';
-import {
-  SourcesSideSheet,
-  SourcesSideSheetMailItem,
-  type ConversationSource,
-} from './SourcesSideSheet';
+import { SourcesSideSheet, type ConversationSource } from './SourcesSideSheet';
 
 const SAMPLE_SOURCES: ConversationSource[] = [
   {
@@ -38,55 +34,42 @@ const SAMPLE_SOURCES: ConversationSource[] = [
   },
 ];
 
+function SourcesSideSheetPlayground() {
+  const [open, setOpen] = React.useState(true);
+  return (
+    <div className="bg-[#f5f5f5] min-h-screen p-8">
+      <div className="mx-auto max-w-[720px] rounded-[12px] border border-[#e5e5e5] bg-white p-6">
+        <h2 className="text-[18px] font-semibold leading-7 text-[#0f172a]">
+          How do I reset my password if I can&apos;t access my recovery email?
+        </h2>
+        <p className="mt-3 text-[14px] leading-6 text-[#475569]">
+          To reset your password without access to your recovery email, follow the 3-step
+          account recovery process: verify your identity using a backup phone number or
+          authenticator app, answer two security questions tied to your account, and confirm
+          a one-time code sent to a trusted device. Once verified, you&apos;ll be prompted
+          to set a new password and re-link a current recovery email.
+        </p>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="mt-4 inline-flex items-center gap-1.5 rounded-[6px] bg-white border border-[#e5e5e5] px-3 py-1.5 text-[13px] font-medium text-[#475569] hover:bg-[#f8fafc]"
+        >
+          View 4 sources
+        </button>
+      </div>
+      <SourcesSideSheet open={open} onOpenChange={setOpen} sources={SAMPLE_SOURCES} />
+    </div>
+  );
+}
+
 const meta: Meta<typeof SourcesSideSheet> = {
   title: 'Components/Overlays/Sources Side Sheet',
   component: SourcesSideSheet,
   parameters: { layout: 'fullscreen' },
-  args: {
-    open: true,
-    sources: SAMPLE_SOURCES,
-  },
-  render: (args) => (
-    <SourcesSideSheet
-      {...args}
-      onOpenChange={() => {}}
-    />
-  ),
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof SourcesSideSheet> = {};
-
-export const CustomItems: StoryObj<typeof SourcesSideSheet> = {
-  name: 'Custom Items',
-  render: () => {
-    const [open, setOpen] = React.useState(true);
-    return (
-      <SourcesSideSheet
-        open={open}
-        onOpenChange={setOpen}
-        sources={[]}
-        count={3}
-        items={[
-          <SourcesSideSheetMailItem
-            senderName="Anjali Kumar"
-            senderEmail="anjali@hiver.com"
-            subject="Welcome to the team"
-            snippet="Excited to have you onboard."
-            timestamp="Feb 4, 2:45 PM"
-          />,
-          <div className="rounded-[8px] border border-dashed border-[#cbd5e1] p-3 text-[14px] text-[#475569]">
-            Custom citation row
-          </div>,
-          <SourcesSideSheetMailItem
-            senderName="Marcus Chen"
-            senderEmail="marcus@hiver.com"
-            subject="Q2 roadmap review"
-            snippet="Sharing the latest deck for tomorrow's sync."
-            timestamp="Feb 5, 10:12 AM"
-          />,
-        ]}
-      />
-    );
-  },
+export const Playground: StoryObj<typeof SourcesSideSheet> = {
+  render: () => <SourcesSideSheetPlayground />,
 };

--- a/packages/kb-ui/src/components/shell/AppShell.stories.tsx
+++ b/packages/kb-ui/src/components/shell/AppShell.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import * as React from 'react';
 import '../../tokens.css';
 import { RiQuillPenLine, RiBarChartBoxLine, RiSettings5Line } from '@remixicon/react';
 import { AppShell } from './AppShell';
@@ -74,23 +75,32 @@ const tree: NavItem[] = [
   },
 ];
 
-const meta: Meta<typeof AppShell> = {
-  title: 'Components/Shell/AppShell',
-  component: AppShell,
-  parameters: { layout: 'fullscreen' },
-  args: {
-    sidebarCollapsed: false,
-  },
-  // AppShell is a layout container with multiple ReactNode slots — slots are
-  // hardcoded in the render wrapper.
-  render: (args) => (
+// Walk the tree to resolve an article id to its title for breadcrumb + heading.
+function findTitle(items: NavItem[], id: string): string | null {
+  for (const item of items) {
+    if (item.id === id) return item.title;
+    if (item.children && item.children.length > 0) {
+      const sub = findTitle(item.children, id);
+      if (sub) return sub;
+    }
+  }
+  return null;
+}
+
+function AppShellPlayground() {
+  const [activeRailId, setActiveRailId] = React.useState<string>('editor');
+  const [activeArticleId, setActiveArticleId] = React.useState<string>('email-views');
+  const activeArticleTitle = findTitle(tree, activeArticleId) ?? activeArticleId;
+
+  return (
     <AppShell
-      {...args}
+      sidebarCollapsed={false}
       rail={
         <SideNavRail
           theme="light"
           items={railItems}
-          activeId="editor"
+          activeId={activeRailId}
+          onItemClick={(id) => setActiveRailId(id)}
           brandLogo={<CompanyLogo size={24} />}
           bottomSlot={<Avatar initials="VK" />}
         />
@@ -100,25 +110,57 @@ const meta: Meta<typeof AppShell> = {
           theme="light"
           title="Editor"
           items={tree}
-          activeId="email-views"
+          activeId={activeArticleId}
+          onItemClick={(id) => setActiveArticleId(id)}
         />
       }
       breadcrumb={
         <KBBreadcrumbBar
-          sidebarCollapsed={args.sidebarCollapsed}
+          sidebarCollapsed={false}
           items={[
             { id: '1', label: 'Offer Multi-channel Support' },
             { id: '2', label: 'Managing emails' },
-            { id: '3', label: 'Search, filter, and create email views' },
+            { id: '3', label: activeArticleTitle },
           ]}
-          actions={<EditorBreadcrumbActions />}
+          actions={
+            <EditorBreadcrumbActions
+              onSaveAsDraft={() => {}}
+              onPublish={() => {}}
+              onClose={() => {}}
+            />
+          }
         />
       }
     >
-      <div className="text-sm text-[#64758b] p-6">Content area</div>
+      <div className="bg-white p-8 max-w-[840px] mx-auto">
+        <h1 className="text-[28px] font-semibold leading-9 text-[#0f172a] mb-4">
+          {activeArticleTitle}
+        </h1>
+        <p className="text-[14px] leading-6 text-[#475569] mb-3">
+          Last edited by Varun Kelkar · 2 hours ago · Draft
+        </p>
+        <p className="text-[15px] leading-7 text-[#0f172a] mb-4">
+          Shared inboxes let your team collaborate on a single email address — like support@ or billing@ — directly inside Gmail. Every teammate sees the same conversations, can claim ownership, and reply on behalf of the group without forwarding threads back and forth.
+        </p>
+        <p className="text-[15px] leading-7 text-[#0f172a] mb-4">
+          To create a shared inbox, open the Hiver sidebar and click the plus icon next to "Shared Inboxes." You'll be prompted to enter the email address you want to share.
+        </p>
+        <p className="text-[15px] leading-7 text-[#0f172a]">
+          Note: shared inboxes created before March 2024 used a legacy permissions model and may need to be migrated manually from the admin console.
+        </p>
+      </div>
     </AppShell>
-  ),
+  );
+}
+
+const meta: Meta<typeof AppShell> = {
+  title: 'Components/Shell/AppShell',
+  component: AppShell,
+  parameters: { layout: 'fullscreen' },
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof AppShell> = {};
+export const Playground: StoryObj<typeof AppShell> = {
+  render: () => <AppShellPlayground />,
+};

--- a/packages/kb-ui/src/components/shell/KBBreadcrumbBar.stories.tsx
+++ b/packages/kb-ui/src/components/shell/KBBreadcrumbBar.stories.tsx
@@ -7,23 +7,38 @@ const meta: Meta<typeof KBBreadcrumbBar> = {
   title: 'Components/Navigation/KB Breadcrumb Bar',
   component: KBBreadcrumbBar,
   parameters: { layout: 'fullscreen' },
-  args: {
-    sidebarCollapsed: false,
-    items: [
-      { id: '1', label: 'Offer Multi-channel Support' },
-      { id: '2', label: 'Managing emails' },
-      { id: '3', label: 'Search, filter, and create email views' },
-    ],
-  },
-  render: (args) => (
-    <div style={{ borderBottom: '1px solid #e2e8f0' }}>
-      <KBBreadcrumbBar
-        {...args}
-        actions={<EditorBreadcrumbActions publishDisabled={false} />}
-      />
-    </div>
-  ),
+  globals: { backgrounds: { value: 'canvas' } },
 };
 export default meta;
 
-export const Default: StoryObj<typeof KBBreadcrumbBar> = {};
+function KBBreadcrumbBarPlayground() {
+  return (
+    <div className="font-sans">
+      <KBBreadcrumbBar
+        sidebarCollapsed={false}
+        items={[
+          { id: '1', label: 'Offer Multi-channel Support' },
+          { id: '2', label: 'Managing emails' },
+          { id: '3', label: 'Search, filter, and create email views' },
+        ]}
+        actions={
+          <EditorBreadcrumbActions
+            onSaveAsDraft={() => {}}
+            onPublish={() => {}}
+            onClose={() => {}}
+            publishDisabled={false}
+          />
+        }
+      />
+      <div className="bg-white p-6" style={{ height: 320 }}>
+        <p className="text-[14px] leading-5 text-[#64748b]">
+          Article body goes here…
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export const Playground: StoryObj<typeof KBBreadcrumbBar> = {
+  render: () => <KBBreadcrumbBarPlayground />,
+};


### PR DESCRIPTION
Rolls the Phase 14 production-readiness pattern across the remaining shell, navigation, and overlay components. All 6 stories now render single \`Playground\` with realistic Hiver-KB editor context and live state wiring.

**Components refined (6):**
- 14.3a — KBBreadcrumbBar (in editor context with article body below)
- 14.3b — SideNavRail (interactive, click → activeId moves)
- 14.3c — FileExplorerNav (interactive, click tree row → active title updates)
- 14.3d — SideSheet (open by default with realistic citations)
- 14.3e — SourcesSideSheet (behind real AI answer page)
- 14.3f — AppShell (full interactive editor with Rail + Explorer + Breadcrumb + Article body)

Test plan:
- [x] typecheck + build-storybook + boot
- [ ] Eyeball preview URL — every shell story should feel like a real Hiver KB view