### PR TITLE
feat(kb-ui): Phase 15c.6b — SideSheet count chip light bg per Figma

### DIFF
--- a/packages/kb-ui/src/components/overlays/SideSheet.tsx
+++ b/packages/kb-ui/src/components/overlays/SideSheet.tsx
@@ -43,7 +43,7 @@ const headerClass =
 const titleClass =
   'text-[16px] font-semibold leading-[24px] text-[#0f172a]';
 const countClass =
-  'inline-flex h-[20px] min-w-[20px] items-center justify-center rounded-full px-2 bg-[#0f172a] text-[12px] font-medium leading-[18px] text-white tabular-nums';
+  'inline-flex h-[20px] min-w-[20px] items-center justify-center rounded-full px-2 bg-[#f1f5f9] text-[12px] font-medium leading-[18px] text-[#475569] tabular-nums';
 const closeBtnClass =
   'inline-flex h-8 w-8 items-center justify-center rounded-[6px] text-[#64758b] transition-colors hover:bg-[#f1f5f9] hover:text-[#0f172a] focus:outline-none focus:ring-2 focus:ring-black/10';
 const bodyClass = 'flex flex-1 flex-col overflow-y-auto px-5 py-4';


### PR DESCRIPTION
## Summary
- Recolor the SideSheet count chip from dark fill + white text to subtle light grey-blue (`bg-[#f1f5f9]`) + dark slate (`text-[#475569]`) so it matches the Figma raster for SourcesSideSheet and aligns with the AISuggestionsCard CountPill tokens.
- No border — Figma raster shows a flat-fill chip against the header bg, so we stay 1:1.

## Test plan
- [x] `npm run --workspace=packages/kb-ui typecheck` — clean
- [x] `npm run --workspace=packages/kb-ui build-storybook` — clean
- [x] `Review/Overlays/SourcesSideSheet > Default` — chip computed style is `bg=rgb(241,245,249)`, `color=rgb(71,85,105)`; visual match against `design/screenshots/sources-sidesheet.png` is tight
- [x] `Components/Overlays/Side-Sheet > Playground` and `Components/Overlays/Sources-Side-Sheet > Playground` still render correctly with the new chip styling

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>