### PR TITLE
feat(kb-ui): Phase 15c.5 — drop chevron column from KBCategoryPage subcategories

### DIFF
--- a/packages/kb-ui/src/pages/KBCategoryPage.stories.tsx
+++ b/packages/kb-ui/src/pages/KBCategoryPage.stories.tsx
@@ -7,7 +7,6 @@ import {
   RiBarChartBoxLine,
   RiSettings5Line,
   RiFolderLine,
-  RiArrowRightSLine,
   RiFile3Line,
   RiMore2Line,
 } from '@remixicon/react';
@@ -143,23 +142,6 @@ const subCategoryColumns: DataTableColumn<SubCategory>[] = [
         <span className="text-[14px] font-normal leading-[20px] text-[#0f172a]">
           {item.title}
         </span>
-      </div>
-    ),
-  },
-  {
-    id: 'chev',
-    header: '',
-    align: 'right',
-    width: 48,
-    headerClassName: 'pl-0 pr-4 py-0',
-    className: 'pl-0 pr-4',
-    render: () => (
-      <div className="flex items-center justify-end">
-        <RiArrowRightSLine
-          size={16}
-          className="text-[#64758b]"
-          aria-hidden="true"
-        />
       </div>
     ),
   },


### PR DESCRIPTION
## Summary
- Remove the right-aligned 48-px chevron column (`RiArrowRightSLine`) from `subCategoryColumns` in `KBCategoryPage.stories.tsx` — Figma frame omits it; production drift identified in Phase 15b.
- Drop the now-unused `RiArrowRightSLine` import. Sub-categories table now renders one column (folder-icon button + title).
- `articleColumns` and `DataTable` are untouched.

## Test plan
- [x] `npm run --workspace=packages/kb-ui typecheck` passes
- [x] `npm run --workspace=packages/kb-ui build-storybook` passes
- [x] `Patterns/Knowledge Base/Category Page > Default` — sub-categories table has 1 column (no chevron); articles table unchanged (5 columns)
- [x] `Review/Tables/SubCategoriesTable > Playground` renders cleanly, no console errors
- [x] No layout regression (header chrome, padding, border identical apart from removed column)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>