### PR TITLE
refactor(kb-ui): tokenize primitives (chunk 3a)

### DIFF
--- a/packages/kb-ui/src/components/primitives/Badge.tsx
+++ b/packages/kb-ui/src/components/primitives/Badge.tsx
@@ -12,11 +12,11 @@ export type BadgeProps = {
 const variantStyles: Record<BadgeVariant, string> = {
   // Padding equalised on both sides per Figma `tag.png` measurement
   // (~9-10 px each side at 1x render scale → `px-2`).
-  published: 'bg-[#f2fdf6] text-[#086e3f] px-2',
+  published: 'bg-[#f2fdf6] text-success-text px-2',
   // Draft bg sampled from Figma `tag.png` at the pill interior =
   // #f5f5f5 (was previously #fcfcfc, which read too washed-out).
-  draft: 'bg-[#f5f5f5] text-[#0f172a] px-2',
-  neutral: 'bg-[#f5f5f5] text-[#0f172a] px-2',
+  draft: 'bg-canvas text-text-primary px-2',
+  neutral: 'bg-canvas text-text-primary px-2',
 };
 
 export function Badge({ variant = 'neutral', icon, children, className }: BadgeProps) {
@@ -29,7 +29,7 @@ export function Badge({ variant = 'neutral', icon, children, className }: BadgeP
       )}
     >
       {variant === 'published' && !icon && (
-        <span className="size-[4px] rounded-full bg-[#086e3f] shrink-0" />
+        <span className="size-[4px] rounded-full bg-success-text shrink-0" />
       )}
       {icon && <span className="flex size-[14px] shrink-0 items-center justify-center">{icon}</span>}
       {children}

--- a/packages/kb-ui/src/components/primitives/Breadcrumb.tsx
+++ b/packages/kb-ui/src/components/primitives/Breadcrumb.tsx
@@ -34,7 +34,7 @@ export function Breadcrumb({ items, className, homeIcon, separator }: Breadcrumb
         )}
         aria-label={home.label}
       >
