### PR TITLE
refactor(kb-ui): tokenize content components (chunk 3b)

### DIFF
--- a/packages/kb-ui/src/components/content/AIConversationLogEntry.tsx
+++ b/packages/kb-ui/src/components/content/AIConversationLogEntry.tsx
@@ -112,16 +112,16 @@ function FeedbackTimestamp({
       {feedback === 'positive' ? (
         <RiThumbUpLine
           aria-hidden="true"
-          className="h-3.5 w-3.5 text-[#086e3f]"
+          className="h-3.5 w-3.5 text-success-text"
         />
       ) : feedback === 'negative' ? (
         <RiThumbDownLine
           aria-hidden="true"
-          className="h-3.5 w-3.5 text-[#d52c1f]"
+          className="h-3.5 w-3.5 text-ai-removal"
         />
       ) : null}
-      {feedback ? <span className="h-3 w-px bg-[#cbd5e1]" aria-hidden="true" /> : null}
-      <span className="text-[13px] font-normal leading-[19px] text-[#475569]">
+      {feedback ? <span className="h-3 w-px bg-border-faint" aria-hidden="true" /> : null}
+      <span className="text-[13px] font-normal leading-[19px] text-text-meta">
         {timestamp}
       </span>
     </div>
@@ -140,8 +140,8 @@ function SourcesLink({ count, onClick }: SourcesLinkProps) {
       onClick={onClick}
       data-kb-part="ai-conversation-log-sources-link"
       className={cn(
-        'text-left text-[14px] font-normal leading-5 text-[#0f172a] underline underline-offset-2',
-        'hover:text-[#0f172a]/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10 focus-visible:rounded-[2px]',
+        'text-left text-[14px] font-normal leading-5 text-text-primary underline underline-offset-2',
+        'hover:text-text-primary/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10 focus-visible:rounded-[2px]',
       )}
     >
       {count} Sources
@@ -174,18 +174,18 @@ function TailRow({ tail }: TailRowProps) {
         icon={
           <CursorClickIcon
             size={14}
-            className="text-[#64748b]"
+            className="text-text-muted"
           />
         }
       >
         <div className="flex items-center gap-2 pt-[1px]">
-          <span aria-hidden="true" className="text-[14px] leading-5 text-[#64748b]">·</span>
+          <span aria-hidden="true" className="text-[14px] leading-5 text-text-muted">·</span>
           <RiPriceTag3Line
             aria-hidden="true"
-            className="h-4 w-4 shrink-0 text-[#475569]"
+            className="h-4 w-4 shrink-0 text-text-meta"
           />
-          <span className="text-[13px] font-normal leading-[19px] text-[#475569]">
-            <span className="text-[#0f172a] underline underline-offset-2">
+          <span className="text-[13px] font-normal leading-[19px] text-text-meta">
+            <span className="text-text-primary underline underline-offset-2">
               Ticket
             </span>{' '}
             created by {actor}
@@ -203,18 +203,18 @@ function TailRow({ tail }: TailRowProps) {
         icon={
           <CursorClickIcon
             size={14}
-            className="text-[#64748b]"
+            className="text-text-muted"
           />
         }
       >
         <div className="flex items-center gap-2 pt-[1px]">
-          <span aria-hidden="true" className="text-[14px] leading-5 text-[#64748b]">·</span>
+          <span aria-hidden="true" className="text-[14px] leading-5 text-text-muted">·</span>
           <RiBookOpenLine
             aria-hidden="true"
-            className="h-4 w-4 shrink-0 text-[#475569]"
+            className="h-4 w-4 shrink-0 text-text-meta"
           />
-          <span className="text-[13px] font-normal leading-[19px] text-[#475569]">
-            <span className="text-[#0f172a] underline underline-offset-2">Source</span>{' '}
+          <span className="text-[13px] font-normal leading-[19px] text-text-meta">
+            <span className="text-text-primary underline underline-offset-2">Source</span>{' '}
             clicked by {actor}
           </span>
         </div>
@@ -230,17 +230,17 @@ function TailRow({ tail }: TailRowProps) {
       icon={
         <CursorClickIcon
           size={14}
-          className="text-[#64748b]"
+          className="text-text-muted"
         />
       }
     >
       <div className="flex items-center gap-2 pt-[1px]">
-        <span aria-hidden="true" className="text-[14px] leading-5 text-[#64748b]">·</span>
+        <span aria-hidden="true" className="text-[14px] leading-5 text-text-muted">·</span>
         <RiFileTextLine
           aria-hidden="true"
-          className="h-4 w-4 shrink-0 text-[#475569]"
+          className="h-4 w-4 shrink-0 text-text-meta"
         />
-        <span className="text-[13px] font-normal leading-[19px] text-[#475569]">
+        <span className="text-[13px] font-normal leading-[19px] text-text-meta">
           search result clicked by {actor}
         </span>
       </div>
@@ -295,7 +295,7 @@ export function AIConversationLogEntry({
        * (center of the 28-px icon column). */}
       <span
         aria-hidden="true"
-        className="pointer-events-none absolute inset-y-8 left-[13.5px] border-l border-dashed border-[#94a3b8]"
+        className="pointer-events-none absolute inset-y-8 left-[13.5px] border-l border-dashed border-text-disabled"
       />
 
       {rows !== undefined ? (
@@ -310,13 +310,13 @@ export function AIConversationLogEntry({
         icon={
           <RiSearchLine
             aria-hidden="true"
-            className="h-4 w-4 text-[#475569]"
+            className="h-4 w-4 text-text-meta"
           />
         }
       >
         <div className="flex items-start gap-3">
           <div className="min-w-0 flex-1">
-            <p className="pt-[5px] text-[14px] font-medium leading-5 text-[#0f172a]">
+            <p className="pt-[5px] text-[14px] font-medium leading-5 text-text-primary">
               {question}
             </p>
           </div>
@@ -333,7 +333,7 @@ export function AIConversationLogEntry({
             <p
               className={cn(
                 'pt-[1px] text-[14px] font-normal leading-5',
-                answerDisabled ? 'text-[#94a3b8]' : 'text-[#0f172a]',
+                answerDisabled ? 'text-text-disabled' : 'text-text-primary',
               )}
             >
               {answer}
@@ -350,7 +350,7 @@ export function AIConversationLogEntry({
           icon={
             <RiBookOpenLine
               aria-hidden="true"
-              className="h-4 w-4 text-[#475569]"
+              className="h-4 w-4 text-text-meta"
             />
           }
         >
@@ -374,20 +374,20 @@ export function AIConversationLogEntry({
             icon={
               <RiCornerDownRightLine
                 aria-hidden="true"
-                className="h-4 w-4 text-[#64748b]"
+                className="h-4 w-4 text-text-muted"
               />
             }
           >
             <div className="flex items-center gap-2 pt-[1px]">
-              <span className="text-[13px] font-normal leading-[19px] text-[#475569]">
+              <span className="text-[13px] font-normal leading-[19px] text-text-meta">
                 follow up
               </span>
-              <span aria-hidden="true" className="text-[13px] leading-[19px] text-[#475569]">:</span>
+              <span aria-hidden="true" className="text-[13px] leading-[19px] text-text-meta">:</span>
               <RiSearchLine
                 aria-hidden="true"
-                className="h-4 w-4 shrink-0 text-[#475569]"
+                className="h-4 w-4 shrink-0 text-text-meta"
               />
-              <span className="text-[14px] font-medium leading-5 text-[#0f172a]">
+              <span className="text-[14px] font-medium leading-5 text-text-primary">
                 {followUp.question}
               </span>
             </div>
@@ -397,7 +397,7 @@ export function AIConversationLogEntry({
           <ConversationRow hideConnectorAbove hideConnectorBelow icon={<AiIcon size={16} />}>
             <div className="flex items-start gap-3">
               <div className="min-w-0 flex-1">
-                <p className="pt-[1px] text-[14px] font-normal leading-5 text-[#0f172a]">
+                <p className="pt-[1px] text-[14px] font-normal leading-5 text-text-primary">
                   {followUp.answer}
                 </p>
               </div>
@@ -412,7 +412,7 @@ export function AIConversationLogEntry({
               icon={
                 <RiBookOpenLine
                   aria-hidden="true"
-                  className="h-4 w-4 text-[#475569]"
+                  className="h-4 w-4 text-text-meta"
                 />
               }
             >
@@ -446,8 +446,8 @@ export function AIConversationLogEntry({
             type="button"
             onClick={onViewAll}
             className={cn(
-              'text-[14px] font-normal leading-5 text-[#0f172a] underline underline-offset-2',
-              'hover:text-[#0f172a]/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10 focus-visible:rounded-[2px]',
+              'text-[14px] font-normal leading-5 text-text-primary underline underline-offset-2',
+              'hover:text-text-primary/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10 focus-visible:rounded-[2px]',
             )}
           >
             view all

--- a/packages/kb-ui/src/components/content/AIConversationLogEntryAtoms.tsx
+++ b/packages/kb-ui/src/components/content/AIConversationLogEntryAtoms.tsx
@@ -69,7 +69,7 @@ export function ConversationRow({
       {hideConnectorAbove ? null : (
         <span
           aria-hidden="true"
-          className="pointer-events-none absolute left-[13.5px] top-0 border-l border-dashed border-[#94a3b8]"
+          className="pointer-events-none absolute left-[13.5px] top-0 border-l border-dashed border-text-disabled"
           style={{ height: `${iconCenter}px` }}
         />
       )}
@@ -77,7 +77,7 @@ export function ConversationRow({
       {hideConnectorBelow ? null : (
         <span
           aria-hidden="true"
-          className="pointer-events-none absolute left-[13.5px] bottom-0 border-l border-dashed border-[#94a3b8]"
+          className="pointer-events-none absolute left-[13.5px] bottom-0 border-l border-dashed border-text-disabled"
           style={{ top: `${iconCenter}px` }}
         />
       )}
@@ -91,7 +91,7 @@ export function ConversationRow({
         className={cn(
           'absolute inline-flex items-center justify-center',
           iconPill
-            ? 'left-0 top-0 h-7 w-7 rounded-full bg-[#f1f5f9]'
+            ? 'left-0 top-0 h-7 w-7 rounded-full bg-surface-muted'
             : 'left-[6px] top-[2px] h-4 w-4 bg-white',
         )}
       >

--- a/packages/kb-ui/src/components/content/AIConversationLogsCard.tsx
+++ b/packages/kb-ui/src/components/content/AIConversationLogsCard.tsx
@@ -65,18 +65,18 @@ function SortDropdown({ options, value, onChange }: SortDropdownProps) {
           data-kb-part="ai-conversation-logs-sort"
           aria-label={`Sort by, current: ${currentLabel}`}
           className={cn(
-            'inline-flex items-center gap-2 rounded-[6px] bg-[#f1f5f9] px-3 py-1.5',
-            'text-[14px] font-medium leading-5 text-[#0f172a]',
-            'hover:bg-[#e2e8f0]',
+            'inline-flex items-center gap-2 rounded-[6px] bg-surface-muted px-3 py-1.5',
+            'text-[14px] font-medium leading-5 text-text-primary',
+            'hover:bg-card-border',
             'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
-            'data-[state=open]:bg-[#e2e8f0]',
+            'data-[state=open]:bg-card-border',
           )}
         >
           Sort by
           <RiArrowDownSLine
             size={14}
             aria-hidden="true"
-            className="text-[#64748b]"
+            className="text-text-muted"
           />
         </button>
       </DropdownMenu.Trigger>
@@ -95,8 +95,8 @@ function SortDropdown({ options, value, onChange }: SortDropdownProps) {
               onSelect={() => onChange?.(opt.id)}
               className={cn(
                 'flex cursor-pointer items-center rounded-[6px] px-2 py-1.5',
-                'text-[14px] leading-5 text-[#0f172a]',
-                'data-[highlighted]:bg-[#f8fafc] focus:outline-none',
+                'text-[14px] leading-5 text-text-primary',
+                'data-[highlighted]:bg-surface-subtle focus:outline-none',
               )}
             >
               {opt.label}
@@ -141,7 +141,7 @@ export function AIConversationLogsCard({
       // Outer border colour matches Figma library-check `156:3987` (#e2e8f0)
       // rather than the global `--color-card-border` (#e5e5e5). Per Phase 15
       // calibration: drift fixed in-place on this card only.
-      className={cn('border-[#e2e8f0] p-5', className)}
+      className={cn('border-card-border p-5', className)}
     >
       {renderHeader ? (
         <>
@@ -150,7 +150,7 @@ export function AIConversationLogsCard({
               {/* Default header block */}
               <div className="flex flex-col gap-1">
                 <div className="flex items-center gap-1.5">
-                  <h3 className="text-[14px] font-medium leading-5 text-[#0f172a]">
+                  <h3 className="text-[14px] font-medium leading-5 text-text-primary">
                     {title}
                   </h3>
                   <span
@@ -161,11 +161,11 @@ export function AIConversationLogsCard({
                     <RiInformationLine
                       size={16}
                       aria-hidden="true"
-                      className="text-[#64748b]"
+                      className="text-text-muted"
                     />
                   </span>
                 </div>
-                <p className="text-[13px] font-normal leading-[19px] text-[#475569]">
+                <p className="text-[13px] font-normal leading-[19px] text-text-meta">
                   {subtitle}
                 </p>
               </div>
@@ -187,13 +187,13 @@ export function AIConversationLogsCard({
                         data-kb-part="ai-conversation-logs-ticket-toggle"
                         className={cn(
                           'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors',
-                          'data-[state=unchecked]:bg-[#e2e8f0] data-[state=checked]:bg-[#0f172a]',
+                          'data-[state=unchecked]:bg-card-border data-[state=checked]:bg-text-primary',
                           'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/20',
                         )}
                       >
                         <Switch.Thumb className="block size-4 translate-x-0.5 rounded-full bg-white shadow transition-transform data-[state=checked]:translate-x-[18px]" />
                       </Switch.Root>
-                      <span className="text-[14px] font-normal leading-5 text-[#475569]">
+                      <span className="text-[14px] font-normal leading-5 text-text-meta">
                         Ticket Created
                       </span>
                     </div>
@@ -208,7 +208,7 @@ export function AIConversationLogsCard({
           )}
 
           {/* Header/list divider */}
-          <div className="border-t border-[#e2e8f0]" />
+          <div className="border-t border-card-border" />
         </>
       ) : null}
 
@@ -218,7 +218,7 @@ export function AIConversationLogsCard({
        * matches Figma library-check `156:3987` (#e2e8f0). */}
       <div
         data-kb-part="ai-conversation-logs-list"
-        className="flex flex-col [&>*]:border-b [&>*]:border-[#e2e8f0] [&>*:last-child]:border-b-0"
+        className="flex flex-col [&>*]:border-b [&>*]:border-card-border [&>*:last-child]:border-b-0"
       >
         {children}
       </div>

--- a/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
+++ b/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
@@ -12,6 +12,7 @@ import {
   RiArrowGoBackLine,
 } from '@remixicon/react';
 import { cn } from '../../utils/cn';
+import { tokens } from '../../tokens';
 import { AICard } from './AICard';
 import { NavArrow } from './NavArrow';
 import type {
@@ -53,9 +54,9 @@ export type AIGapSuggestionCardProps = {
  * ───────────────────────────────────────────────────────────── */
 
 export const DEFAULT_GAP_TYPES: Record<string, SuggestionTypeMeta> = {
-  addition: { label: 'Addition', color: '#086e3f', Icon: RiAddLine },
-  replace: { label: 'Replace', color: '#065b89', Icon: RiRefreshLine },
-  removal: { label: 'Removal', color: '#d52c1f', Icon: RiCloseLine },
+  addition: { label: 'Addition', color: tokens.color.aiAddition, Icon: RiAddLine },
+  replace: { label: 'Replace', color: tokens.color.aiReplace, Icon: RiRefreshLine },
+  removal: { label: 'Removal', color: tokens.color.aiRemoval, Icon: RiCloseLine },
 };
 
 function TypeChip({
@@ -72,7 +73,7 @@ function TypeChip({
         data-kb-part="ai-gap-type-chip"
         data-kb-type={type}
         className="inline-flex items-center gap-1"
-        style={{ color: '#94a3b8' }}
+        style={{ color: tokens.color.textDisabled }}
       >
         <span className="text-[12px] font-medium leading-[18px]">{type}</span>
       </span>
@@ -109,8 +110,8 @@ function SourcesButton({
         // weight=normal, not medium. Lighter weight also improves
         // visual baseline alignment with the icon + adjacent NavArrow
         // / accept-reject pills (medium gave a heavier optical feel).
-        'text-[14px] font-normal leading-[20px] text-[#475569]',
-        'transition-colors hover:bg-[#f1f5f9] hover:text-[#0f172a]',
+        'text-[14px] font-normal leading-[20px] text-text-meta',
+        'transition-colors hover:bg-surface-muted hover:text-text-primary',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
       )}
     >
@@ -149,8 +150,8 @@ function AcceptButton({ onClick }: { onClick?: () => void }) {
         // icon=icon/neutral/default (#0f172a). Same pill shape as
         // the reject button (rounded-full). Hover deepens the bg one
         // step to keep affordance visible on the light fill.
-        'inline-flex size-6 items-center justify-center rounded-full bg-[#f1f5f9]',
-        'text-[#0f172a] transition-colors hover:bg-[#e2e8f0]',
+        'inline-flex size-6 items-center justify-center rounded-full bg-surface-muted',
+        'text-text-primary transition-colors hover:bg-card-border',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
       )}
     >
@@ -190,7 +191,7 @@ export function AIGapSuggestionCard({
       >
         <TypeChip type={suggestion.type} registry={resolvedRegistry} />
         <span aria-hidden className="mx-3 h-4 w-px shrink-0 bg-card-divider" />
-        <span className="text-[12px] font-medium leading-[18px] text-[#475569] tracking-wide">
+        <span className="text-[12px] font-medium leading-[18px] text-text-meta tracking-wide">
           {decisionLabel}
         </span>
         <button
@@ -199,8 +200,8 @@ export function AIGapSuggestionCard({
           aria-label={`Undo ${state} for ${suggestion.title}`}
           className={cn(
             'ml-auto inline-flex size-6 items-center justify-center rounded-[4px]',
-            'text-[#64748b] transition-colors',
-            'hover:bg-[#f1f5f9] hover:text-[#0f172a]',
+            'text-text-muted transition-colors',
+            'hover:bg-surface-muted hover:text-text-primary',
             'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
           )}
         >
@@ -223,13 +224,13 @@ export function AIGapSuggestionCard({
           {meta}
           <h3
             data-kb-part="ai-gap-title"
-            className="mt-2 text-[14px] font-medium leading-[20px] text-[#0f172a]"
+            className="mt-2 text-[14px] font-medium leading-[20px] text-text-primary"
           >
             {suggestion.title}
           </h3>
           <p
             data-kb-part="ai-gap-description"
-            className="mt-1 text-[14px] font-normal leading-[20px] text-[#64748b]"
+            className="mt-1 text-[14px] font-normal leading-[20px] text-text-muted"
           >
             {suggestion.description}
           </p>

--- a/packages/kb-ui/src/components/content/AISuggestionsCard.tsx
+++ b/packages/kb-ui/src/components/content/AISuggestionsCard.tsx
@@ -47,8 +47,8 @@ function CountPill({ count }: { count: number }) {
     <span
       data-kb-part="ai-suggestions-card-count"
       className={cn(
-        'inline-flex min-w-[20px] items-center justify-center rounded-full border border-card-border bg-[#f1f5f9] px-1.5',
-        'text-[12px] font-medium leading-[18px] text-[#475569] tabular-nums',
+        'inline-flex min-w-[20px] items-center justify-center rounded-full border border-card-border bg-surface-muted px-1.5',
+        'text-[12px] font-medium leading-[18px] text-text-meta tabular-nums',
       )}
     >
       {count}
@@ -85,14 +85,14 @@ export function AISuggestionsCard({
           {/* Per Figma `ai-suggestions-card-pre-review.png` — the title
            * is weight=medium, not semibold. Semibold read too heavy
            * compared to surrounding card UI in the live render. */}
-          <span className="text-[14px] font-medium leading-[20px] text-[#0f172a]">
+          <span className="text-[14px] font-medium leading-[20px] text-text-primary">
             {resolvedTitle}
           </span>
           {isTerminal && <CountPill count={count} />}
         </div>
       }
       body={
-        <p className="mt-2 text-[14px] font-normal leading-[20px] text-[#475569]">
+        <p className="mt-2 text-[14px] font-normal leading-[20px] text-text-meta">
           {summary}
         </p>
       }
@@ -109,7 +109,7 @@ export function AISuggestionsCard({
               aria-label="Reviewed all suggestions"
               className={cn(
                 'inline-flex items-center gap-1.5 px-3 py-2',
-                'text-[14px] font-medium leading-[20px] text-[#475569]',
+                'text-[14px] font-medium leading-[20px] text-text-meta',
                 'cursor-not-allowed',
               )}
             >

--- a/packages/kb-ui/src/components/content/AnalyticsAreaChart.tsx
+++ b/packages/kb-ui/src/components/content/AnalyticsAreaChart.tsx
@@ -10,6 +10,7 @@ import {
   YAxis,
 } from 'recharts';
 import { cn } from '../../utils/cn';
+import { tokens } from '../../tokens';
 
 /* ─────────────────────────────────────────────────────────────
  * AnalyticsAreaChart — Recharts wrapper used by every line/area
@@ -156,7 +157,7 @@ export function AnalyticsAreaChart({
 }: AnalyticsAreaChartProps) {
   const palette = seriesPalette ?? DEFAULT_SERIES_PALETTE;
   const colorFor = (seriesKey: AreaSeriesKey): string =>
-    palette[seriesKey] ?? '#94a3b8';
+    palette[seriesKey] ?? tokens.color.textDisabled;
   // Scope gradient ids per instance to avoid collisions when multiple
   // charts render on the same page (Recharts gradients are pulled by
   // `url(#id)` from the document — duplicate ids = wrong fills).
@@ -251,11 +252,11 @@ export function AnalyticsAreaChart({
             <Tooltip
               contentStyle={{
                 borderRadius: 8,
-                border: '1px solid #e5e5e5',
+                border: `1px solid ${tokens.color.cardBorder}`,
                 boxShadow:
                   '0 4px 6px -1px rgba(0,0,0,0.05), 0 2px 4px -2px rgba(0,0,0,0.10)',
               }}
-              labelStyle={{ color: '#0f172a', fontWeight: 500 }}
+              labelStyle={{ color: tokens.color.textPrimary, fontWeight: 500 }}
             />
             {series.map((s) => (
               <Area

--- a/packages/kb-ui/src/components/content/AnalyticsChartCard.tsx
+++ b/packages/kb-ui/src/components/content/AnalyticsChartCard.tsx
@@ -45,7 +45,7 @@ export function AnalyticsChartCard({
       <div className="mb-4 flex items-start justify-between gap-4">
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-1.5">
-            <h3 className="text-[14px] font-medium leading-5 text-[#0f172a]">
+            <h3 className="text-[14px] font-medium leading-5 text-text-primary">
               {title}
             </h3>
             {infoTooltip && (
@@ -56,14 +56,14 @@ export function AnalyticsChartCard({
               >
                 <RiInformationLine
                   size={16}
-                  className="text-[#64748b]"
+                  className="text-text-muted"
                   aria-hidden="true"
                 />
               </span>
             )}
           </div>
           {subtitle && (
-            <p className="text-[12px] font-normal leading-4 text-[#64748b]">
+            <p className="text-[12px] font-normal leading-4 text-text-muted">
               {subtitle}
             </p>
           )}

--- a/packages/kb-ui/src/components/content/ArticleBody.tsx
+++ b/packages/kb-ui/src/components/content/ArticleBody.tsx
@@ -146,7 +146,7 @@ function PlainSentences({ sentences }: { sentences: SuggestionSentence[] }) {
         typeof s === 'string' ? (
           <p
             key={i}
-            className="mb-2 text-[16px] leading-[24px] text-[#0f172a] last:mb-0"
+            className="mb-2 text-[16px] leading-[24px] text-text-primary last:mb-0"
           >
             {s}
           </p>

--- a/packages/kb-ui/src/components/content/ArticleSettingsPanel.tsx
+++ b/packages/kb-ui/src/components/content/ArticleSettingsPanel.tsx
@@ -176,8 +176,8 @@ function SlugField({
       </div>
       <div
         className={cn(
-          'flex w-full min-h-[40px] items-center gap-2 rounded-[8px] border border-[#e5e5e5] bg-white px-3',
-          'focus-within:border-[#cbd5e1]',
+          'flex w-full min-h-[40px] items-center gap-2 rounded-[8px] border border-card-border bg-white px-3',
+          'focus-within:border-border-faint',
         )}
       >
         <input
@@ -188,11 +188,11 @@ function SlugField({
           maxLength={SLUG_MAX}
           placeholder="article-url-slug"
           className={cn(
-            'flex-1 bg-transparent text-[14px] leading-[20px] font-normal text-[#0f172a]',
-            'placeholder:text-[#94a3b8] focus:outline-none',
+            'flex-1 bg-transparent text-[14px] leading-[20px] font-normal text-text-primary',
+            'placeholder:text-text-disabled focus:outline-none',
           )}
         />
-        <RiArrowDownSLine aria-hidden="true" className="h-4 w-4 shrink-0 text-[#94a3b8]" />
+        <RiArrowDownSLine aria-hidden="true" className="h-4 w-4 shrink-0 text-text-disabled" />
       </div>
     </div>
   );
@@ -221,7 +221,7 @@ function TagsField({
       <FieldLabel>Tags</FieldLabel>
       <div
         className={cn(
-          'flex w-full min-h-[40px] flex-wrap items-center gap-1.5 rounded-[8px] border border-[#e5e5e5] bg-white',
+          'flex w-full min-h-[40px] flex-wrap items-center gap-1.5 rounded-[8px] border border-card-border bg-white',
           'px-2 py-1.5',
         )}
       >
@@ -250,7 +250,7 @@ function PublishDateField({
     <div className="flex flex-col gap-1.5">
       <FieldLabel>Publish date</FieldLabel>
       <FieldBox onClick={onOpen} ariaLabel="Change publish date">
-        <RiCalendar2Line aria-hidden="true" className="h-4 w-4 shrink-0 text-[#64748b]" />
+        <RiCalendar2Line aria-hidden="true" className="h-4 w-4 shrink-0 text-text-muted" />
         {date ? <span className="truncate">{date}</span> : <Placeholder>Pick a date</Placeholder>}
       </FieldBox>
     </div>
@@ -280,8 +280,8 @@ function SeoTitleField({
       </div>
       <div
         className={cn(
-          'flex w-full min-h-[40px] items-center gap-2 rounded-[8px] border border-[#e5e5e5] bg-white px-3',
-          'focus-within:border-[#cbd5e1]',
+          'flex w-full min-h-[40px] items-center gap-2 rounded-[8px] border border-card-border bg-white px-3',
+          'focus-within:border-border-faint',
         )}
       >
         <input
@@ -292,8 +292,8 @@ function SeoTitleField({
           maxLength={SEO_MAX}
           placeholder="SEO page title"
           className={cn(
-            'flex-1 bg-transparent text-[14px] leading-[20px] font-normal text-[#0f172a]',
-            'placeholder:text-[#94a3b8] focus:outline-none',
+            'flex-1 bg-transparent text-[14px] leading-[20px] font-normal text-text-primary',
+            'placeholder:text-text-disabled focus:outline-none',
           )}
         />
       </div>
@@ -357,10 +357,10 @@ function ReviewersField({
           onClick={onAdd}
           aria-label="Add reviewer"
           className={cn(
-            'inline-flex size-6 items-center justify-center rounded-full border border-dashed border-[#cbd5e1]',
-            'bg-white text-[#64748b] ring-2 ring-white',
+            'inline-flex size-6 items-center justify-center rounded-full border border-dashed border-border-faint',
+            'bg-white text-text-muted ring-2 ring-white',
             reviewers.length > 0 && '-ml-2',
-            'hover:bg-[#f8fafc] focus:outline-none focus:ring-2 focus:ring-black/10',
+            'hover:bg-surface-subtle focus:outline-none focus:ring-2 focus:ring-black/10',
           )}
         >
           <RiAddLine className="h-[14px] w-[14px]" />
@@ -414,7 +414,7 @@ export function ArticleSettingsPanel({
       className={cn(
         // Figma `53:8384` ships card border `#f1f5f9` (color-border).
         // Aligns with ContentEditor; replaces the prior `#e2e8f0` drift.
-        'flex flex-col rounded-[12px] border border-[#f1f5f9] bg-white',
+        'flex flex-col rounded-[12px] border border-surface-muted bg-white',
         'shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.05),0px_2px_4px_-2px_rgba(0,0,0,0.10)]',
         // Width + outer padding swap on the compact variant.
         // Default 452 / py-6 px-[22px] (24/22)  ─  Compact 380 / px-4 py-4 (16/16).
@@ -435,12 +435,12 @@ export function ArticleSettingsPanel({
               'focus:outline-none focus:ring-2 focus:ring-black/10 rounded-[4px]',
             )}
           >
-            <RiSettings5Line aria-hidden="true" className="h-4 w-4 shrink-0 text-[#0f172a]" />
-            <span className="flex-1 text-[14px] font-medium leading-[20px] text-[#0f172a]">Settings</span>
+            <RiSettings5Line aria-hidden="true" className="h-4 w-4 shrink-0 text-text-primary" />
+            <span className="flex-1 text-[14px] font-medium leading-[20px] text-text-primary">Settings</span>
             {collapsed ? (
-              <RiArrowDownSLine aria-hidden="true" className="h-4 w-4 shrink-0 text-[#0f172a]" />
+              <RiArrowDownSLine aria-hidden="true" className="h-4 w-4 shrink-0 text-text-primary" />
             ) : (
-              <RiArrowUpSLine aria-hidden="true" className="h-4 w-4 shrink-0 text-[#0f172a]" />
+              <RiArrowUpSLine aria-hidden="true" className="h-4 w-4 shrink-0 text-text-primary" />
             )}
           </button>
           <div className="flex items-center">{headerSlot}</div>
@@ -456,12 +456,12 @@ export function ArticleSettingsPanel({
             'focus:outline-none focus:ring-2 focus:ring-black/10 rounded-[4px]',
           )}
         >
-          <RiSettings5Line aria-hidden="true" className="h-4 w-4 shrink-0 text-[#0f172a]" />
-          <span className="flex-1 text-[14px] font-medium leading-[20px] text-[#0f172a]">Settings</span>
+          <RiSettings5Line aria-hidden="true" className="h-4 w-4 shrink-0 text-text-primary" />
+          <span className="flex-1 text-[14px] font-medium leading-[20px] text-text-primary">Settings</span>
           {collapsed ? (
-            <RiArrowDownSLine aria-hidden="true" className="h-4 w-4 shrink-0 text-[#0f172a]" />
+            <RiArrowDownSLine aria-hidden="true" className="h-4 w-4 shrink-0 text-text-primary" />
           ) : (
-            <RiArrowUpSLine aria-hidden="true" className="h-4 w-4 shrink-0 text-[#0f172a]" />
+            <RiArrowUpSLine aria-hidden="true" className="h-4 w-4 shrink-0 text-text-primary" />
           )}
         </button>
       )}
@@ -472,7 +472,7 @@ export function ArticleSettingsPanel({
               top spacing to match the 12-px field gap. */}
           <div
             aria-hidden="true"
-            className={cn('h-px w-full bg-[#e5e5e5]', compact ? 'mt-3' : 'mt-5')}
+            className={cn('h-px w-full bg-card-border', compact ? 'mt-3' : 'mt-5')}
           />
 
           {/* Field stack — default 20-px gap, compact 12-px gap. Field
@@ -527,7 +527,7 @@ export function ArticleSettingsPanel({
             )}
             {footerSlot ? (
               <>
-                <div aria-hidden="true" className="h-px w-full bg-[#e5e5e5]" />
+                <div aria-hidden="true" className="h-px w-full bg-card-border" />
                 {footerSlot}
               </>
             ) : null}

--- a/packages/kb-ui/src/components/content/ArticleSettingsPanelAtoms.tsx
+++ b/packages/kb-ui/src/components/content/ArticleSettingsPanelAtoms.tsx
@@ -18,7 +18,7 @@ import { cn } from '../../utils/cn';
 
 export function FieldLabel({ children }: { children: React.ReactNode }) {
   return (
-    <label className="text-[14px] font-medium leading-[20px] text-[#0f172a]">
+    <label className="text-[14px] font-medium leading-[20px] text-text-primary">
       {children}
     </label>
   );
@@ -35,10 +35,10 @@ export type FieldBoxProps = {
 
 export function FieldBox({ children, className, as = 'button', onClick, ariaLabel }: FieldBoxProps) {
   const baseClass = cn(
-    'flex w-full min-h-[40px] items-center gap-2 rounded-[8px] border border-[#e5e5e5] bg-white px-3',
-    'text-[14px] leading-[20px] font-normal text-[#0f172a]',
-    'transition-colors focus:outline-none focus:border-[#cbd5e1]',
-    'hover:border-[#cbd5e1]',
+    'flex w-full min-h-[40px] items-center gap-2 rounded-[8px] border border-card-border bg-white px-3',
+    'text-[14px] leading-[20px] font-normal text-text-primary',
+    'transition-colors focus:outline-none focus:border-border-faint',
+    'hover:border-border-faint',
     className,
   );
 
@@ -56,21 +56,21 @@ export function ChevronSuffix() {
   return (
     <RiArrowDownSLine
       aria-hidden="true"
-      className="ml-auto h-4 w-4 shrink-0 text-[#94a3b8]"
+      className="ml-auto h-4 w-4 shrink-0 text-text-disabled"
     />
   );
 }
 
 export function CharCounter({ count, max }: { count: number; max: number }) {
   return (
-    <span className="text-[12px] font-normal leading-[18px] text-[#94a3b8] tabular-nums">
+    <span className="text-[12px] font-normal leading-[18px] text-text-disabled tabular-nums">
       {count}/{max}
     </span>
   );
 }
 
 export function Placeholder({ children }: { children: React.ReactNode }) {
-  return <span className="text-[#94a3b8]">{children}</span>;
+  return <span className="text-text-disabled">{children}</span>;
 }
 
 /* ─────────────────────────────────────────────────────────────
@@ -89,8 +89,8 @@ export function TagChip({ label, onRemove }: TagChipProps) {
   return (
     <span
       className={cn(
-        'inline-flex h-[22px] items-center gap-1.5 rounded-full bg-[#f1f5f9] pl-2 pr-1',
-        'text-[12px] font-medium leading-[18px] text-[#0f172a]',
+        'inline-flex h-[22px] items-center gap-1.5 rounded-full bg-surface-muted pl-2 pr-1',
+        'text-[12px] font-medium leading-[18px] text-text-primary',
       )}
     >
       <span>{label}</span>
@@ -101,7 +101,7 @@ export function TagChip({ label, onRemove }: TagChipProps) {
           aria-label={`Remove ${label}`}
           className={cn(
             'inline-flex h-[16px] w-[16px] items-center justify-center rounded-full',
-            'text-[#64748b] hover:bg-[#e2e8f0] hover:text-[#0f172a]',
+            'text-text-muted hover:bg-card-border hover:text-text-primary',
             'focus:outline-none focus:ring-2 focus:ring-black/10',
           )}
         >
@@ -118,9 +118,9 @@ export function AddChipButton({ onClick, label = '+ Add' }: { onClick?: () => vo
       type="button"
       onClick={onClick}
       className={cn(
-        'inline-flex h-[22px] items-center rounded-full border border-dashed border-[#cbd5e1] bg-white px-2',
-        'text-[12px] font-medium leading-[18px] text-[#475569]',
-        'hover:bg-[#f8fafc] focus:outline-none focus:ring-2 focus:ring-black/10',
+        'inline-flex h-[22px] items-center rounded-full border border-dashed border-border-faint bg-white px-2',
+        'text-[12px] font-medium leading-[18px] text-text-meta',
+        'hover:bg-surface-subtle focus:outline-none focus:ring-2 focus:ring-black/10',
       )}
     >
       {label}

--- a/packages/kb-ui/src/components/content/ContentEditor.tsx
+++ b/packages/kb-ui/src/components/content/ContentEditor.tsx
@@ -220,9 +220,9 @@ function ToolbarButton({ onClick, active, disabled, label, children }: ToolbarBu
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20',
         '[&>svg]:h-[14px] [&>svg]:w-[14px]',
         active
-          ? 'bg-[#f8fafc] text-[#0f172a]'
-          : 'bg-transparent text-[#475569] hover:bg-[#f8fafc] hover:text-[#0f172a]',
-        disabled && 'opacity-40 cursor-not-allowed hover:bg-transparent hover:text-[#475569]',
+          ? 'bg-surface-subtle text-text-primary'
+          : 'bg-transparent text-text-meta hover:bg-surface-subtle hover:text-text-primary',
+        disabled && 'opacity-40 cursor-not-allowed hover:bg-transparent hover:text-text-meta',
       )}
     >
       {children}
@@ -231,7 +231,7 @@ function ToolbarButton({ onClick, active, disabled, label, children }: ToolbarBu
 }
 
 function ToolbarDivider() {
-  return <span aria-hidden="true" className="mx-1 h-4 w-px bg-[#e2e8f0] shrink-0" />;
+  return <span aria-hidden="true" className="mx-1 h-4 w-px bg-card-border shrink-0" />;
 }
 
 /* ─────────────────────────────────────────────────────────────
@@ -287,7 +287,7 @@ function ParagraphDropdown({ editor }: { editor: Editor }) {
         className={cn(
           'inline-flex h-6 items-center gap-0.5 pl-1.5 pr-0.5 rounded-[6px] transition-colors',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20',
-          open ? 'bg-[#f8fafc] text-[#0f172a]' : 'bg-transparent text-[#475569] hover:bg-[#f8fafc] hover:text-[#0f172a]',
+          open ? 'bg-surface-subtle text-text-primary' : 'bg-transparent text-text-meta hover:bg-surface-subtle hover:text-text-primary',
         )}
       >
         <span className="text-[14px] font-medium leading-5">{currentOpt.shortLabel}</span>
@@ -296,7 +296,7 @@ function ParagraphDropdown({ editor }: { editor: Editor }) {
       {open && (
         <div
           role="listbox"
-          className="absolute left-0 top-full z-50 mt-1 min-w-[160px] rounded-[8px] border border-[#e5e5e5] bg-white py-1 shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.05),0px_2px_4px_-2px_rgba(0,0,0,0.10)]"
+          className="absolute left-0 top-full z-50 mt-1 min-w-[160px] rounded-[8px] border border-card-border bg-white py-1 shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.05),0px_2px_4px_-2px_rgba(0,0,0,0.10)]"
         >
           {PARAGRAPH_OPTIONS.map((opt) => {
             const isActive = opt.value === current;
@@ -308,8 +308,8 @@ function ParagraphDropdown({ editor }: { editor: Editor }) {
                 aria-selected={isActive}
                 onClick={() => apply(opt.value)}
                 className={cn(
-                  'flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left text-[14px] leading-5 text-[#0f172a]',
-                  'hover:bg-[#f8fafc] focus-visible:outline-none focus-visible:bg-[#f8fafc]',
+                  'flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left text-[14px] leading-5 text-text-primary',
+                  'hover:bg-surface-subtle focus-visible:outline-none focus-visible:bg-surface-subtle',
                 )}
               >
                 <span
@@ -322,7 +322,7 @@ function ParagraphDropdown({ editor }: { editor: Editor }) {
                 >
                   {opt.label}
                 </span>
-                {isActive && <RiCheckLine className="h-[14px] w-[14px] text-[#0f172a]" />}
+                {isActive && <RiCheckLine className="h-[14px] w-[14px] text-text-primary" />}
               </button>
             );
           })}
@@ -380,7 +380,7 @@ function OverflowMenu({ editor }: { editor: Editor }) {
       {open && (
         <div
           role="menu"
-          className="absolute right-0 top-full z-50 mt-1 min-w-[180px] rounded-[8px] border border-[#e5e5e5] bg-white py-1 shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.05),0px_2px_4px_-2px_rgba(0,0,0,0.10)]"
+          className="absolute right-0 top-full z-50 mt-1 min-w-[180px] rounded-[8px] border border-card-border bg-white py-1 shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.05),0px_2px_4px_-2px_rgba(0,0,0,0.10)]"
         >
           {items.map((item) => (
             <button
@@ -392,12 +392,12 @@ function OverflowMenu({ editor }: { editor: Editor }) {
                 setOpen(false);
               }}
               className={cn(
-                'flex w-full items-center gap-2 px-3 py-1.5 text-left text-[14px] leading-5 text-[#0f172a]',
-                'hover:bg-[#f8fafc] focus-visible:outline-none focus-visible:bg-[#f8fafc]',
-                item.active && 'bg-[#f8fafc]',
+                'flex w-full items-center gap-2 px-3 py-1.5 text-left text-[14px] leading-5 text-text-primary',
+                'hover:bg-surface-subtle focus-visible:outline-none focus-visible:bg-surface-subtle',
+                item.active && 'bg-surface-subtle',
               )}
             >
-              <span className="text-[#475569]">{item.icon}</span>
+              <span className="text-text-meta">{item.icon}</span>
               <span>{item.label}</span>
             </button>
           ))}
@@ -447,7 +447,7 @@ function ContentEditorToolbar({
       aria-label="Formatting toolbar"
       data-kb-part="content-editor-toolbar"
       className={cn(
-        'inline-flex w-max items-center gap-0.5 rounded-[8px] border border-[#e2e8f0]',
+        'inline-flex w-max items-center gap-0.5 rounded-[8px] border border-card-border',
         'bg-white p-1 shadow-md',
       )}
     >
@@ -557,7 +557,7 @@ export function ContentEditor({
         // Figma `53:2316` ships card border `#f1f5f9` (color-border), not the
         // generic `#e2e8f0` used elsewhere — keeps Source / Editor / Settings
         // cards visually consistent on the same canvas.
-        'w-[720px] rounded-[12px] border border-[#f1f5f9] bg-white p-10',
+        'w-[720px] rounded-[12px] border border-surface-muted bg-white p-10',
         'shadow-[0px_8px_12px_-4px_rgba(0,0,0,0.05),0px_4px_6px_-2px_rgba(0,0,0,0.10)]',
         className,
       )}

--- a/packages/kb-ui/src/components/content/DataTable.tsx
+++ b/packages/kb-ui/src/components/content/DataTable.tsx
@@ -11,7 +11,7 @@ import { Card } from '../primitives/Card';
  * 7 hand-rolled `*Table.tsx` files:
  *
  *   - row + header height           h-12
- *   - row divider                   border-b border-[#e5e5e5]
+ *   - row divider                   border-b border-card-border
  *   - hover state (interactive)     hover:bg-[#fafafa] + transition
  *   - card chrome                   rounded-[12px], 1px slate border, p-5
  *
@@ -81,7 +81,7 @@ export type DataTableProps<T> = {
   /**
    * When `wrapped=false`, the wrapper acquires the legacy
    * "ArticlesTable / SubCategoriesTable" chrome:
-   * `bg-white rounded-[8px] border border-[#e5e5e5] overflow-hidden`.
+   * `bg-white rounded-[8px] border border-card-border overflow-hidden`.
    */
   unwrappedChrome?: boolean;
   /**
@@ -120,7 +120,7 @@ export function DataTable<T>({
   // hold the legacy 48-px tall column-header.
   const headerTrClass = cn(
     'h-12',
-    headerDivider && 'border-b border-[#e5e5e5]',
+    headerDivider && 'border-b border-card-border',
   );
 
   const padY = `${cellPaddingY}px`;
@@ -150,7 +150,7 @@ export function DataTable<T>({
               key={c.id}
               scope="col"
               className={cn(
-                'align-middle text-[14px] font-medium leading-[20px] text-[#0f172a]',
+                'align-middle text-[14px] font-medium leading-[20px] text-text-primary',
                 alignClass(c.align),
                 // Header padding mirrors the Figma reference: legacy
                 // ArticlesTable / SubCategoriesTable use `pl-4 pr-0 py-0`
@@ -172,7 +172,7 @@ export function DataTable<T>({
           <tr>
             <td
               colSpan={columns.length}
-              className="py-3 text-[14px] text-[#94a3b8]"
+              className="py-3 text-[14px] text-text-disabled"
               style={{ paddingTop: padY, paddingBottom: padY }}
             >
               {emptyMessage}
@@ -190,7 +190,7 @@ export function DataTable<T>({
                 onClick={interactive ? () => onRowClick?.(row, idx) : undefined}
                 className={cn(
                   'h-12 align-middle',
-                  idx < rows.length - 1 && 'border-b border-[#e5e5e5]',
+                  idx < rows.length - 1 && 'border-b border-card-border',
                   interactive &&
                     'cursor-pointer transition-colors duration-150 hover:bg-[#fafafa]',
                 )}
@@ -199,7 +199,7 @@ export function DataTable<T>({
                   <td
                     key={c.id}
                     className={cn(
-                      'align-middle text-[14px] font-normal leading-[20px] text-[#0f172a]',
+                      'align-middle text-[14px] font-normal leading-[20px] text-text-primary',
                       alignClass(c.align),
                       c.className,
                     )}
@@ -234,7 +234,7 @@ export function DataTable<T>({
       <div
         data-kb-component={dataKbComponent ?? 'data-table'}
         className={cn(
-          'bg-white rounded-[8px] border border-[#e5e5e5] overflow-hidden',
+          'bg-white rounded-[8px] border border-card-border overflow-hidden',
           className,
         )}
       >

--- a/packages/kb-ui/src/components/content/DateRangePill.tsx
+++ b/packages/kb-ui/src/components/content/DateRangePill.tsx
@@ -57,17 +57,17 @@ export function DateRangePill({ value, onChange, label, className, presets }: Da
           type="button"
           data-kb-component="date-range-pill"
           className={cn(
-            'inline-flex items-center gap-2 rounded-[8px] bg-[#f1f5f9] px-3 py-1.5',
-            'text-[14px] font-normal leading-5 text-[#0f172a]',
-            'hover:bg-[#e2e8f0]',
+            'inline-flex items-center gap-2 rounded-[8px] bg-surface-muted px-3 py-1.5',
+            'text-[14px] font-normal leading-5 text-text-primary',
+            'hover:bg-card-border',
             'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
-            'data-[state=open]:bg-[#e2e8f0]',
+            'data-[state=open]:bg-card-border',
             className,
           )}
         >
-          <RiCalendarLine size={14} className="text-[#64748b]" aria-hidden="true" />
+          <RiCalendarLine size={14} className="text-text-muted" aria-hidden="true" />
           <span>{displayLabel}</span>
-          <RiArrowDownSLine size={14} className="text-[#64748b]" aria-hidden="true" />
+          <RiArrowDownSLine size={14} className="text-text-muted" aria-hidden="true" />
         </button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Portal>
@@ -85,8 +85,8 @@ export function DateRangePill({ value, onChange, label, className, presets }: Da
               onSelect={handleSelect(preset.value as DateRange)}
               className={cn(
                 'flex cursor-pointer items-center rounded-[6px] px-2 py-1.5',
-                'text-[14px] leading-5 text-[#0f172a]',
-                'data-[highlighted]:bg-[#f8fafc] focus:outline-none',
+                'text-[14px] leading-5 text-text-primary',
+                'data-[highlighted]:bg-surface-subtle focus:outline-none',
               )}
             >
               {preset.label}
@@ -97,8 +97,8 @@ export function DateRangePill({ value, onChange, label, className, presets }: Da
             onSelect={handleSelect('custom')}
             className={cn(
               'flex cursor-pointer items-center rounded-[6px] px-2 py-1.5',
-              'text-[14px] leading-5 text-[#0f172a]',
-              'data-[highlighted]:bg-[#f8fafc] focus:outline-none',
+              'text-[14px] leading-5 text-text-primary',
+              'data-[highlighted]:bg-surface-subtle focus:outline-none',
             )}
           >
             Custom…

--- a/packages/kb-ui/src/components/content/HelpfulnessTag.tsx
+++ b/packages/kb-ui/src/components/content/HelpfulnessTag.tsx
@@ -36,8 +36,8 @@ export type HelpfulnessTagProps = {
 };
 
 const VARIANT_CLASS: Record<HelpfulnessVariant, string> = {
-  up: 'bg-[#f2fcf6] text-[#086e3f]',
-  down: 'bg-[#fff7f5] text-[#d52c1f]',
+  up: 'bg-success-wash-subtle text-success-text',
+  down: 'bg-[#fff7f5] text-trend-down',
 };
 
 export function HelpfulnessTag({ value, variant, className }: HelpfulnessTagProps) {

--- a/packages/kb-ui/src/components/content/NavArrow.tsx
+++ b/packages/kb-ui/src/components/content/NavArrow.tsx
@@ -26,8 +26,8 @@ export function NavArrow({ direction, onClick, className }: NavArrowProps) {
       aria-label={direction === 'up' ? 'Previous suggestion' : 'Next suggestion'}
       className={cn(
         'inline-flex size-6 items-center justify-center rounded-[4px]',
-        'text-[#64748b] transition-colors',
-        'hover:bg-[#f1f5f9] hover:text-[#0f172a]',
+        'text-text-muted transition-colors',
+        'hover:bg-surface-muted hover:text-text-primary',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
         className,
       )}

--- a/packages/kb-ui/src/components/content/PageHeader.tsx
+++ b/packages/kb-ui/src/components/content/PageHeader.tsx
@@ -66,11 +66,11 @@ export function PageHeader({
         )}
       >
         <div>
-          <h1 className="text-[24px] font-semibold leading-[32px] text-[#0f172a]">
+          <h1 className="text-[24px] font-semibold leading-[32px] text-text-primary">
             {title}
           </h1>
           {subtitle && (
-            <p className="mt-1 text-[14px] font-normal leading-[20px] text-[#475569]">
+            <p className="mt-1 text-[14px] font-normal leading-[20px] text-text-meta">
               {subtitle}
             </p>
           )}
@@ -90,17 +90,17 @@ export function PageHeader({
         {icon && (
           <span
             aria-hidden="true"
-            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[6.6px] border border-dashed border-[#cbd5e1] bg-[#f8fafc] [&>svg]:h-[22px] [&>svg]:w-[22px]"
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[6.6px] border border-dashed border-border-faint bg-surface-subtle [&>svg]:h-[22px] [&>svg]:w-[22px]"
           >
             {icon}
           </span>
         )}
         <div className="flex flex-col gap-0.5">
-          <h1 className="text-[18px] font-semibold leading-[28px] text-[#0f172a]">
+          <h1 className="text-[18px] font-semibold leading-[28px] text-text-primary">
             {title}
           </h1>
           {subtitle && (
-            <p className="text-[14px] font-medium leading-[20px] text-[#475569]">
+            <p className="text-[14px] font-medium leading-[20px] text-text-meta">
               {subtitle}
             </p>
           )}

--- a/packages/kb-ui/src/components/content/SlashCommandMenu.tsx
+++ b/packages/kb-ui/src/components/content/SlashCommandMenu.tsx
@@ -209,7 +209,7 @@ export const SlashCommandMenu = React.forwardRef<HTMLDivElement, SlashCommandMen
         role="listbox"
         aria-label="Insert block"
         className={cn(
-          'min-w-[220px] max-w-[320px] rounded-[8px] border border-[#e2e8f0] bg-white',
+          'min-w-[220px] max-w-[320px] rounded-[8px] border border-card-border bg-white',
           'shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.10),0px_2px_4px_-2px_rgba(0,0,0,0.06)]',
           'py-1 overflow-hidden',
           // Prevent the editor from regaining focus when clicking a row; we
@@ -218,7 +218,7 @@ export const SlashCommandMenu = React.forwardRef<HTMLDivElement, SlashCommandMen
         )}
       >
         {items.length === 0 ? (
-          <div className="px-3 py-2 text-[13px] leading-5 text-[#64748b]">No results</div>
+          <div className="px-3 py-2 text-[13px] leading-5 text-text-muted">No results</div>
         ) : (
           <div ref={listRef} className="max-h-[280px] overflow-y-auto">
             {items.map((cmd, i) => {
@@ -239,22 +239,22 @@ export const SlashCommandMenu = React.forwardRef<HTMLDivElement, SlashCommandMen
                   className={cn(
                     'flex w-full items-start gap-2.5 px-2.5 py-1.5 text-left',
                     'focus-visible:outline-none',
-                    isActive ? 'bg-[#f8fafc]' : 'bg-transparent',
+                    isActive ? 'bg-surface-subtle' : 'bg-transparent',
                   )}
                 >
                   <span
                     className={cn(
-                      'mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center text-[#475569]',
+                      'mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center text-text-meta',
                       '[&>svg]:h-4 [&>svg]:w-4',
                     )}
                   >
                     <Icon />
                   </span>
                   <span className="flex min-w-0 flex-col">
-                    <span className="text-[14px] font-medium leading-5 text-[#0f172a]">
+                    <span className="text-[14px] font-medium leading-5 text-text-primary">
                       {cmd.title}
                     </span>
-                    <span className="text-[12px] font-normal leading-[18px] text-[#64748b]">
+                    <span className="text-[12px] font-normal leading-[18px] text-text-muted">
                       {cmd.subtitle}
                     </span>
                   </span>

--- a/packages/kb-ui/src/components/content/StatCard.tsx
+++ b/packages/kb-ui/src/components/content/StatCard.tsx
@@ -54,9 +54,9 @@ export function StatCard({
       data-kb-trend={trendDirection}
       className={cn('flex flex-col gap-2', className)}
     >
-      <div className="text-[14px] font-normal leading-5 text-[#475569]">{label}</div>
+      <div className="text-[14px] font-normal leading-5 text-text-meta">{label}</div>
       <div className="flex items-center gap-2">
-        <span className="text-[18px] font-medium leading-[28px] text-[#0f172a]">{value}</span>
+        <span className="text-[18px] font-medium leading-[28px] text-text-primary">{value}</span>
         {showTrend && (
           <span
             className={cn(

--- a/packages/kb-ui/src/components/content/StatCardGrid.tsx
+++ b/packages/kb-ui/src/components/content/StatCardGrid.tsx
@@ -34,12 +34,12 @@ export function StatCardGrid({ title, infoTooltip, stats, className, headerRight
       className={cn('p-5', className)}
     >
       <div className="flex items-center gap-1.5">
-        <h3 className="text-[14px] font-medium leading-5 text-[#0f172a]">{title}</h3>
+        <h3 className="text-[14px] font-medium leading-5 text-text-primary">{title}</h3>
         <span
           className="inline-flex"
           {...(infoTooltip ? { title: infoTooltip, 'aria-label': infoTooltip } : {})}
         >
-          <RiInformationLine size={16} className="text-[#64748b]" aria-hidden="true" />
+          <RiInformationLine size={16} className="text-text-muted" aria-hidden="true" />
         </span>
         {headerRight !== undefined ? <div className="ml-auto flex items-center">{headerRight}</div> : null}
       </div>

--- a/packages/kb-ui/src/components/content/SuggestionBlock.tsx
+++ b/packages/kb-ui/src/components/content/SuggestionBlock.tsx
@@ -3,6 +3,7 @@
 //        9aGp5t9fH1d0PXi4LMhOdb#74:10788 (AI Gaps editor — inline review flow)
 import * as React from 'react';
 import { cn } from '../../utils/cn';
+import { tokens } from '../../tokens';
 import type { AISuggestionType } from './ai-suggestion-types';
 
 /* ─────────────────────────────────────────────────────────────
@@ -63,7 +64,8 @@ export type SuggestionBlockProps = {
 type VariantKey = 'addition' | 'removal';
 
 const SENTENCE_BG: Record<VariantKey, string> = {
-  addition: '#e7f9ee',
+  addition: tokens.color.highlight,
+  // #fce8e8 — pastel removal wash; not yet in design tokens. TODO: tokenize in Chunk 4.
   removal: '#fce8e8',
 };
 
@@ -145,7 +147,7 @@ function SentenceList({
           return (
             <div
               key={i}
-              className="text-[16px] leading-[24px] text-[#0f172a]"
+              className="text-[16px] leading-[24px] text-text-primary"
             >
               <SuggestionHighlight>{sentence}</SuggestionHighlight>
             </div>

--- a/packages/kb-ui/src/components/content/SuggestionCard.tsx
+++ b/packages/kb-ui/src/components/content/SuggestionCard.tsx
@@ -8,6 +8,7 @@ import {
   RiMailLine,
 } from '@remixicon/react';
 import { cn } from '../../utils/cn';
+import { tokens } from '../../tokens';
 
 /* ─────────────────────────────────────────────────────────────
  * Types
@@ -52,7 +53,7 @@ export type SuggestionKindMeta = {
  * ───────────────────────────────────────────────────────────── */
 
 // mirror of --color-ai-pink — kept inline so Ri* icons accept color prop
-const PINK = '#D92FFF';
+const PINK = tokens.color.aiPink;
 
 /**
  * Default registry — covers the 3 historical built-in kinds. Custom
@@ -143,11 +144,11 @@ function KindChip({ kind, pathFrom, pathTo, registry }: KindChipProps) {
   // edge case where both path props are undefined.
   if (kind === 'move-article' && entry) {
     return (
-      <span className="flex items-center gap-[6px] text-[14px] font-medium text-[#475569]">
+      <span className="flex items-center gap-[6px] text-[14px] font-medium text-text-meta">
         {entry.icon}
         <span className="inline-flex items-center gap-1">
           {pathFrom ?? ''}
-          <span aria-hidden className="text-[#94a3b8]">
+          <span aria-hidden className="text-text-disabled">
             ›
           </span>
           {pathTo ?? ''}
@@ -159,14 +160,14 @@ function KindChip({ kind, pathFrom, pathTo, registry }: KindChipProps) {
   if (!entry) {
     // Unknown kind — render the raw key as label, no icon. Don't throw.
     return (
-      <span className="flex items-center gap-[6px] text-[14px] font-medium text-[#475569]">
+      <span className="flex items-center gap-[6px] text-[14px] font-medium text-text-meta">
         {kind}
       </span>
     );
   }
 
   return (
-    <span className="flex items-center gap-[6px] text-[14px] font-medium text-[#475569]">
+    <span className="flex items-center gap-[6px] text-[14px] font-medium text-text-meta">
       {entry.icon}
       {entry.label}
     </span>
@@ -181,7 +182,7 @@ function MetaDot() {
   return (
     <span
       aria-hidden
-      className="mx-[8px] text-[14px] font-medium text-[#94a3b8] leading-none select-none"
+      className="mx-[8px] text-[14px] font-medium text-text-disabled leading-none select-none"
     >
       ·
     </span>
@@ -241,8 +242,8 @@ export function SuggestionCard({
         'rounded-[12px] border border-card-border bg-white',
         'px-[20px] py-[20px]',
         'transition-colors duration-150',
-        clickable && 'cursor-pointer hover:bg-[#f8fafc]',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0f172a]/20',
+        clickable && 'cursor-pointer hover:bg-surface-subtle',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-primary/20',
         className,
       )}
     >
@@ -254,7 +255,7 @@ export function SuggestionCard({
         <span aria-hidden className="flex size-[20px] items-center justify-center shrink-0">
           {titleIcon}
         </span>
-        <span className="text-[14px] font-semibold leading-5 text-[#0f172a] truncate">
+        <span className="text-[14px] font-semibold leading-5 text-text-primary truncate">
           {title}
         </span>
       </div>
@@ -264,7 +265,7 @@ export function SuggestionCard({
           flush with icon, not indented past it). */}
       <p
         data-kb-part="suggestion-description"
-        className="text-[14px] font-normal leading-5 text-[#64748b]"
+        className="text-[14px] font-normal leading-5 text-text-muted"
       >
         {description}
       </p>
@@ -291,12 +292,12 @@ export function SuggestionCard({
         ) : (
           <>
             <MetaDot />
-            <span className="flex items-center gap-[6px] text-[14px] font-medium text-[#475569]">
+            <span className="flex items-center gap-[6px] text-[14px] font-medium text-text-meta">
               <RiMailLine size={16} />
               {conversationCount} Conversations
             </span>
             <MetaDot />
-            <span className="text-[12px] font-medium leading-5 text-[#475569] tracking-[0.04em]">
+            <span className="text-[12px] font-medium leading-5 text-text-meta tracking-[0.04em]">
               {impact.toUpperCase()} IMPACT
             </span>
           </>


### PR DESCRIPTION
- Sweeps ~201 inline hex usages across 21 files in `packages/kb-ui/src/components/content/` to Tailwind token classes
- Recharts/SVG attr colors now reference `tokens.ts` (AnalyticsAreaChart, SuggestionCard, AIGapSuggestionCard, SuggestionBlock)
- `#e5e5e5` folded into `card-border` (#e2e8f0); `#f2fdf6` folded into `success-wash-subtle` (#f2fcf6)
- Verification gate clean: typecheck, build, build-storybook

**Non-mapped hexes left inline (Chunk 4 to decide whether to tokenize):**
- `AIGapSuggestionCard.tsx:133` — `#fad9d6` — RejectButton hover bg (light red wash, ~12% over white)
- `AnalyticsAreaChart.tsx:210` — `#e5e7eb` — Recharts CartesianGrid stroke (Tailwind gray-200)
- `DataTable.tsx:195` — `#fafafa` — interactive row hover bg
- `HelpfulnessTag.tsx:40` — `#fff7f5` — down-variant pill bg (Figma background/accents/red/faint)
- `SuggestionBlock.tsx:69` — `#fce8e8` — pastel removal sentence wash (per-sentence inline-style bg)
- `ContentEditor.tsx:503` — `#2563eb` / `#1d4ed8` — Tiptap Link mark blue + hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)