### PR TITLE
feat(kb-ui): Phase 15d round-1 — 9 user-flagged review fixes

### DIFF
--- a/packages/kb-ui/src/components/content/AIConversationLogEntry.tail-search-result-clicked.review.stories.tsx
+++ b/packages/kb-ui/src/components/content/AIConversationLogEntry.tail-search-result-clicked.review.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { RiCursorAiLine, RiFileTextLine } from '@remixicon/react';
+import { RiCursorLine, RiFileTextLine } from '@remixicon/react';
 import '../../tokens.css';
 import { ConversationRow } from './AIConversationLogEntryAtoms';
 import { FigmaCompare } from '../../_review/FigmaCompare';
@@ -36,7 +36,7 @@ function TailSearchResultClickedReview() {
           hideConnectorAbove
           hideConnectorBelow
           icon={
-            <RiCursorAiLine
+            <RiCursorLine
               aria-hidden="true"
               className="h-4 w-4 text-[#64758b]"
             />

--- a/packages/kb-ui/src/components/content/AIConversationLogEntry.tail-source-clicked.review.stories.tsx
+++ b/packages/kb-ui/src/components/content/AIConversationLogEntry.tail-source-clicked.review.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { RiBookOpenLine, RiCursorAiLine } from '@remixicon/react';
+import { RiBookOpenLine, RiCursorLine } from '@remixicon/react';
 import '../../tokens.css';
 import { ConversationRow } from './AIConversationLogEntryAtoms';
 import { FigmaCompare } from '../../_review/FigmaCompare';
@@ -35,7 +35,7 @@ function TailSourceClickedReview() {
           hideConnectorAbove
           hideConnectorBelow
           icon={
-            <RiCursorAiLine
+            <RiCursorLine
               aria-hidden="true"
               className="h-4 w-4 text-[#64758b]"
             />

--- a/packages/kb-ui/src/components/content/AIConversationLogEntry.tail-ticket.review.stories.tsx
+++ b/packages/kb-ui/src/components/content/AIConversationLogEntry.tail-ticket.review.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { RiCursorAiLine, RiPriceTag3Line } from '@remixicon/react';
+import { RiCursorLine, RiPriceTag3Line } from '@remixicon/react';
 import '../../tokens.css';
 import { ConversationRow } from './AIConversationLogEntryAtoms';
 import { FigmaCompare } from '../../_review/FigmaCompare';
@@ -35,7 +35,7 @@ function TailTicketReview() {
           hideConnectorAbove
           hideConnectorBelow
           icon={
-            <RiCursorAiLine
+            <RiCursorLine
               aria-hidden="true"
               className="h-4 w-4 text-[#64758b]"
             />

--- a/packages/kb-ui/src/components/content/AIConversationLogEntry.tsx
+++ b/packages/kb-ui/src/components/content/AIConversationLogEntry.tsx
@@ -7,7 +7,7 @@ import {
   RiThumbDownLine,
   RiBookOpenLine,
   RiCornerDownRightLine,
-  RiCursorAiLine,
+  RiCursorLine,
   RiPriceTag3Line,
   RiFileTextLine,
 } from '@remixicon/react';
@@ -172,7 +172,7 @@ function TailRow({ tail }: TailRowProps) {
         hideConnectorAbove
         hideConnectorBelow
         icon={
-          <RiCursorAiLine
+          <RiCursorLine
             aria-hidden="true"
             className="h-4 w-4 text-[#64758b]"
           />
@@ -201,7 +201,7 @@ function TailRow({ tail }: TailRowProps) {
         hideConnectorAbove
         hideConnectorBelow
         icon={
-          <RiCursorAiLine
+          <RiCursorLine
             aria-hidden="true"
             className="h-4 w-4 text-[#64758b]"
           />
@@ -228,7 +228,7 @@ function TailRow({ tail }: TailRowProps) {
       hideConnectorAbove
       hideConnectorBelow
       icon={
-        <RiCursorAiLine
+        <RiCursorLine
           aria-hidden="true"
           className="h-4 w-4 text-[#64758b]"
         />
@@ -280,18 +280,22 @@ export function AIConversationLogEntry({
   return (
     <div
       data-kb-component="ai-conversation-log-entry"
-      className={cn('relative flex flex-col gap-3 py-5', className)}
+      // `py-8` (32 px) gives the rhythm `[entry][32-px gap][divider]
+      // [32-px gap][entry]` per Figma `ai-conversation-logs-card.png`
+      // (~80 px PNG / 2.45x scale = 32 px render). Was `py-5` (20 px)
+      // — divider felt cramped between entries.
+      className={cn('relative flex flex-col gap-3 py-8', className)}
     >
       {/* Shared dotted connector — runs full height of the entry's
        * left rail, behind the icon glyphs. The icon glyph wrappers
        * are `bg-white` (or pill-coloured) so they appear to break
-       * the line cleanly. `inset-y-5` matches the entry's `py-5`
+       * the line cleanly. `inset-y-8` matches the entry's `py-8`
        * so the line spans from just below the question icon to
        * just above the last tail icon. Axis at `left-[13.5px]`
        * (center of the 28-px icon column). */}
       <span
         aria-hidden="true"
-        className="pointer-events-none absolute inset-y-5 left-[13.5px] border-l border-dashed border-[#94a3b8]"
+        className="pointer-events-none absolute inset-y-8 left-[13.5px] border-l border-dashed border-[#94a3b8]"
       />
 
       {rows !== undefined ? (

--- a/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
+++ b/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
@@ -105,7 +105,11 @@ function SourcesButton({
       onClick={onClick}
       className={cn(
         'inline-flex items-center gap-1 rounded-[4px] px-1.5 py-1',
-        'text-[14px] font-medium leading-[20px] text-[#475569]',
+        // Per Figma `ai-gap-active-addition.png` — '4 Sources' is
+        // weight=normal, not medium. Lighter weight also improves
+        // visual baseline alignment with the icon + adjacent NavArrow
+        // / accept-reject pills (medium gave a heavier optical feel).
+        'text-[14px] font-normal leading-[20px] text-[#475569]',
         'transition-colors hover:bg-[#f1f5f9] hover:text-[#0f172a]',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
       )}

--- a/packages/kb-ui/src/components/content/AISuggestionsCard.tsx
+++ b/packages/kb-ui/src/components/content/AISuggestionsCard.tsx
@@ -82,7 +82,10 @@ export function AISuggestionsCard({
       header={
         <div className="flex items-center gap-2">
           <AiIcon size={16} aria-hidden="true" />
-          <span className="text-[14px] font-semibold leading-[20px] text-[#0f172a]">
+          {/* Per Figma `ai-suggestions-card-pre-review.png` — the title
+           * is weight=medium, not semibold. Semibold read too heavy
+           * compared to surrounding card UI in the live render. */}
+          <span className="text-[14px] font-medium leading-[20px] text-[#0f172a]">
             {resolvedTitle}
           </span>
           {isTerminal && <CountPill count={count} />}

--- a/packages/kb-ui/src/components/content/AnalyticsAreaChart.tsx
+++ b/packages/kb-ui/src/components/content/AnalyticsAreaChart.tsx
@@ -175,7 +175,15 @@ export function AnalyticsAreaChart({
       data-kb-component="analytics-area-chart"
       className={cn('flex w-full flex-col', className)}
     >
-      <div style={{ width: '100%', height }}>
+      {/* Negative left margin (-16 px) outdents JUST the SVG plot so the
+       * y-axis label column (12k / 9k / 6k / 3k / 0) lines up with the
+       * parent card's title left edge instead of jutting in past it.
+       * Sampled from Figma `chart-article-views-over-time.png` — labels
+       * and title share the same x. Card padding ('lg' = 32 px) absorbs
+       * the outdent so the chart still sits inside the card. The legend
+       * below stays inside the wrapper (no outdent) so it aligns with
+       * the title at the card's normal padding edge. */}
+      <div className="-ml-4" style={{ width: 'calc(100% + 16px)', height }}>
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart
             data={data}

--- a/packages/kb-ui/src/components/primitives/Badge.tsx
+++ b/packages/kb-ui/src/components/primitives/Badge.tsx
@@ -10,9 +10,13 @@ export type BadgeProps = {
 };
 
 const variantStyles: Record<BadgeVariant, string> = {
-  published: 'bg-[#f2fdf6] text-[#086e3f] pl-1 pr-2',
-  draft: 'bg-[#fcfcfc] text-[#0f172a] pl-2 pr-2',
-  neutral: 'bg-[#fcfcfc] text-[#0f172a] pl-2 pr-2',
+  // Padding equalised on both sides per Figma `tag.png` measurement
+  // (~9-10 px each side at 1x render scale → `px-2`).
+  published: 'bg-[#f2fdf6] text-[#086e3f] px-2',
+  // Draft bg sampled from Figma `tag.png` at the pill interior =
+  // #f5f5f5 (was previously #fcfcfc, which read too washed-out).
+  draft: 'bg-[#f5f5f5] text-[#0f172a] px-2',
+  neutral: 'bg-[#f5f5f5] text-[#0f172a] px-2',
 };
 
 export function Badge({ variant = 'neutral', icon, children, className }: BadgeProps) {

--- a/packages/kb-ui/src/components/shell/EditorBreadcrumbActions.tsx
+++ b/packages/kb-ui/src/components/shell/EditorBreadcrumbActions.tsx
@@ -77,11 +77,18 @@ export function EditorBreadcrumbActions({
       >
         {publishLabel}
       </Button>
+      {/*
+        Close button — square subtle pill matching `Button` variant="subtle"
+        coloring (`bg-[#f1f5f9]`, hover `#e2e8f0`). Sampled from Figma
+        `kb-breadcrumb-bar.png` — the close button has a visible idle bg
+        of #f1f5f9 (was previously transparent). Per memory rule:
+        secondary buttons are `bg-[#f1f5f9]`, not `bg-black`.
+      */}
       <button
         type="button"
         onClick={onClose}
         aria-label="Close"
-        className="inline-flex size-8 items-center justify-center rounded-[6px] text-[#64758b] hover:bg-[#f8fafc] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]"
+        className="inline-flex size-8 items-center justify-center rounded-[6px] bg-[#f1f5f9] text-[#0f172a] hover:bg-[#e2e8f0] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]"
       >
         <RiCloseLine size={16} />
       </button>

--- a/packages/kb-ui/src/components/shell/KBBreadcrumbBar.tsx
+++ b/packages/kb-ui/src/components/shell/KBBreadcrumbBar.tsx
@@ -77,13 +77,20 @@ export function KBBreadcrumbBar({
         </button>
 
         {/*
-          Figma `50:8395` (sidebar-collapsed shell, home glyph) renders the
-          breadcrumb path immediately after the home icon — no vertical
-          divider. The divider is only present in the expanded shell where
-          the side-panel toggle needs separation from the path. Suppress it
-          when `sidebarCollapsed` is true to match both Figma states.
+          Figma `50:8395` (sidebar-collapsed shell, home glyph) renders a
+          `/` separator (light slate-300) immediately after the home icon
+          — same glyph used between path items below. The expanded shell
+          variant uses a 1-px vertical divider before the side-panel
+          toggle. Pick the right one based on `sidebarCollapsed`.
         */}
-        {!sidebarCollapsed && (
+        {sidebarCollapsed ? (
+          <span
+            aria-hidden="true"
+            className="inline-flex items-center justify-center text-[14px] leading-5 text-[#cbd5e1] px-[6px] shrink-0 select-none"
+          >
+            /
+          </span>
+        ) : (
           <span aria-hidden="true" className="h-5 w-px shrink-0 bg-[#e2e8f0]" />
         )}
 
@@ -107,10 +114,13 @@ export function KBBreadcrumbBar({
                       {item.label}
                     </span>
                   ) : (
+                    // Inactive breadcrumb items: weight=normal + color=#64748b
+                    // (slate-500). Sampled from Figma `kb-breadcrumb-bar.png`
+                    // — anti-aliased dark edges average to slate-500.
                     <a
                       href="#"
                       onClick={(e) => e.preventDefault()}
-                      className="text-[14px] font-medium leading-5 text-[#475569] hover:bg-[#f8fafc] hover:text-[#0f172a] rounded-[4px] px-[6px] py-0 truncate max-w-[260px]"
+                      className="text-[14px] font-normal leading-5 text-[#64748b] hover:bg-[#f8fafc] hover:text-[#0f172a] rounded-[4px] px-[6px] py-0 truncate max-w-[260px]"
                       title={item.label}
                     >
                       {item.label}


### PR DESCRIPTION
## Summary
Round-1 review pass on Phase 15a-d Review/* stories. 9 targeted drift fixes shipped, all PNG-grounded.

| # | Fix |
|---|---|
| 1a | KBBreadcrumbBar: add `/` separator after home icon (sidebar-collapsed) |
| 1b | KBBreadcrumbBar: inactive items `font-medium → font-normal`, color `#475569 → #64748b` |
| 1c | EditorBreadcrumbActions: close button → subtle variant (`bg-[#f1f5f9]`) |
| 2a | Badge published: padding `pl-1 pr-2 → px-2` (symmetric) |
| 2b | Badge draft/neutral bg: `#fcfcfc → #f5f5f5` (PNG-sampled) |
| 3-5 | AIConversationLogEntry tail rows: `RiCursorAiLine → RiCursorLine` (regular cursor) |
| 6 | AIConversationLogEntry: `py-5 → py-8` for `[entry][gap][divider][gap][entry]` rhythm |
| 7 | AIGapSuggestionCard sources: `font-medium → font-normal` |
| 8 | AISuggestionsCard header: `font-semibold → font-medium` |
| 9 | AnalyticsAreaChart: y-axis label column shifted left to align with title (`-ml-4`) |

Two user directives interpreted via PNG ground truth:
- Fix #2b — user said "+1 lighter" but draft pill in Figma is `#f5f5f5` (darker than prior `#fcfcfc`); used PNG.
- Fix #9 — user said "labels extend left of title"; live render had labels right of title. Aligned both ways match the PNG end-state.

## Test plan
- [x] typecheck / build / build-storybook
- [x] Playwright split-mode 1:1 vs synced PNGs (all 9 stories)
- [x] cascade verify: Editor Page, AI Gaps Default, AI Answer Performance, Article Performance