### PR TITLE
feat(kb-ui): Phase 15c.8 - Components SuggestionBlock story uses new per-sentence API

### DIFF
--- a/packages/kb-ui/src/components/content/SuggestionBlock.stories.tsx
+++ b/packages/kb-ui/src/components/content/SuggestionBlock.stories.tsx
@@ -1,94 +1,27 @@
 import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import '../../tokens.css';
-import { SuggestionBlock } from './SuggestionBlock';
+import { SuggestionBlock, SuggestionHighlight } from './SuggestionBlock';
 
-/**
- * The block lives inline inside an article body, which is itself
- * roughly 620px wide inside the editor shell. Mimic that width so
- * the wash proportions read correctly.
- */
-const CANVAS: React.CSSProperties = {
-  background: '#ffffff',
-  padding: 32,
-  width: 620,
-};
-
-const BODY_TYPE: React.CSSProperties = {
-  color: '#0f172a',
-  fontFamily: 'Inter, system-ui, sans-serif',
-  fontSize: 14,
-  lineHeight: '22px',
-};
-
-const H2: React.CSSProperties = {
-  ...BODY_TYPE,
-  fontSize: 18,
-  lineHeight: '26px',
-  fontWeight: 600,
-  margin: 0,
-};
-
-const H3: React.CSSProperties = {
-  ...BODY_TYPE,
-  fontSize: 16,
-  lineHeight: '24px',
-  fontWeight: 600,
-  margin: '12px 0 0 0',
-};
-
-const PARA: React.CSSProperties = {
-  ...BODY_TYPE,
-  margin: '8px 0 0 0',
-};
-
-const ARTICLE_PARA: React.CSSProperties = {
-  ...BODY_TYPE,
-  margin: '12px 0 0 0',
-};
-
-const LIST: React.CSSProperties = {
-  ...BODY_TYPE,
-  margin: '12px 0 0 0',
-  paddingLeft: 20,
-  listStyleType: 'decimal',
-};
-
-const ADDITION_CONTENT = (
-  <>
-    <h2 style={H2}>Resetting Your Password via Mobile App</h2>
-    <ol style={LIST}>
-      <li>Open the Hiver mobile app and tap your profile icon in the bottom-right corner.</li>
-      <li>Navigate to Settings → Security → Change Password.</li>
-      <li>Tap &ldquo;Forgot Password?&rdquo; to receive a reset link via email.</li>
-      <li>Check your registered email for the reset link (arrives within 2 minutes).</li>
-      <li>Tap the link from your mobile device — it will open directly in the app.</li>
-      <li>Enter your new password (minimum 12 characters, must include one uppercase letter and one number).</li>
-    </ol>
-  </>
-);
-
-const REMOVAL_CONTENT = (
-  <>
-    <h2 style={H2}>Troubleshooting</h2>
-    <h3 style={H3}>Resetting via Chrome Extension</h3>
-    <p style={PARA}>
-      If you&apos;re using the Hiver Chrome Extension, you can reset your password by clicking the gear icon → Account → Reset Password. This will redirect you to the web dashboard to complete the reset process.
-    </p>
-  </>
-);
-
-const OLD_CONTENT = (
-  <p style={{ ...BODY_TYPE, margin: 0 }}>
-    Navigate to the admin panel at <strong>admin.hiver.com/legacy/users</strong> and select the user whose password needs to be reset.
-  </p>
-);
-
-const NEW_CONTENT = (
-  <p style={{ ...BODY_TYPE, margin: 0 }}>
-    Navigate to the admin panel at <strong>admin.hiver.com/settings/users</strong> and select the user whose password needs to be reset. You can also use the search bar to quickly find users by name or email.
-  </p>
-);
+/* ─────────────────────────────────────────────────────────────
+ * Public Components/* Playground for SuggestionBlock.
+ *
+ * Mirrors the per-sentence highlight pattern from the Phase 15a
+ * review story (Review/Content/SuggestionBlock). The block lives
+ * inline inside an article body — heading + body copy + the
+ * highlighted region in context — so reviewers can see how the
+ * per-sentence wash hugs each line of wrapped text rather than
+ * spanning the full container.
+ *
+ * Single Playground per Phase 14 single-story convention; the
+ * three variants (addition / removal / replace) are stacked in
+ * the same article shell so the surface tells one coherent
+ * "How to Reset Your Password" story.
+ *
+ * Article shell helpers are duplicated here (rather than shared
+ * with the review story) so the public component remains free of
+ * review-only coupling like FigmaCompare.
+ * ───────────────────────────────────────────────────────────── */
 
 const meta: Meta<typeof SuggestionBlock> = {
   title: 'Components/AI/Suggestion Block',
@@ -98,27 +31,226 @@ const meta: Meta<typeof SuggestionBlock> = {
 };
 export default meta;
 
+/* ─── Article-style typography helpers ─── */
+
+function ArticleH1({ children }: { children: React.ReactNode }) {
+  return (
+    <h1 className="mb-2 text-[24px] font-semibold leading-[32px] text-[#0f172a]">
+      {children}
+    </h1>
+  );
+}
+
+function ArticleSubtitle({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mb-8 text-[14px] font-normal leading-[20px] text-[#475569]">
+      {children}
+    </p>
+  );
+}
+
+function ArticleP({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mb-8 text-[16px] font-normal leading-[24px] text-[#0f172a]">
+      {children}
+    </p>
+  );
+}
+
+function ArticleH2({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="mb-5 text-[20px] font-semibold leading-[28px] text-[#0f172a]">
+      {children}
+    </h2>
+  );
+}
+
+function ArticleH3({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="mb-5 text-[18px] font-normal leading-[24px] text-[#0f172a]">
+      {children}
+    </h3>
+  );
+}
+
+/**
+ * Numbered list item where the numeral renders on the white page
+ * (outside the highlight) and only the prose text gets the wash.
+ * Matches Figma 137:4022 — see SuggestionBlock.review.stories.tsx.
+ */
+function NumberedItem({
+  index,
+  children,
+}: {
+  index: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <span className="flex items-start text-[16px] leading-[24px] text-[#0f172a]">
+      <span className="shrink-0 pr-2 tabular-nums">{index}.</span>
+      <SuggestionHighlight>{children}</SuggestionHighlight>
+    </span>
+  );
+}
+
+/* ─── Sentence catalogues ─── */
+
+const ADDITION_SENTENCES = [
+  <span
+    key="h2"
+    className="block text-[20px] font-semibold leading-[28px] text-[#0f172a]"
+  >
+    <SuggestionHighlight>Resetting Your Password via Mobile App</SuggestionHighlight>
+  </span>,
+  <NumberedItem key="li-1" index={1}>
+    Open the Hiver mobile app and tap your profile icon in the
+    bottom-right corner.
+  </NumberedItem>,
+  <NumberedItem key="li-2" index={2}>
+    Navigate to Settings → Security → Change Password.
+  </NumberedItem>,
+  <NumberedItem key="li-3" index={3}>
+    Tap “Forgot Password?” to receive a reset link via email.
+  </NumberedItem>,
+  <NumberedItem key="li-4" index={4}>
+    Check your registered email for the reset link (arrives within 2
+    minutes).
+  </NumberedItem>,
+  <NumberedItem key="li-5" index={5}>
+    Tap the link from your mobile device — it will open directly in the app.
+  </NumberedItem>,
+  <NumberedItem key="li-6" index={6}>
+    Enter your new password (minimum 12 characters, must include one
+    uppercase letter and one number).
+  </NumberedItem>,
+];
+
+const REMOVAL_SENTENCES = [
+  <span
+    key="r-1"
+    className="block text-[16px] leading-[24px] text-[#0f172a]"
+  >
+    <SuggestionHighlight>
+      Navigate to the admin panel at{' '}
+      <strong>admin.hiver.com/legacy/users</strong>
+      {' '}and select the user whose password needs to be reset.
+    </SuggestionHighlight>
+  </span>,
+];
+
+const REPLACE_OLD_SENTENCES = [
+  <span
+    key="repl-old-1"
+    className="block text-[16px] leading-[24px] text-[#0f172a]"
+  >
+    <SuggestionHighlight>
+      Navigate to the admin panel at{' '}
+      <strong>admin.hiver.com/legacy/users</strong>
+      {' '}and select the user whose password needs to be reset.
+    </SuggestionHighlight>
+  </span>,
+];
+
+const REPLACE_NEW_SENTENCES = [
+  <span
+    key="repl-new-1"
+    className="block text-[16px] leading-[24px] text-[#0f172a]"
+  >
+    <SuggestionHighlight>
+      Navigate to the admin panel at{' '}
+      <strong>admin.hiver.com/settings/users</strong>
+      {' '}and select the user whose password needs to be reset. You
+      can also use the search bar to quickly find users by name or
+      email.
+    </SuggestionHighlight>
+  </span>,
+];
+
+/* ─── Playground ─── */
+
 function SuggestionBlockPlayground() {
   return (
-    <div style={CANVAS}>
-      <h2 style={H2}>Reset Your Password</h2>
-      <p style={ARTICLE_PARA}>
-        If you&apos;ve forgotten your Hiver password, you can reset it in a few
-        steps. The process below covers the standard web flow — additional
-        guidance for our mobile and extension surfaces is included where
-        relevant.
-      </p>
-      <SuggestionBlock type="addition" oldContent={OLD_CONTENT} newContent={NEW_CONTENT}>
-        {ADDITION_CONTENT}
-      </SuggestionBlock>
-      <p style={ARTICLE_PARA}>
-        Once your password is reset, you&apos;ll be signed out of all active
-        sessions across web, mobile, and the Chrome extension. Sign back in with
-        your new credentials to resume.
-      </p>
-      <SuggestionBlock type="removal" oldContent={OLD_CONTENT} newContent={NEW_CONTENT}>
-        {REMOVAL_CONTENT}
-      </SuggestionBlock>
+    <div
+      className="border border-[#f1f5f9] bg-white p-10 rounded-[12px]"
+      style={{
+        width: 720,
+        boxShadow:
+          '0 4px 3px rgba(0,0,0,0.05), 0 2px 2px rgba(0,0,0,0.10)',
+      }}
+    >
+      <ArticleH1>How to Reset Your Password</ArticleH1>
+      <ArticleSubtitle>Last updated 9 months ago</ArticleSubtitle>
+
+      <ArticleP>
+        Your Hiver account password can be reset through several methods
+        depending on how you access the platform. This guide covers all
+        available reset options for both standard accounts and SSO-managed
+        accounts.
+      </ArticleP>
+
+      <ArticleH2>Resetting from the Web Dashboard</ArticleH2>
+      <ol className="mb-8 list-decimal pl-6 text-[16px] font-normal leading-[24px] text-[#0f172a] [&>li]:mb-[10px]">
+        <li>Go to app.hiver.com and click <strong>“Sign In”</strong></li>
+        <li>Click <strong>“Forgot Password?”</strong> below the sign-in form</li>
+        <li>Enter the email address associated with your Hiver account</li>
+        <li>Click <strong>“Send Reset Link”</strong> — you’ll receive an email within 2 minutes</li>
+        <li>Click the reset link in the email and enter your new password</li>
+        <li>Confirm your new password and click <strong>“Reset Password”</strong></li>
+      </ol>
+
+      {/* Addition — heading + 6 numbered items, each row its own highlight. */}
+      <div className="mb-8">
+        <SuggestionBlock type="addition" sentences={ADDITION_SENTENCES} />
+      </div>
+
+      <ArticleH2>SSO Password Reset (Admin Only)</ArticleH2>
+      <ArticleP>
+        If your organization uses Single Sign-On (SSO), individual users
+        cannot reset their passwords through Hiver. Instead, an
+        administrator must initiate the reset from the identity provider
+        or the Hiver admin panel.
+      </ArticleP>
+
+      {/* Removal — single sentence wrapping to two lines, tight wash. */}
+      <div className="mb-8">
+        <SuggestionBlock type="removal" sentences={REMOVAL_SENTENCES} />
+      </div>
+
+      <ArticleP>
+        Once the legacy reset has been processed, the new admin tooling
+        replaces the URL above with a unified settings page. The
+        replacement block below shows what an in-place edit looks like
+        when an AI suggestion swaps the legacy paragraph for the new
+        one.
+      </ArticleP>
+
+      {/* Replace — old (red) stacked above new (green), per-sentence. */}
+      <div className="mb-8">
+        <SuggestionBlock
+          type="replace"
+          oldSentences={REPLACE_OLD_SENTENCES}
+          newSentences={REPLACE_NEW_SENTENCES}
+        />
+      </div>
+
+      <ArticleH2>Password Requirements</ArticleH2>
+      <ArticleP>Your new password must meet the following requirements:</ArticleP>
+      <ul className="mb-8 list-disc pl-6 text-[16px] font-normal leading-[24px] text-[#0f172a] [&>li]:mb-[10px]">
+        <li>Minimum 12 characters</li>
+        <li>At least one uppercase letter (A-Z)</li>
+        <li>At least one lowercase letter (a-z)</li>
+        <li>At least one number (0-9)</li>
+        <li>Cannot match any of your last 5 passwords</li>
+      </ul>
+
+      <ArticleH2>Troubleshooting</ArticleH2>
+      <ArticleH3>Resetting via Chrome Extension</ArticleH3>
+      <ArticleP>
+        If you’re using the Hiver Chrome Extension, you can reset your
+        password by clicking the gear icon → Account → Reset Password.
+        This will redirect you to the web dashboard to complete the
+        reset process.
+      </ArticleP>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Rewrite the public `Components/AI/Suggestion Block` Playground to use the per-sentence highlight API (`sentences[]` / `oldSentences` + `newSentences`) that shipped in 15a; the public surface was still rendering the legacy block-mode full-slab wash even though the component itself already supported tight per-sentence highlights.
- Single Playground stacks addition (heading + 6 numbered items, numerals outside the wash), removal (single sentence wrapping to two lines via `box-decoration-break: clone`), and replace (red old above green new) inside one "How to Reset Your Password" article shell.
- Article-shell helpers duplicated into the public story (per the brief's preference for option (b)) to keep the public file free of FigmaCompare / review-only coupling.

## Untouched
- `SuggestionBlock` component itself (already correct from 15a).
- `Review/Content/SuggestionBlock` story.
- `ArticleBody.tsx` and `KBAIGapsExperience.stories.tsx` - already on the new API.

## Test plan
- [x] `npm run --workspace=packages/kb-ui typecheck` clean
- [x] `npm run --workspace=packages/kb-ui build-storybook` clean
- [x] `Components/AI/Suggestion Block > Playground` - addition has 7 highlights at `rgb(231, 249, 238)` (heading + 6 numbered items, gap = 4px between rows, numerals on white background outside the wash)
- [x] Removal has 1 highlight at `rgb(252, 232, 232)`, height 42.89px (two wrapped lines, tight per-line via `box-decoration-break: clone`)
- [x] Replace shows red sentence (`rgb(252, 232, 232)`, 42.89h) stacked above green sentence (`rgb(231, 249, 238)`, 66.89h)
- [x] No full-block slab wash anywhere - every highlight rect hugs actual text width
- [x] `Review/Content/SuggestionBlock > Addition` matches public Playground styling (same 7 highlights, same color)
- [x] `Patterns/AI Optimisation/AI Gaps > Default` still renders 3 SuggestionBlocks (addition, replace, removal) with per-sentence highlights intact

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>