### PR TITLE
chore(kb-ui): hide Review/* stories from public Chromatic build

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -24,6 +24,8 @@ jobs:
         run: npm ci
 
       - name: Build Storybook
+        env:
+          STORYBOOK_PUBLIC: '1'
         run: npm run --workspace=packages/kb-ui build-storybook
 
       - name: Publish to Chromatic

--- a/packages/kb-ui/.storybook/main.ts
+++ b/packages/kb-ui/.storybook/main.ts
@@ -1,7 +1,58 @@
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { StorybookConfig } from '@storybook/react-vite';
 
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Default: include every story (local dev shows Review/*).
+// When STORYBOOK_PUBLIC=1 (set by the Chromatic workflow), exclude
+// Review/* stories — those are internal calibration surfaces
+// (FigmaCompare side-by-side review canvas) and shouldn't ship
+// in the public Storybook build.
+//
+// Storybook's stories array does not honour `!` negation entries
+// reliably, so we resolve the file list ourselves in a function-form
+// `stories` loader and filter out review stories when STORYBOOK_PUBLIC=1.
+async function collectStoryFiles(srcDir: string): Promise<string[]> {
+  const out: string[] = [];
+  const entries = await readdir(srcDir, {
+    withFileTypes: true,
+    recursive: true,
+  });
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const name = entry.name;
+    const isStory =
+      name.endsWith('.mdx') ||
+      name.endsWith('.stories.ts') ||
+      name.endsWith('.stories.tsx');
+    if (!isStory) continue;
+    const parentPath =
+      // Node 20+ Dirent.parentPath; fall back to the older `path` field.
+      (entry as unknown as { parentPath?: string; path?: string })
+        .parentPath ??
+      (entry as unknown as { path?: string }).path ??
+      srcDir;
+    out.push(path.join(parentPath, name));
+  }
+  return out;
+}
+
 const config: StorybookConfig = {
-  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(ts|tsx)'],
+  stories: async () => {
+    const srcDir = path.resolve(dirname, '..', 'src');
+    const storybookDir = path.resolve(dirname);
+    const all = await collectStoryFiles(srcDir);
+    const filtered =
+      process.env.STORYBOOK_PUBLIC === '1'
+        ? all.filter((file) => !file.includes('.review.stories.'))
+        : all;
+    // Storybook expects entries relative to the .storybook directory.
+    return filtered.map(
+      (file) => `./${path.relative(storybookDir, file)}`,
+    );
+  },
   addons: ['@storybook/addon-docs'],
   framework: {
     name: '@storybook/react-vite',


### PR DESCRIPTION
## Summary

- Public Chromatic Storybook deploy no longer ships the Review/* sidebar (FigmaCompare side-by-side calibration canvas). Review stories live behind a STORYBOOK_PUBLIC=1 env var that the workflow sets on the Build Storybook step.
- Local dev (npm run --workspace=packages/kb-ui storybook) is unchanged — the Review group remains visible with all six subgroups (Primitives, Content, Overlays, Navigation, Shell, Tables).
- Implementation: .storybook/main.ts now uses a function-form stories loader. The `!` negation entry is not honoured by Storybook's stories array reliably, so we walk src/ via fs.readdir and filter out *.review.stories.@(ts|tsx) when the env var is set.

## Test plan

- [x] `npm run --workspace=packages/kb-ui typecheck` clean
- [x] `STORYBOOK_PUBLIC=1 npm run --workspace=packages/kb-ui build-storybook` — index.json: 45 entries, 0 entries titled `Review/*`, `grep '"Review/' storybook-static/index.json` returns 0 matches
- [x] `npm run --workspace=packages/kb-ui build-storybook` (no env var, existing CI smoke gate) — index.json: 69 entries, 24 `Review/*` entries preserved
- [x] `npm run --workspace=packages/kb-ui storybook` dev server — index.json over HTTP shows 24 Review/* entries across all 6 expected subgroups; sidebar renders the Review root
- [ ] Chromatic CI on this PR confirms the published build hides Review/*

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>