-        {homeIcon ?? <RiLayoutLeftLine size={14} className="text-[#94a3b8]" />}
+        {homeIcon ?? <RiLayoutLeftLine size={14} className="text-text-disabled" />}
       </button>
       {rest.map((item, idx) => {
         const isCurrent = idx === lastIdx;
@@ -43,14 +43,14 @@ export function Breadcrumb({ items, className, homeIcon, separator }: Breadcrumb
           <span key={item.id} className="inline-flex items-center gap-1">
             <span
               aria-hidden="true"
-              className="inline-flex items-center justify-center text-[14px] leading-5 text-[#cbd5e1] px-[2px] shrink-0 select-none"
+              className="inline-flex items-center justify-center text-[14px] leading-5 text-border-faint px-[2px] shrink-0 select-none"
             >
               {separator ?? '/'}
             </span>
             {isCurrent ? (
               <span
                 aria-current="page"
-                className="text-[14px] font-medium text-[#0f172a] bg-[#f8fafc] rounded-[4px] px-2 py-0.5"
+                className="text-[14px] font-medium text-text-primary bg-surface-subtle rounded-[4px] px-2 py-0.5"
               >
                 {item.label}
               </span>
@@ -58,12 +58,12 @@ export function Breadcrumb({ items, className, homeIcon, separator }: Breadcrumb
               <button
                 type="button"
                 onClick={item.onClick}
-                className="text-[14px] font-normal text-[#475569] hover:text-[#0f172a] cursor-pointer bg-transparent p-0 border-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20 rounded-[4px]"
+                className="text-[14px] font-normal text-text-meta hover:text-text-primary cursor-pointer bg-transparent p-0 border-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20 rounded-[4px]"
               >
                 {item.label}
               </button>
             ) : (
-              <span className="text-[14px] font-normal text-[#475569]">
+              <span className="text-[14px] font-normal text-text-meta">
                 {item.label}
               </span>
             )}

--- a/packages/kb-ui/src/components/primitives/Button.tsx
+++ b/packages/kb-ui/src/components/primitives/Button.tsx
@@ -31,15 +31,15 @@ export function Button({
       disabled={disabled}
       className={cn(
         'box-border inline-flex items-center justify-center gap-1.5 font-sans text-[14px] font-medium leading-5 transition-colors',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1] focus-visible:ring-offset-1',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-faint focus-visible:ring-offset-1',
         {
           'h-8 px-3 rounded-[6px] bg-black text-white hover:bg-black/90 active:bg-black/80': variant === 'primary',
-          'h-8 px-3 rounded-[6px] bg-[#f1f5f9] text-[#0f172a] hover:bg-[#e2e8f0] active:bg-[#cbd5e1]': variant === 'subtle',
-          'h-8 px-3 rounded-[6px] bg-transparent text-[#0f172a] hover:bg-[#f8fafc] active:bg-[#f1f5f9]': variant === 'ghost',
-          'h-8 w-8 rounded-[6px] bg-[#f8fafc] text-[#0f172a] hover:bg-[#e2e8f0] active:bg-[#cbd5e1]': variant === 'icon',
-          'h-8 px-3 rounded-[6px] bg-transparent text-[#0f172a] border border-[#d5d5d5] hover:bg-[#f8fafc] active:bg-[#f1f5f9]': variant === 'outline',
+          'h-8 px-3 rounded-[6px] bg-surface-muted text-text-primary hover:bg-card-border active:bg-border-faint': variant === 'subtle',
+          'h-8 px-3 rounded-[6px] bg-transparent text-text-primary hover:bg-surface-subtle active:bg-surface-muted': variant === 'ghost',
+          'h-8 w-8 rounded-[6px] bg-surface-subtle text-text-primary hover:bg-card-border active:bg-border-faint': variant === 'icon',
+          'h-8 px-3 rounded-[6px] bg-transparent text-text-primary border border-[#d5d5d5] hover:bg-surface-subtle active:bg-surface-muted': variant === 'outline',
           'h-8 px-3 rounded-[6px] bg-[#f03f33] text-white hover:bg-[#f03f33]/90 active:bg-[#f03f33]/80': variant === 'danger',
-          'h-8 px-3 rounded-[6px] bg-transparent text-[#d52c1f] border border-[#f96c62] hover:bg-[#fef2f2] active:bg-[#fee2e2]': variant === 'danger-outline',
+          'h-8 px-3 rounded-[6px] bg-transparent text-ai-removal border border-[#f96c62] hover:bg-[#fef2f2] active:bg-[#fee2e2]': variant === 'danger-outline',
           'opacity-50 cursor-not-allowed pointer-events-none': disabled,
         },
         className,

--- a/packages/kb-ui/src/components/primitives/Divider.tsx
+++ b/packages/kb-ui/src/components/primitives/Divider.tsx
@@ -7,7 +7,7 @@ export function Divider({ subtle = false, className }: DividerProps) {
     <hr
       className={cn(
         'w-full border-0 border-t',
-        subtle ? 'border-t-[#f1f5f9]' : 'border-t-[#e5e5e5]',
+        subtle ? 'border-t-surface-muted' : 'border-t-[#e5e5e5]',
         className,
       )}
     />

--- a/packages/kb-ui/src/components/primitives/Dropdown.tsx
+++ b/packages/kb-ui/src/components/primitives/Dropdown.tsx
@@ -19,10 +19,10 @@ export function Dropdown({
 }: DropdownProps) {
   const trigger = (
     <div className={cn('flex flex-col gap-2', className)}>
-      <label className="text-[14px] font-medium leading-5 text-[#0f172a]">{label}</label>
+      <label className="text-[14px] font-medium leading-5 text-text-primary">{label}</label>
       <TextInput
         {...inputProps}
-        suffix={<RiArrowDownSLine size={14} className="text-[#475569]" />}
+        suffix={<RiArrowDownSLine size={14} className="text-text-meta" />}
       />
     </div>
   );
@@ -56,7 +56,7 @@ export function Dropdown({
                 onSelect?.(option.value);
               }}
               className={cn(
-                'mx-1 cursor-pointer rounded-[4px] px-3 py-2 text-[14px] outline-none hover:bg-[#f1f5f9] focus:bg-[#f1f5f9]',
+                'mx-1 cursor-pointer rounded-[4px] px-3 py-2 text-[14px] outline-none hover:bg-surface-muted focus:bg-surface-muted',
                 option.disabled && 'cursor-not-allowed opacity-50 hover:bg-transparent focus:bg-transparent',
               )}
             >

--- a/packages/kb-ui/src/components/primitives/Field.tsx
+++ b/packages/kb-ui/src/components/primitives/Field.tsx
@@ -41,11 +41,11 @@ export function Field({
           {label !== undefined && (
             <label
               htmlFor={htmlFor}
-              className="text-[14px] font-medium leading-5 text-[#0f172a]"
+              className="text-[14px] font-medium leading-5 text-text-primary"
             >
               {label}
               {required && (
-                <span aria-hidden="true" className="ml-0.5 text-[#64748b]">
+                <span aria-hidden="true" className="ml-0.5 text-text-muted">
                   *
                 </span>
               )}
@@ -58,7 +58,7 @@ export function Field({
                   <button
                     type="button"
                     aria-label="More information"
-                    className="inline-flex items-center text-[#94a3b8] outline-none focus-visible:text-[#475569]"
+                    className="inline-flex items-center text-text-disabled outline-none focus-visible:text-text-meta"
                   >
                     <RiInformationLine size={14} aria-hidden="true" />
                   </button>
@@ -67,10 +67,10 @@ export function Field({
                   <Tooltip.Content
                     side="top"
                     sideOffset={6}
-                    className="z-50 max-w-xs rounded-md bg-[#0f172a] px-2 py-1 text-[12px] leading-[18px] text-white shadow-md"
+                    className="z-50 max-w-xs rounded-md bg-text-primary px-2 py-1 text-[12px] leading-[18px] text-white shadow-md"
                   >
                     {tooltip}
-                    <Tooltip.Arrow className="fill-[#0f172a]" />
+                    <Tooltip.Arrow className="fill-text-primary" />
                   </Tooltip.Content>
                 </Tooltip.Portal>
               </Tooltip.Root>
@@ -80,7 +80,7 @@ export function Field({
       )}
       {children}
       {showHintRow && (
-        <div className="flex items-center justify-between gap-2 text-[12px] font-normal leading-[18px] text-[#64748b]">
+        <div className="flex items-center justify-between gap-2 text-[12px] font-normal leading-[18px] text-text-muted">
           <span>{hint}</span>
           {hintEnd !== undefined && <span>{hintEnd}</span>}
         </div>

--- a/packages/kb-ui/src/components/primitives/TextInput.tsx
+++ b/packages/kb-ui/src/components/primitives/TextInput.tsx
@@ -48,12 +48,12 @@ export function TextInput({
         placeholder={placeholder}
         disabled={disabled}
         className={cn(
-          'min-w-0 flex-1 border-0 bg-transparent p-0 text-[14px] font-normal leading-5 text-[#0f172a] outline-none placeholder:text-[#94a3b8] disabled:cursor-not-allowed',
+          'min-w-0 flex-1 border-0 bg-transparent p-0 text-[14px] font-normal leading-5 text-text-primary outline-none placeholder:text-text-disabled disabled:cursor-not-allowed',
           inputClassName,
         )}
       />
       {charCount && (
-        <span className="shrink-0 text-[12px] font-normal leading-[18px] text-[#64748b] tabular-nums">
+        <span className="shrink-0 text-[12px] font-normal leading-[18px] text-text-muted tabular-nums">
           {charCount.current}/{charCount.max}
         </span>
       )}

--- a/packages/kb-ui/src/tokens.css
+++ b/packages/kb-ui/src/tokens.css
@@ -30,6 +30,7 @@
   --color-btn-danger-bg:       #feeeec;  /* dismiss/delete button background */
   --color-border:              #f1f5f9;  /* card strokes, dividers */
   --color-border-input:        #e2e8f0;  /* slate-200 — unified card outer border + input border + divider */
+  --color-border-faint:        #cbd5e1;  /* slate-300 — soft hairlines, chevron separators, pressed-state bg */
   --color-text-disabled:       #94a3b8;  /* disabled text */
   --color-highlight:           #e7f9ee;  /* inline highlight bg */
 
@@ -136,6 +137,7 @@
 
   --color-border:              #f1f5f9;
   --color-border-input:        #e2e8f0;  /* slate-200 — unified card outer border + input border + divider */
+  --color-border-faint:        #cbd5e1;  /* slate-300 — soft hairlines, chevron separators, pressed-state bg */
   --color-highlight:           #e7f9ee;
 
   /* ── AI Gaps semantic palette ──────────────── */

--- a/packages/kb-ui/src/tokens.ts
+++ b/packages/kb-ui/src/tokens.ts
@@ -25,6 +25,7 @@ export const tokens = {
 
     border: '#f1f5f9',
     borderInput: '#e2e8f0',  // slate-200 — unified card outer border + input border + divider
+    borderFaint: '#cbd5e1',  // slate-300 — soft hairlines, chevron separators, pressed-state bg
     highlight: '#e7f9ee',
 
     // AI Gaps semantic (Figma file 9aGp5t9fH1d0PXi4LMhOdb Frame 3 active addition 81:16926)


### PR DESCRIPTION
## Summary

- Added `--color-border-faint` (#cbd5e1, slate-300) token to `tokens.css` (both `:root` and `@theme`) + `tokens.ts`
- Swept 7 primitives (Button, Badge, Field, Breadcrumb, TextInput, Dropdown, Divider) from inline `text-[#hex]` / `bg-[#hex]` / `border-[#hex]` to token classes (`text-text-primary`, `bg-canvas`, `border-card-border`, etc.)
- Button-internal danger palette (`#f03f33`, `#f96c62`, `#fef2f2`, `#fee2e2`, `#d5d5d5`) intentionally stays inline per spec; SVG `fill=`/`stroke=` and TS-constant hexes deferred to follow-up
- Verification gate passed: typecheck + build + build-storybook