### PR TITLE
fix(kb-ui): correct #64758b typo to #64748b across foundations

### DIFF
--- a/apps/demo/src/components/ArticleSeoCard.tsx
+++ b/apps/demo/src/components/ArticleSeoCard.tsx
@@ -57,7 +57,7 @@ function counterTone(
   count: number,
 ): { color: string; label: string } {
   if (count === 0) {
-    return { color: '#64758b', label: 'Empty' };
+    return { color: '#64748b', label: 'Empty' };
   }
   if (count >= META_DESC_OPTIMAL_LO && count <= META_DESC_MAX) {
     return { color: '#15803d', label: 'Optimal' };
@@ -68,7 +68,7 @@ function counterTone(
   if (count >= 120) {
     return { color: '#15803d', label: 'Almost optimal' };
   }
-  return { color: '#64758b', label: 'Too short' };
+  return { color: '#64748b', label: 'Too short' };
 }
 
 /**
@@ -165,7 +165,7 @@ export function ArticleSeoCard({
           <h2 className="text-[14px] font-semibold leading-[20px] text-[#0f172a]">
             SEO
           </h2>
-          <p className="text-[12px] font-normal leading-[18px] text-[#64758b]">
+          <p className="text-[12px] font-normal leading-[18px] text-[#64748b]">
             Optimise how this article appears in search results.
           </p>
         </div>
@@ -222,7 +222,7 @@ export function ArticleSeoCard({
 
         <div className="flex items-center justify-between gap-2">
           <p
-            className="text-[12px] font-normal leading-[18px] text-[#64758b]"
+            className="text-[12px] font-normal leading-[18px] text-[#64748b]"
             id="ai-helper-text"
           >
             {aiReady
@@ -260,7 +260,7 @@ export function ArticleSeoCard({
           </button>
         </div>
 
-        <p className="text-[12px] font-normal leading-[18px] text-[#64758b]">
+        <p className="text-[12px] font-normal leading-[18px] text-[#64748b]">
           Auto-generated. Search engines treat this URL as the primary version
           when the same content is reachable via multiple paths.
         </p>
@@ -349,7 +349,7 @@ function SuggestionPanel({
         <span className="text-[12px] font-semibold leading-[18px] text-[#0f172a]">
           AI suggestion
         </span>
-        <span className="text-[12px] font-normal leading-[18px] text-[#64758b]">
+        <span className="text-[12px] font-normal leading-[18px] text-[#64748b]">
           · {suggestion.length}/{META_DESC_MAX} chars
         </span>
       </div>

--- a/apps/demo/src/routes/ai-optimise/passwordResetRegions.tsx
+++ b/apps/demo/src/routes/ai-optimise/passwordResetRegions.tsx
@@ -35,7 +35,7 @@ function H1({ children }: { children: React.ReactNode }) {
 
 function Subtitle({ children }: { children: React.ReactNode }) {
   return (
-    <p className="mb-6 text-[14px] font-normal leading-[20px] text-[#64758b]">
+    <p className="mb-6 text-[14px] font-normal leading-[20px] text-[#64748b]">
       {children}
     </p>
   );

--- a/apps/demo/src/routes/analytics/AIAnswerPerformancePage.tsx
+++ b/apps/demo/src/routes/analytics/AIAnswerPerformancePage.tsx
@@ -58,7 +58,7 @@ const citedColumns: DataTableColumn<MostCitedRow>[] = [
       <span className="inline-flex items-center gap-2">
         <RiFile3Line
           size={16}
-          className="shrink-0 text-[#64758b]"
+          className="shrink-0 text-[#64748b]"
           aria-hidden="true"
         />
         <span>{r.title}</span>

--- a/apps/demo/src/routes/analytics/ArticlePerformancePage.tsx
+++ b/apps/demo/src/routes/analytics/ArticlePerformancePage.tsx
@@ -57,7 +57,7 @@ const attentionColumns: DataTableColumn<ArticleAttentionRow>[] = [
       <div className="flex items-center gap-2 min-w-0 pr-2">
         <RiFile3Line
           size={16}
-          className="shrink-0 text-[#64758b]"
+          className="shrink-0 text-[#64748b]"
           aria-hidden="true"
         />
         <span className="truncate">{r.title}</span>
@@ -81,7 +81,7 @@ const performanceColumns: DataTableColumn<ArticlePerformanceRow>[] = [
       <div className="flex items-center gap-2 min-w-0 pr-2">
         <RiFile3Line
           size={16}
-          className="shrink-0 text-[#64758b]"
+          className="shrink-0 text-[#64748b]"
           aria-hidden="true"
         />
         <span className="truncate">{r.title}</span>

--- a/apps/demo/src/routes/kb/CategoryPage.tsx
+++ b/apps/demo/src/routes/kb/CategoryPage.tsx
@@ -84,7 +84,7 @@ const subCategoryColumns: DataTableColumn<SubCategoryRow>[] = [
           aria-label={`Open ${item.title}`}
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-[#64758b]',
+            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-[#64748b]',
             'hover:bg-[#f8fafc] focus:bg-[#f8fafc] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]',
           )}
         >
@@ -107,7 +107,7 @@ const subCategoryColumns: DataTableColumn<SubCategoryRow>[] = [
       <div className="flex items-center justify-end">
         <RiArrowRightSLine
           size={16}
-          className="text-[#64758b]"
+          className="text-[#64748b]"
           aria-hidden="true"
         />
       </div>
@@ -128,7 +128,7 @@ const articleColumns: DataTableColumn<ArticleRow>[] = [
           aria-label={`Open ${a.title}`}
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-[#64758b]',
+            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-[#64748b]',
             'hover:bg-[#f8fafc] focus:bg-[#f8fafc] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]',
           )}
         >
@@ -194,7 +194,7 @@ const articleColumns: DataTableColumn<ArticleRow>[] = [
     width: 251,
     headerClassName: 'px-4 py-0 text-[#475569]',
     className: 'px-4',
-    render: (a) => <span className="text-[#64758b]">{a.lastUpdated}</span>,
+    render: (a) => <span className="text-[#64748b]">{a.lastUpdated}</span>,
   },
 ];
 

--- a/packages/kb-ui/src/components/content/AIConversationLogEntry.followup-question.review.stories.tsx
+++ b/packages/kb-ui/src/components/content/AIConversationLogEntry.followup-question.review.stories.tsx
@@ -37,7 +37,7 @@ function FollowupQuestionReview() {
           icon={
             <RiCornerDownRightLine
               aria-hidden="true"
-              className="h-4 w-4 text-[#64758b]"
+              className="h-4 w-4 text-[#64748b]"
             />
           }
         >

--- a/packages/kb-ui/src/components/content/AIConversationLogEntry.tail-search-result-clicked.review.stories.tsx
+++ b/packages/kb-ui/src/components/content/AIConversationLogEntry.tail-search-result-clicked.review.stories.tsx
@@ -38,12 +38,12 @@ function TailSearchResultClickedReview() {
           icon={
             <RiCursorLine
               aria-hidden="true"
-              className="h-4 w-4 text-[#64758b]"
+              className="h-4 w-4 text-[#64748b]"
             />
           }
         >
           <div className="flex items-center gap-2 pt-[1px]">
-            <span aria-hidden="true" className="text-[14px] leading-5 text-[#64758b]">·</span>
+            <span aria-hidden="true" className="text-[14px] leading-5 text-[#64748b]">·</span>
             <RiFileTextLine
               aria-hidden="true"
               className="h-4 w-4 shrink-0 text-[#475569]"

--- a/packages/kb-ui/src/components/content/AIConversationLogEntry.tail-source-clicked.review.stories.tsx
+++ b/packages/kb-ui/src/components/content/AIConversationLogEntry.tail-source-clicked.review.stories.tsx
@@ -37,12 +37,12 @@ function TailSourceClickedReview() {
           icon={
             <RiCursorLine
               aria-hidden="true"
-              className="h-4 w-4 text-[#64758b]"
+              className="h-4 w-4 text-[#64748b]"
             />
           }
         >
           <div className="flex items-center gap-2 pt-[1px]">
-            <span aria-hidden="true" className="text-[14px] leading-5 text-[#64758b]">·</span>
+            <span aria-hidden="true" className="text-[14px] leading-5 text-[#64748b]">·</span>
             <RiBookOpenLine
               aria-hidden="true"
               className="h-4 w-4 shrink-0 text-[#475569]"

--- a/packages/kb-ui/src/components/content/AIConversationLogEntry.tail-ticket.review.stories.tsx
+++ b/packages/kb-ui/src/components/content/AIConversationLogEntry.tail-ticket.review.stories.tsx
@@ -37,12 +37,12 @@ function TailTicketReview() {
           icon={
             <RiCursorLine
               aria-hidden="true"
-              className="h-4 w-4 text-[#64758b]"
+              className="h-4 w-4 text-[#64748b]"
             />
           }
         >
           <div className="flex items-center gap-2 pt-[1px]">
-            <span aria-hidden="true" className="text-[14px] leading-5 text-[#64758b]">·</span>
+            <span aria-hidden="true" className="text-[14px] leading-5 text-[#64748b]">·</span>
             <RiPriceTag3Line
               aria-hidden="true"
               className="h-4 w-4 shrink-0 text-[#475569]"

--- a/packages/kb-ui/src/components/content/AIConversationLogEntry.tsx
+++ b/packages/kb-ui/src/components/content/AIConversationLogEntry.tsx
@@ -174,12 +174,12 @@ function TailRow({ tail }: TailRowProps) {
         icon={
           <CursorClickIcon
             size={14}
-            className="text-[#64758b]"
+            className="text-[#64748b]"
           />
         }
       >
         <div className="flex items-center gap-2 pt-[1px]">
-          <span aria-hidden="true" className="text-[14px] leading-5 text-[#64758b]">·</span>
+          <span aria-hidden="true" className="text-[14px] leading-5 text-[#64748b]">·</span>
           <RiPriceTag3Line
             aria-hidden="true"
             className="h-4 w-4 shrink-0 text-[#475569]"
@@ -203,12 +203,12 @@ function TailRow({ tail }: TailRowProps) {
         icon={
           <CursorClickIcon
             size={14}
-            className="text-[#64758b]"
+            className="text-[#64748b]"
           />
         }
       >
         <div className="flex items-center gap-2 pt-[1px]">
-          <span aria-hidden="true" className="text-[14px] leading-5 text-[#64758b]">·</span>
+          <span aria-hidden="true" className="text-[14px] leading-5 text-[#64748b]">·</span>
           <RiBookOpenLine
             aria-hidden="true"
             className="h-4 w-4 shrink-0 text-[#475569]"
@@ -230,12 +230,12 @@ function TailRow({ tail }: TailRowProps) {
       icon={
         <CursorClickIcon
           size={14}
-          className="text-[#64758b]"
+          className="text-[#64748b]"
         />
       }
     >
       <div className="flex items-center gap-2 pt-[1px]">
-        <span aria-hidden="true" className="text-[14px] leading-5 text-[#64758b]">·</span>
+        <span aria-hidden="true" className="text-[14px] leading-5 text-[#64748b]">·</span>
         <RiFileTextLine
           aria-hidden="true"
           className="h-4 w-4 shrink-0 text-[#475569]"
@@ -374,7 +374,7 @@ export function AIConversationLogEntry({
             icon={
               <RiCornerDownRightLine
                 aria-hidden="true"
-                className="h-4 w-4 text-[#64758b]"
+                className="h-4 w-4 text-[#64748b]"
               />
             }
           >

--- a/packages/kb-ui/src/components/content/AIConversationLogsCard.tsx
+++ b/packages/kb-ui/src/components/content/AIConversationLogsCard.tsx
@@ -76,7 +76,7 @@ function SortDropdown({ options, value, onChange }: SortDropdownProps) {
           <RiArrowDownSLine
             size={14}
             aria-hidden="true"
-            className="text-[#64758b]"
+            className="text-[#64748b]"
           />
         </button>
       </DropdownMenu.Trigger>
@@ -161,7 +161,7 @@ export function AIConversationLogsCard({
                     <RiInformationLine
                       size={16}
                       aria-hidden="true"
-                      className="text-[#64758b]"
+                      className="text-[#64748b]"
                     />
                   </span>
                 </div>

--- a/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
+++ b/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
@@ -199,7 +199,7 @@ export function AIGapSuggestionCard({
           aria-label={`Undo ${state} for ${suggestion.title}`}
           className={cn(
             'ml-auto inline-flex size-6 items-center justify-center rounded-[4px]',
-            'text-[#64758b] transition-colors',
+            'text-[#64748b] transition-colors',
             'hover:bg-[#f1f5f9] hover:text-[#0f172a]',
             'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
           )}
@@ -229,7 +229,7 @@ export function AIGapSuggestionCard({
           </h3>
           <p
             data-kb-part="ai-gap-description"
-            className="mt-1 text-[14px] font-normal leading-[20px] text-[#64758b]"
+            className="mt-1 text-[14px] font-normal leading-[20px] text-[#64748b]"
           >
             {suggestion.description}
           </p>

--- a/packages/kb-ui/src/components/content/AnalyticsChartCard.tsx
+++ b/packages/kb-ui/src/components/content/AnalyticsChartCard.tsx
@@ -56,14 +56,14 @@ export function AnalyticsChartCard({
               >
                 <RiInformationLine
                   size={16}
-                  className="text-[#64758b]"
+                  className="text-[#64748b]"
                   aria-hidden="true"
                 />
               </span>
             )}
           </div>
           {subtitle && (
-            <p className="text-[12px] font-normal leading-4 text-[#64758b]">
+            <p className="text-[12px] font-normal leading-4 text-[#64748b]">
               {subtitle}
             </p>
           )}

--- a/packages/kb-ui/src/components/content/ArticleSettingsPanel.stories.tsx
+++ b/packages/kb-ui/src/components/content/ArticleSettingsPanel.stories.tsx
@@ -169,7 +169,7 @@ function ArticleSettingsPanelPlayground() {
       label: 'Publish date',
       content: (
         <FieldBox ariaLabel="Change publish date">
-          <RiCalendar2Line aria-hidden="true" className="h-4 w-4 shrink-0 text-[#64758b]" />
+          <RiCalendar2Line aria-hidden="true" className="h-4 w-4 shrink-0 text-[#64748b]" />
           {customSettings.publishDate ? (
             <span className="truncate">{customSettings.publishDate}</span>
           ) : (
@@ -229,7 +229,7 @@ function ArticleSettingsPanelPlayground() {
           <button
             type="button"
             aria-label="Add reviewer"
-            className={`inline-flex size-6 items-center justify-center rounded-full border border-dashed border-[#cbd5e1] bg-white text-[#64758b] ring-2 ring-white hover:bg-[#f8fafc] focus:outline-none focus:ring-2 focus:ring-black/10${(customSettings.reviewers?.length ?? 0) > 0 ? ' -ml-2' : ''}`}
+            className={`inline-flex size-6 items-center justify-center rounded-full border border-dashed border-[#cbd5e1] bg-white text-[#64748b] ring-2 ring-white hover:bg-[#f8fafc] focus:outline-none focus:ring-2 focus:ring-black/10${(customSettings.reviewers?.length ?? 0) > 0 ? ' -ml-2' : ''}`}
           >
             <RiAddLine className="h-[14px] w-[14px]" />
           </button>

--- a/packages/kb-ui/src/components/content/ArticleSettingsPanel.tsx
+++ b/packages/kb-ui/src/components/content/ArticleSettingsPanel.tsx
@@ -250,7 +250,7 @@ function PublishDateField({
     <div className="flex flex-col gap-1.5">
       <FieldLabel>Publish date</FieldLabel>
       <FieldBox onClick={onOpen} ariaLabel="Change publish date">
-        <RiCalendar2Line aria-hidden="true" className="h-4 w-4 shrink-0 text-[#64758b]" />
+        <RiCalendar2Line aria-hidden="true" className="h-4 w-4 shrink-0 text-[#64748b]" />
         {date ? <span className="truncate">{date}</span> : <Placeholder>Pick a date</Placeholder>}
       </FieldBox>
     </div>
@@ -358,7 +358,7 @@ function ReviewersField({
           aria-label="Add reviewer"
           className={cn(
             'inline-flex size-6 items-center justify-center rounded-full border border-dashed border-[#cbd5e1]',
-            'bg-white text-[#64758b] ring-2 ring-white',
+            'bg-white text-[#64748b] ring-2 ring-white',
             reviewers.length > 0 && '-ml-2',
             'hover:bg-[#f8fafc] focus:outline-none focus:ring-2 focus:ring-black/10',
           )}

--- a/packages/kb-ui/src/components/content/ArticleSettingsPanelAtoms.tsx
+++ b/packages/kb-ui/src/components/content/ArticleSettingsPanelAtoms.tsx
@@ -101,7 +101,7 @@ export function TagChip({ label, onRemove }: TagChipProps) {
           aria-label={`Remove ${label}`}
           className={cn(
             'inline-flex h-[16px] w-[16px] items-center justify-center rounded-full',
-            'text-[#64758b] hover:bg-[#e2e8f0] hover:text-[#0f172a]',
+            'text-[#64748b] hover:bg-[#e2e8f0] hover:text-[#0f172a]',
             'focus:outline-none focus:ring-2 focus:ring-black/10',
           )}
         >

--- a/packages/kb-ui/src/components/content/ContentEditor.tsx
+++ b/packages/kb-ui/src/components/content/ContentEditor.tsx
@@ -699,7 +699,7 @@ function ContentEditorStyles() {
       [data-kb-part="content-editor"] .kb-editor-prose pre .hljs-attr { color: #86efac; }
       [data-kb-part="content-editor"] .kb-editor-prose pre .hljs-number,
       [data-kb-part="content-editor"] .kb-editor-prose pre .hljs-built_in { color: #fbbf24; }
-      [data-kb-part="content-editor"] .kb-editor-prose pre .hljs-comment { color: #64758b; font-style: italic; }
+      [data-kb-part="content-editor"] .kb-editor-prose pre .hljs-comment { color: #64748b; font-style: italic; }
       [data-kb-part="content-editor"] .kb-editor-prose pre .hljs-title,
       [data-kb-part="content-editor"] .kb-editor-prose pre .hljs-function,
       [data-kb-part="content-editor"] .kb-editor-prose pre .hljs-params { color: #60a5fa; }

--- a/packages/kb-ui/src/components/content/DataTable.articles.review.stories.tsx
+++ b/packages/kb-ui/src/components/content/DataTable.articles.review.stories.tsx
@@ -88,7 +88,7 @@ const articles: Article[] = [
 //   updated → Label 8  px-[24px] (scale/space/4xl), text #0f172a
 //
 // NOTE: the canonical KBCategoryPage uses px-4 (=16) on every cell
-// AND paints "Last Updated" subtle slate (#64758b). Both diverge
+// AND paints "Last Updated" subtle slate (#64748b). Both diverge
 // from Figma — flagged as page-level drift in the report.
 const articleColumns: DataTableColumn<Article>[] = [
   {
@@ -103,7 +103,7 @@ const articleColumns: DataTableColumn<Article>[] = [
           aria-label={`Open ${a.title}`}
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-[#64758b]',
+            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-[#64748b]',
             'hover:bg-[#f8fafc] focus:bg-[#f8fafc] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]',
           )}
         >
@@ -171,7 +171,7 @@ const articleColumns: DataTableColumn<Article>[] = [
     className: 'px-6',
     render: (a) => (
       // Figma colors this with the default text color (#0f172a), not
-      // the subtle slate (#64758b) the canonical page uses. Wrap with
+      // the subtle slate (#64748b) the canonical page uses. Wrap with
       // `block truncate` so longer strings ellipsis instead of wrapping
       // to a second line (would push the row past the canonical 48 px).
       <span className="block truncate text-[#0f172a]">{a.lastUpdated}</span>

--- a/packages/kb-ui/src/components/content/DataTable.stories.tsx
+++ b/packages/kb-ui/src/components/content/DataTable.stories.tsx
@@ -48,7 +48,7 @@ const articleColumns: DataTableColumn<Article>[] = [
     header: 'Article Title',
     render: (a) => (
       <div className="flex items-center gap-2 min-w-0 pr-2">
-        <RiFile3Line size={16} className="shrink-0 text-[#64758b]" aria-hidden="true" />
+        <RiFile3Line size={16} className="shrink-0 text-[#64748b]" aria-hidden="true" />
         <span className="truncate">{a.title}</span>
       </div>
     ),
@@ -79,7 +79,7 @@ const articleColumns: DataTableColumn<Article>[] = [
     header: 'Last Updated',
     width: 251,
     render: (a) => (
-      <span className="text-[#64758b]">{a.lastUpdated}</span>
+      <span className="text-[#64748b]">{a.lastUpdated}</span>
     ),
   },
 ];

--- a/packages/kb-ui/src/components/content/DataTable.subcategories.review.stories.tsx
+++ b/packages/kb-ui/src/components/content/DataTable.subcategories.review.stories.tsx
@@ -56,7 +56,7 @@ const subCategoryColumns: DataTableColumn<SubCategory>[] = [
           aria-label={`Open ${item.title}`}
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-[#64758b]',
+            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-[#64748b]',
             'hover:bg-[#f8fafc] focus:bg-[#f8fafc] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]',
           )}
         >

--- a/packages/kb-ui/src/components/content/DateRangePill.tsx
+++ b/packages/kb-ui/src/components/content/DateRangePill.tsx
@@ -65,9 +65,9 @@ export function DateRangePill({ value, onChange, label, className, presets }: Da
             className,
           )}
         >
-          <RiCalendarLine size={14} className="text-[#64758b]" aria-hidden="true" />
+          <RiCalendarLine size={14} className="text-[#64748b]" aria-hidden="true" />
           <span>{displayLabel}</span>
-          <RiArrowDownSLine size={14} className="text-[#64758b]" aria-hidden="true" />
+          <RiArrowDownSLine size={14} className="text-[#64748b]" aria-hidden="true" />
         </button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Portal>

--- a/packages/kb-ui/src/components/content/NavArrow.tsx
+++ b/packages/kb-ui/src/components/content/NavArrow.tsx
@@ -26,7 +26,7 @@ export function NavArrow({ direction, onClick, className }: NavArrowProps) {
       aria-label={direction === 'up' ? 'Previous suggestion' : 'Next suggestion'}
       className={cn(
         'inline-flex size-6 items-center justify-center rounded-[4px]',
-        'text-[#64758b] transition-colors',
+        'text-[#64748b] transition-colors',
         'hover:bg-[#f1f5f9] hover:text-[#0f172a]',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
         className,

--- a/packages/kb-ui/src/components/content/SlashCommandMenu.tsx
+++ b/packages/kb-ui/src/components/content/SlashCommandMenu.tsx
@@ -218,7 +218,7 @@ export const SlashCommandMenu = React.forwardRef<HTMLDivElement, SlashCommandMen
         )}
       >
         {items.length === 0 ? (
-          <div className="px-3 py-2 text-[13px] leading-5 text-[#64758b]">No results</div>
+          <div className="px-3 py-2 text-[13px] leading-5 text-[#64748b]">No results</div>
         ) : (
           <div ref={listRef} className="max-h-[280px] overflow-y-auto">
             {items.map((cmd, i) => {
@@ -254,7 +254,7 @@ export const SlashCommandMenu = React.forwardRef<HTMLDivElement, SlashCommandMen
                     <span className="text-[14px] font-medium leading-5 text-[#0f172a]">
                       {cmd.title}
                     </span>
-                    <span className="text-[12px] font-normal leading-[18px] text-[#64758b]">
+                    <span className="text-[12px] font-normal leading-[18px] text-[#64748b]">
                       {cmd.subtitle}
                     </span>
                   </span>

--- a/packages/kb-ui/src/components/content/StatCardGrid.tsx
+++ b/packages/kb-ui/src/components/content/StatCardGrid.tsx
@@ -39,7 +39,7 @@ export function StatCardGrid({ title, infoTooltip, stats, className, headerRight
           className="inline-flex"
           {...(infoTooltip ? { title: infoTooltip, 'aria-label': infoTooltip } : {})}
         >
-          <RiInformationLine size={16} className="text-[#64758b]" aria-hidden="true" />
+          <RiInformationLine size={16} className="text-[#64748b]" aria-hidden="true" />
         </span>
         {headerRight !== undefined ? <div className="ml-auto flex items-center">{headerRight}</div> : null}
       </div>

--- a/packages/kb-ui/src/components/content/SuggestionCard.tsx
+++ b/packages/kb-ui/src/components/content/SuggestionCard.tsx
@@ -41,7 +41,7 @@ export type SuggestionKindMeta = {
  *   Brand pink   : #D92FFF (start of the AiIcon gradient — used for
  *                  all "suggestion" glyphs so they read as a family)
  *   Title text   : #0f172a
- *   Description  : #64758b (muted body — matches Figma screenshot)
+ *   Description  : #64748b (muted body — matches Figma screenshot)
  *   Divider      : #f1f5f9 (1px, full inner width)
  *   Meta label   : #475569 (meta text — matches kb-ui tokens)
  *   Meta dim     : #94a3b8 (middot separator)
@@ -264,7 +264,7 @@ export function SuggestionCard({
           flush with icon, not indented past it). */}
       <p
         data-kb-part="suggestion-description"
-        className="text-[14px] font-normal leading-5 text-[#64758b]"
+        className="text-[14px] font-normal leading-5 text-[#64748b]"
       >
         {description}
       </p>

--- a/packages/kb-ui/src/components/nav/FileExplorerNav.stories.tsx
+++ b/packages/kb-ui/src/components/nav/FileExplorerNav.stories.tsx
@@ -110,7 +110,7 @@ function FileExplorerNavPlayground() {
         showSearch={true}
       />
       <div className="flex-1 bg-[#f5f5f5] flex items-center justify-center">
-        <span className="text-[14px] text-[#64758b]">
+        <span className="text-[14px] text-[#64748b]">
           Editing: {activeTitle}
         </span>
       </div>

--- a/packages/kb-ui/src/components/nav/FileExplorerNav.tsx
+++ b/packages/kb-ui/src/components/nav/FileExplorerNav.tsx
@@ -250,7 +250,7 @@ function FolderRow({
           <span
             className={cn(
               'flex size-6 items-center justify-center rounded-[6px] shrink-0',
-              isDark ? 'text-white/60' : 'text-[#64758b]',
+              isDark ? 'text-white/60' : 'text-[#64748b]',
             )}
           >
             <ChevronIcon size={16} />
@@ -258,7 +258,7 @@ function FolderRow({
           <span
             className={cn(
               'flex size-6 items-center justify-center rounded-[6px] shrink-0',
-              isDark ? 'text-white/60' : 'text-[#64758b]',
+              isDark ? 'text-white/60' : 'text-[#64748b]',
             )}
           >
             <RiFolderLine size={16} />
@@ -349,7 +349,7 @@ function ArticleRow({ item, depth, isActive, isDark, onClick }: ArticleRowProps)
           <span
             className={cn(
               'flex size-6 items-center justify-center rounded-[6px] shrink-0',
-              isDark ? 'text-white/60' : 'text-[#64758b]',
+              isDark ? 'text-white/60' : 'text-[#64748b]',
             )}
           >
             <RiFile3Line size={16} />
@@ -416,7 +416,7 @@ export function FileExplorerNav({
     (isFlat ? null : (
       <RiQuillPenLine
         size={16}
-        className={isDark ? 'text-white/60' : 'text-[#64758b]'}
+        className={isDark ? 'text-white/60' : 'text-[#64748b]'}
       />
     ));
 
@@ -554,7 +554,7 @@ export function FileExplorerNav({
               'flex size-6 items-center justify-center rounded-[6px] cursor-pointer transition-colors duration-150',
               isDark
                 ? 'text-white/60 hover:bg-white/[0.06] hover:text-white/90'
-                : 'text-[#64758b] hover:bg-[#f8fafc] hover:text-[#0f172a]',
+                : 'text-[#64748b] hover:bg-[#f8fafc] hover:text-[#0f172a]',
             )}
           >
             <RiSearchLine size={16} />

--- a/packages/kb-ui/src/components/nav/SideNavRail.stories.tsx
+++ b/packages/kb-ui/src/components/nav/SideNavRail.stories.tsx
@@ -35,7 +35,7 @@ function SideNavRailPlayground() {
         bottomSlot={<Avatar initials="VK" />}
       />
       <div className="flex-1 bg-[#f5f5f5] flex items-center justify-center">
-        <span className="text-[14px] text-[#64758b]">
+        <span className="text-[14px] text-[#64748b]">
           Active section: {labelFor(activeId)}
         </span>
       </div>

--- a/packages/kb-ui/src/components/overlays/SideSheet.stories.tsx
+++ b/packages/kb-ui/src/components/overlays/SideSheet.stories.tsx
@@ -55,7 +55,7 @@ function SideSheetPlayground() {
               key={citation.senderName}
               className="rounded-[8px] border border-[#e5e5e5] p-3 flex flex-col gap-1"
             >
-              <div className="text-[12px] text-[#64758b] flex items-center gap-2">
+              <div className="text-[12px] text-[#64748b] flex items-center gap-2">
                 <span>{citation.senderName}</span>
                 <span>·</span>
                 <span>{citation.timestamp}</span>

--- a/packages/kb-ui/src/components/overlays/SideSheet.tsx
+++ b/packages/kb-ui/src/components/overlays/SideSheet.tsx
@@ -45,7 +45,7 @@ const titleClass =
 const countClass =
   'inline-flex h-[20px] min-w-[20px] items-center justify-center rounded-full px-2 bg-[#f1f5f9] text-[12px] font-medium leading-[18px] text-[#475569] tabular-nums';
 const closeBtnClass =
-  'inline-flex h-8 w-8 items-center justify-center rounded-[6px] text-[#64758b] transition-colors hover:bg-[#f1f5f9] hover:text-[#0f172a] focus:outline-none focus:ring-2 focus:ring-black/10';
+  'inline-flex h-8 w-8 items-center justify-center rounded-[6px] text-[#64748b] transition-colors hover:bg-[#f1f5f9] hover:text-[#0f172a] focus:outline-none focus:ring-2 focus:ring-black/10';
 const bodyClass = 'flex flex-1 flex-col overflow-y-auto px-5 py-4';
 
 /* ─────────────────────────────────────────────────────────────

--- a/packages/kb-ui/src/components/overlays/SourcesSideSheet.tsx
+++ b/packages/kb-ui/src/components/overlays/SourcesSideSheet.tsx
@@ -85,12 +85,12 @@ export function MailItem({
       <div className="flex items-center gap-2">
         <RiMailLine
           aria-hidden="true"
-          className="h-4 w-4 shrink-0 text-[#64758b]"
+          className="h-4 w-4 shrink-0 text-[#64748b]"
         />
         <span className="flex-1 truncate text-[14px] font-semibold leading-[20px] text-[#0f172a]">
           {senderName}
         </span>
-        <span className="shrink-0 text-[12px] font-normal leading-[18px] text-[#64758b]">
+        <span className="shrink-0 text-[12px] font-normal leading-[18px] text-[#64748b]">
           {timestamp}
         </span>
       </div>
@@ -101,7 +101,7 @@ export function MailItem({
       </div>
 
       {/* Row 3: preview snippet (single-line, ellipsized) */}
-      <div className="mt-1 truncate text-[14px] font-normal leading-[20px] text-[#64758b]">
+      <div className="mt-1 truncate text-[14px] font-normal leading-[20px] text-[#64748b]">
         {snippet}
       </div>
     </>

--- a/packages/kb-ui/src/components/primitives/Avatar.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Avatar.stories.tsx
@@ -38,7 +38,7 @@ function AvatarPlayground() {
             initials={person.initials}
             src={person.src}
           />
-          <span className="text-[12px] leading-[18px] text-[#64758b]">
+          <span className="text-[12px] leading-[18px] text-[#64748b]">
             {person.name}
           </span>
         </div>

--- a/packages/kb-ui/src/components/primitives/Card.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Card.stories.tsx
@@ -18,7 +18,7 @@ function CardPlayground() {
         <h3 className="text-[16px] font-semibold leading-6 text-[#0f172a]">
           Reset your password
         </h3>
-        <p className="text-[14px] leading-5 text-[#64758b] mt-2">
+        <p className="text-[14px] leading-5 text-[#64748b] mt-2">
           Step-by-step guide to recover access if you've forgotten your credentials.
           Updated for 2026.
         </p>

--- a/packages/kb-ui/src/components/primitives/Divider.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Divider.stories.tsx
@@ -23,7 +23,7 @@ function DividerPlayground() {
       {SECTIONS.map((section, index) => (
         <div key={section.label}>
           <div className="py-3">
-            <div className="text-[12px] leading-[18px] text-[#64758b]">
+            <div className="text-[12px] leading-[18px] text-[#64748b]">
               {section.label}
             </div>
             <div className="text-[14px] leading-[20px] text-[#0f172a]">

--- a/packages/kb-ui/src/components/primitives/TextInput.tsx
+++ b/packages/kb-ui/src/components/primitives/TextInput.tsx
@@ -53,7 +53,7 @@ export function TextInput({
         )}
       />
       {charCount && (
-        <span className="shrink-0 text-[12px] font-normal leading-[18px] text-[#64758b] tabular-nums">
+        <span className="shrink-0 text-[12px] font-normal leading-[18px] text-[#64748b] tabular-nums">
           {charCount.current}/{charCount.max}
         </span>
       )}

--- a/packages/kb-ui/src/components/shell/KBBreadcrumbBar.tsx
+++ b/packages/kb-ui/src/components/shell/KBBreadcrumbBar.tsx
@@ -71,7 +71,7 @@ export function KBBreadcrumbBar({
           onClick={handleLeadingClick}
           aria-label={leadingLabel}
           data-testid={leadingTestId}
-          className="inline-flex size-[22px] shrink-0 p-[4px] items-center justify-center rounded-[4px] text-[#64758b] hover:bg-[#f8fafc] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]"
+          className="inline-flex size-[22px] shrink-0 p-[4px] items-center justify-center rounded-[4px] text-[#64748b] hover:bg-[#f8fafc] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]"
         >
           <LeadingIcon size={14} />
         </button>

--- a/packages/kb-ui/src/pages/KBAIGapsExperience.stories.tsx
+++ b/packages/kb-ui/src/pages/KBAIGapsExperience.stories.tsx
@@ -123,7 +123,7 @@ function H1({ children }: { children: React.ReactNode }) {
 
 function Subtitle({ children }: { children: React.ReactNode }) {
   return (
-    <p className="mb-6 text-[14px] font-normal leading-[20px] text-[#64758b]">
+    <p className="mb-6 text-[14px] font-normal leading-[20px] text-[#64748b]">
       {children}
     </p>
   );

--- a/packages/kb-ui/src/pages/KBAnalyticsAIAnswerPerformancePage.stories.tsx
+++ b/packages/kb-ui/src/pages/KBAnalyticsAIAnswerPerformancePage.stories.tsx
@@ -128,7 +128,7 @@ const citedColumns: DataTableColumn<Cited>[] = [
       <span className="inline-flex items-center gap-2">
         <RiFile3Line
           size={16}
-          className="shrink-0 text-[#64758b]"
+          className="shrink-0 text-[#64748b]"
           aria-hidden="true"
         />
         <span>{r.title}</span>

--- a/packages/kb-ui/src/pages/KBAnalyticsArticlePerformancePage.stories.tsx
+++ b/packages/kb-ui/src/pages/KBAnalyticsArticlePerformancePage.stories.tsx
@@ -99,7 +99,7 @@ const attentionColumns: DataTableColumn<AttentionRow>[] = [
       <div className="flex items-center gap-2 min-w-0 pr-2">
         <RiFile3Line
           size={16}
-          className="shrink-0 text-[#64758b]"
+          className="shrink-0 text-[#64748b]"
           aria-hidden="true"
         />
         <span className="truncate">{r.title}</span>
@@ -172,7 +172,7 @@ const performanceColumns: DataTableColumn<PerfRow>[] = [
       <div className="flex items-center gap-2 min-w-0 pr-2">
         <RiFile3Line
           size={16}
-          className="shrink-0 text-[#64758b]"
+          className="shrink-0 text-[#64748b]"
           aria-hidden="true"
         />
         <span className="truncate">{r.title}</span>

--- a/packages/kb-ui/src/pages/KBCategoryPage.stories.tsx
+++ b/packages/kb-ui/src/pages/KBCategoryPage.stories.tsx
@@ -133,7 +133,7 @@ const subCategoryColumns: DataTableColumn<SubCategory>[] = [
           aria-label={`Open ${item.title}`}
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-[#64758b]',
+            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-[#64748b]',
             'hover:bg-[#f8fafc] focus:bg-[#f8fafc] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]',
           )}
         >
@@ -160,7 +160,7 @@ const articleColumns: DataTableColumn<Article>[] = [
           aria-label={`Open ${a.title}`}
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-[#64758b]',
+            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-[#64748b]',
             'hover:bg-[#f8fafc] focus:bg-[#f8fafc] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]',
           )}
         >
@@ -227,7 +227,7 @@ const articleColumns: DataTableColumn<Article>[] = [
     headerClassName: 'px-4 py-0 text-[#475569]',
     className: 'px-4',
     render: (a) => (
-      <span className="text-[#64758b]">{a.lastUpdated}</span>
+      <span className="text-[#64748b]">{a.lastUpdated}</span>
     ),
   },
 ];

--- a/packages/kb-ui/src/pages/KBEditorPage.stories.tsx
+++ b/packages/kb-ui/src/pages/KBEditorPage.stories.tsx
@@ -135,7 +135,7 @@ const expandedBreadcrumbItems = [
 
 /**
  * Figma `53:8464` shows, directly under the H1:
- *   "Last updated 9 months ago"   — subtitle, 14/20 #64758b
+ *   "Last updated 9 months ago"   — subtitle, 14/20 #64748b
  *
  * Per spec we are NOT modifying `ContentEditor.tsx`; the subtitle is
  * injected as a first paragraph in the editor content. Tiptap strips most

--- a/packages/kb-ui/src/stories/Welcome.stories.tsx
+++ b/packages/kb-ui/src/stories/Welcome.stories.tsx
@@ -35,7 +35,7 @@ const card = (idx: number, title: string, body: React.ReactNode): React.ReactNod
       <span style={{ color: '#6634ef', fontWeight: 700, fontSize: 14 }}>{idx}</span>
     </div>
     <h3 style={{ fontSize: 15, fontWeight: 600, margin: '0 0 6px' }}>{title}</h3>
-    <p style={{ fontSize: 13, lineHeight: 1.5, color: '#64758b', margin: 0 }}>{body}</p>
+    <p style={{ fontSize: 13, lineHeight: 1.5, color: '#64748b', margin: 0 }}>{body}</p>
   </div>
 );
 

--- a/packages/kb-ui/src/tokens.css
+++ b/packages/kb-ui/src/tokens.css
@@ -20,7 +20,7 @@
   --color-text-primary:   #0f172a;  /* headings, primary labels */
   --color-text-secondary: #334155;  /* card titles, secondary labels */
   --color-text-meta:      #475569;  /* meta info, sources badge */
-  --color-text-muted:     #64758b;  /* Figma text/neutral/faint — body copy, descriptions */
+  --color-text-muted:     #64748b;  /* Figma text/neutral/faint — body copy, descriptions */
 
   /* ── Semantic ───────────────────────────────── */
   --color-success-text:   #086e3f;  /* addition badge text */
@@ -29,7 +29,7 @@
   --color-border:         #f1f5f9;  /* card strokes, dividers */
   --color-border-input:   #e5e5e5;  /* input borders */
   --color-text-disabled:  #94a3b8;  /* disabled text */
-  --color-text-faint:     #64758b;  /* Figma text/neutral/faint — faint label text */
+  --color-text-faint:     #64748b;  /* Figma text/neutral/faint — faint label text */
   --color-highlight:      #e7f9ee;  /* inline highlight bg */
 
   /* ── AI Gaps semantic palette ──────────────── */
@@ -125,9 +125,9 @@
   --color-text-primary:   #0f172a;
   --color-text-secondary: #334155;
   --color-text-meta:      #475569;
-  --color-text-muted:     #64758b;  /* Figma text/neutral/faint */
+  --color-text-muted:     #64748b;  /* Figma text/neutral/faint */
   --color-text-disabled:  #94a3b8;
-  --color-text-faint:     #64758b;  /* Figma text/neutral/faint */
+  --color-text-faint:     #64748b;  /* Figma text/neutral/faint */
 
   --color-success-text:   #086e3f;
   --color-btn-primary:    #000000;

--- a/packages/kb-ui/src/tokens.ts
+++ b/packages/kb-ui/src/tokens.ts
@@ -15,9 +15,9 @@ export const tokens = {
     textPrimary: '#0f172a',
     textSecondary: '#334155',
     textMeta: '#475569',
-    textMuted: '#64758b',   // Figma text/neutral/faint
+    textMuted: '#64748b',   // Figma text/neutral/faint
     textDisabled: '#94a3b8',
-    textFaint: '#64758b',   // Figma text/neutral/faint
+    textFaint: '#64748b',   // Figma text/neutral/faint
 
     successText: '#086e3f',
     btnPrimary: '#000000',


### PR DESCRIPTION
- Tokens (`--color-text-muted`, `--color-text-faint`) and 107 inline occurrences across `packages/kb-ui/src/` + `apps/demo/` swept from `#64758b` to `#64748b` (Tailwind slate-500 — what `design.md` already documents).
- `Foundations.stories.tsx` intentionally left for Chunk 3 (doc sync).
- Verified: typecheck, build, build-storybook all green; final `grep -rn "#64758b"` returns only the 5 expected lines in `Foundations.stories.tsx`.