### PR TITLE
refactor(kb-ui): tokenize shell/nav/overlays/brand (chunk 3c)

### DIFF
--- a/packages/kb-ui/src/components/nav/FileExplorerNav.tsx
+++ b/packages/kb-ui/src/components/nav/FileExplorerNav.tsx
@@ -139,16 +139,16 @@ function FlatRow({ item, isActive, isDark, onClick }: FlatRowProps) {
           item.icon && 'gap-2',
           'text-left text-[14px] leading-[20px] transition-colors duration-150',
           'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
-          isDark ? 'text-white/90' : 'text-[#0f172a]',
+          isDark ? 'text-white/90' : 'text-text-primary',
           isSection
             ? 'cursor-default font-medium'
             : isActive
               ? isDark
                 ? 'bg-white/[0.08] font-medium'
-                : 'bg-[#f8fafc] font-medium'
+                : 'bg-surface-subtle font-medium'
               : isDark
                 ? 'font-normal hover:bg-white/[0.05]'
-                : 'font-normal hover:bg-[#f8fafc]',
+                : 'font-normal hover:bg-surface-subtle',
         )}
       >
         {item.icon && (
@@ -156,7 +156,7 @@ function FlatRow({ item, isActive, isDark, onClick }: FlatRowProps) {
             aria-hidden
             className={cn(
               'inline-flex size-4 shrink-0 items-center justify-center [&>svg]:w-4 [&>svg]:h-4',
-              isDark ? 'text-white/60' : 'text-[#475569]',
+              isDark ? 'text-white/60' : 'text-text-meta',
             )}
           >
             {item.icon}
@@ -216,12 +216,12 @@ function FolderRow({
   const state: RowState = isActive ? 'active' : isActiveSub ? 'active-sub' : 'default';
   const ChevronIcon = isExpanded ? RiArrowDownSLine : RiArrowRightSLine;
 
-  const labelColor = isDark ? 'text-white/90' : 'text-[#0f172a]';
+  const labelColor = isDark ? 'text-white/90' : 'text-text-primary';
   // Per Figma `6:438`: folder/sub-folder rows use font-normal in every state.
   // Only `type=category, state=hover` uses font-medium on the label. Keep regular
   // weight across the board and let background + size carry the emphasis.
   const labelWeight = 'font-normal';
-  const countColor = isDark ? 'text-white/40' : 'text-[#475569]';
+  const countColor = isDark ? 'text-white/40' : 'text-text-meta';
 
   // Figma behavior: on ACTIVE the count stays visible (no kebab — see 6:508, 6:491).
   // On HOVER (non-active) the kebab replaces the count (see 6:493 vs 6:484).
@@ -250,7 +250,7 @@ function FolderRow({
           <span
             className={cn(
               'flex size-6 items-center justify-center rounded-[6px] shrink-0',
-              isDark ? 'text-white/60' : 'text-[#64748b]',
+              isDark ? 'text-white/60' : 'text-text-muted',
             )}
           >
             <ChevronIcon size={16} />
@@ -258,7 +258,7 @@ function FolderRow({
           <span
             className={cn(
               'flex size-6 items-center justify-center rounded-[6px] shrink-0',
-              isDark ? 'text-white/60' : 'text-[#64748b]',
+              isDark ? 'text-white/60' : 'text-text-muted',
             )}
           >
             <RiFolderLine size={16} />
@@ -286,7 +286,7 @@ function FolderRow({
               <span
                 className={cn(
                   'hidden group-hover:flex items-center justify-center',
-                  isDark ? 'text-white/60' : 'text-[#475569]',
+                  isDark ? 'text-white/60' : 'text-text-meta',
                 )}
               >
                 <RiMore2Line size={16} />
@@ -310,8 +310,9 @@ type ArticleRowProps = {
 function ArticleRow({ item, depth, isActive, isDark, onClick }: ArticleRowProps) {
   const state: RowState = isActive ? 'active' : 'default';
 
-  const labelColor = isDark ? 'text-white/80' : 'text-[#0f172a]';
+  const labelColor = isDark ? 'text-white/80' : 'text-text-primary';
   // Spec colors: published = #42cd83, draft = #898989. 4×4 size.
+  // (Status-dot spec hexes are intentionally inline — not in the token system.)
   const statusDotColor =
     item.status === 'published'
       ? 'bg-[#42cd83]'
@@ -349,7 +350,7 @@ function ArticleRow({ item, depth, isActive, isDark, onClick }: ArticleRowProps)
           <span
             className={cn(
               'flex size-6 items-center justify-center rounded-[6px] shrink-0',
-              isDark ? 'text-white/60' : 'text-[#64748b]',
+              isDark ? 'text-white/60' : 'text-text-muted',
             )}
           >
             <RiFile3Line size={16} />
@@ -376,7 +377,7 @@ function ArticleRow({ item, depth, isActive, isDark, onClick }: ArticleRowProps)
               <span
                 className={cn(
                   'hidden group-hover:flex items-center justify-center',
-                  isDark ? 'text-white/60' : 'text-[#475569]',
+                  isDark ? 'text-white/60' : 'text-text-meta',
                 )}
               >
                 <RiMore2Line size={16} />
@@ -416,7 +417,7 @@ export function FileExplorerNav({
     (isFlat ? null : (
       <RiQuillPenLine
         size={16}
-        className={isDark ? 'text-white/60' : 'text-[#64748b]'}
+        className={isDark ? 'text-white/60' : 'text-text-muted'}
       />
     ));
 
@@ -511,7 +512,7 @@ export function FileExplorerNav({
     <aside
       className={cn(
         'flex flex-col w-[288px] h-full',
-        isDark ? 'bg-[#1a1a1a]' : 'bg-white border-r border-[#e2e8f0]',
+        isDark ? 'bg-[#1a1a1a]' : 'bg-white border-r border-card-border',
         className,
       )}
       aria-label="File explorer"
@@ -530,7 +531,7 @@ export function FileExplorerNav({
               aria-hidden
               className={cn(
                 'inline-flex items-center justify-center [&>svg]:w-4 [&>svg]:h-4',
-                isDark ? 'text-white/60' : 'text-[#0f172a]',
+                isDark ? 'text-white/60' : 'text-text-primary',
               )}
             >
               {resolvedHeaderIcon}
@@ -540,7 +541,7 @@ export function FileExplorerNav({
             data-kb-part="explorer-title"
             className={cn(
               'text-[14px] font-semibold',
-              isDark ? 'text-white/90' : 'text-[#0f172a]',
+              isDark ? 'text-white/90' : 'text-text-primary',
             )}
           >
             {title}
@@ -554,7 +555,7 @@ export function FileExplorerNav({
               'flex size-6 items-center justify-center rounded-[6px] cursor-pointer transition-colors duration-150',
               isDark
                 ? 'text-white/60 hover:bg-white/[0.06] hover:text-white/90'
-                : 'text-[#64748b] hover:bg-[#f8fafc] hover:text-[#0f172a]',
+                : 'text-text-muted hover:bg-surface-subtle hover:text-text-primary',
             )}
           >
             <RiSearchLine size={16} />
@@ -567,7 +568,7 @@ export function FileExplorerNav({
         data-kb-part="explorer-divider"
         className={cn(
           'h-px mx-[16px] shrink-0',
-          isDark ? 'bg-white/10' : 'bg-[#e2e8f0]',
+          isDark ? 'bg-white/10' : 'bg-card-border',
         )}
       />
 
@@ -597,7 +598,7 @@ export function FileExplorerNav({
                       data-kb-part="flat-section-divider"
                       className={cn(
                         'h-px mx-[16px]',
-                        isDark ? 'bg-white/10' : 'bg-[#e2e8f0]',
+                        isDark ? 'bg-white/10' : 'bg-card-border',
                       )}
                     />
                   )}

--- a/packages/kb-ui/src/components/nav/SideNavRail.tsx
+++ b/packages/kb-ui/src/components/nav/SideNavRail.tsx
@@ -36,7 +36,7 @@ export function SideNavRail({
     <nav
       className={cn(
         'flex h-full w-[54px] flex-col',
-        isDark ? 'bg-[#1a1a1a]' : 'bg-white border-r border-[#e2e8f0]',
+        isDark ? 'bg-[#1a1a1a]' : 'bg-white border-r border-card-border',
         className,
       )}
       aria-label="Primary"
@@ -56,7 +56,7 @@ export function SideNavRail({
         data-kb-part="rail-divider"
         className={cn(
           'h-px mx-[8px] shrink-0',
-          isDark ? 'bg-white/10' : 'bg-[#e2e8f0]',
+          isDark ? 'bg-white/10' : 'bg-card-border',
         )}
       />
 
@@ -85,8 +85,8 @@ export function SideNavRail({
                     ? // Active pill matches Figma `1:4350` (.menu-items active):
                       // bg-[rgba(230,230,230,0.44)]. Previously used #f8fafc
                       // which was nearly invisible against white rail bg.
-                      'bg-[rgba(230,230,230,0.44)] text-[#0f172a]'
-                    : 'text-[#475569] hover:bg-[rgba(230,230,230,0.32)] hover:text-[#0f172a]',
+                      'bg-[rgba(230,230,230,0.44)] text-text-primary'
+                    : 'text-text-meta hover:bg-[rgba(230,230,230,0.32)] hover:text-text-primary',
               )}
             >
               {/* Enforce 16×16 glyph in-component so size is not caller-dependent.

--- a/packages/kb-ui/src/components/overlays/SideSheet.tsx
+++ b/packages/kb-ui/src/components/overlays/SideSheet.tsx
@@ -39,13 +39,13 @@ export type SideSheetProps = {
  * ───────────────────────────────────────────────────────────── */
 
 const headerClass =
-  'flex h-[56px] shrink-0 items-center gap-2 border-b border-card-border bg-[#f8fafc] px-5';
+  'flex h-[56px] shrink-0 items-center gap-2 border-b border-card-border bg-surface-subtle px-5';
 const titleClass =
-  'text-[16px] font-semibold leading-[24px] text-[#0f172a]';
+  'text-[16px] font-semibold leading-[24px] text-text-primary';
 const countClass =
-  'inline-flex h-[20px] min-w-[20px] items-center justify-center rounded-full px-2 bg-[#f1f5f9] text-[12px] font-medium leading-[18px] text-[#475569] tabular-nums';
+  'inline-flex h-[20px] min-w-[20px] items-center justify-center rounded-full px-2 bg-surface-muted text-[12px] font-medium leading-[18px] text-text-meta tabular-nums';
 const closeBtnClass =
-  'inline-flex h-8 w-8 items-center justify-center rounded-[6px] text-[#64748b] transition-colors hover:bg-[#f1f5f9] hover:text-[#0f172a] focus:outline-none focus:ring-2 focus:ring-black/10';
+  'inline-flex h-8 w-8 items-center justify-center rounded-[6px] text-text-muted transition-colors hover:bg-surface-muted hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-black/10';
 const bodyClass = 'flex flex-1 flex-col overflow-y-auto px-5 py-4';
 
 /* ─────────────────────────────────────────────────────────────

--- a/packages/kb-ui/src/components/overlays/SourcesSideSheet.tsx
+++ b/packages/kb-ui/src/components/overlays/SourcesSideSheet.tsx
@@ -85,23 +85,23 @@ export function MailItem({
       <div className="flex items-center gap-2">
         <RiMailLine
           aria-hidden="true"
-          className="h-4 w-4 shrink-0 text-[#64748b]"
+          className="h-4 w-4 shrink-0 text-text-muted"
         />
-        <span className="flex-1 truncate text-[14px] font-semibold leading-[20px] text-[#0f172a]">
+        <span className="flex-1 truncate text-[14px] font-semibold leading-[20px] text-text-primary">
           {senderName}
         </span>
-        <span className="shrink-0 text-[12px] font-normal leading-[18px] text-[#64748b]">
+        <span className="shrink-0 text-[12px] font-normal leading-[18px] text-text-muted">
           {timestamp}
         </span>
       </div>
 
       {/* Row 2: subject */}
-      <div className="mt-2 truncate text-[14px] font-medium leading-[20px] text-[#0f172a]">
+      <div className="mt-2 truncate text-[14px] font-medium leading-[20px] text-text-primary">
         {subject}
       </div>
 
       {/* Row 3: preview snippet (single-line, ellipsized) */}
-      <div className="mt-1 truncate text-[14px] font-normal leading-[20px] text-[#64748b]">
+      <div className="mt-1 truncate text-[14px] font-normal leading-[20px] text-text-muted">
         {snippet}
       </div>
     </>
@@ -121,7 +121,7 @@ export function MailItem({
         data-kb-part="sources-side-sheet-card"
         className={cn(
           baseClass,
-          'transition-colors hover:bg-[#f8fafc] focus:outline-none focus:ring-2 focus:ring-black/10',
+          'transition-colors hover:bg-surface-subtle focus:outline-none focus:ring-2 focus:ring-black/10',
         )}
       >
         {content}

--- a/packages/kb-ui/src/components/shell/AppShell.tsx
+++ b/packages/kb-ui/src/components/shell/AppShell.tsx
@@ -67,7 +67,7 @@ export function AppShell({
       data-kb-component="app-shell"
       data-kb-sidebar-collapsed={sidebarCollapsed ? 'true' : 'false'}
       className={cn(
-        'flex h-screen w-full overflow-hidden bg-[#f5f5f5]',
+        'flex h-screen w-full overflow-hidden bg-canvas',
         className,
       )}
     >

--- a/packages/kb-ui/src/components/shell/EditorBreadcrumbActions.tsx
+++ b/packages/kb-ui/src/components/shell/EditorBreadcrumbActions.tsx
@@ -55,10 +55,10 @@ export function EditorBreadcrumbActions({
         disabled={effectiveSaveDisabled}
         className={cn(
           'inline-flex items-center h-8 px-3 py-1.5 rounded-[6px] text-[14px] font-normal',
-          'focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-border-faint',
           effectiveSaveDisabled
-            ? 'text-[#94a3b8] cursor-not-allowed'
-            : 'text-[#475569] hover:bg-[#f8fafc]',
+            ? 'text-text-disabled cursor-not-allowed'
+            : 'text-text-meta hover:bg-surface-subtle',
         )}
       >
         {saveLabel}
@@ -88,7 +88,7 @@ export function EditorBreadcrumbActions({
         type="button"
         onClick={onClose}
         aria-label="Close"
-        className="inline-flex size-8 items-center justify-center rounded-[6px] bg-[#f1f5f9] text-[#0f172a] hover:bg-[#e2e8f0] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]"
+        className="inline-flex size-8 items-center justify-center rounded-[6px] bg-surface-muted text-text-primary hover:bg-card-border focus:outline-none focus-visible:ring-2 focus-visible:ring-border-faint"
       >
         <RiCloseLine size={16} />
       </button>

--- a/packages/kb-ui/src/components/shell/KBBreadcrumbBar.tsx
+++ b/packages/kb-ui/src/components/shell/KBBreadcrumbBar.tsx
@@ -71,7 +71,7 @@ export function KBBreadcrumbBar({
           onClick={handleLeadingClick}
           aria-label={leadingLabel}
           data-testid={leadingTestId}
-          className="inline-flex size-[22px] shrink-0 p-[4px] items-center justify-center rounded-[4px] text-[#64748b] hover:bg-[#f8fafc] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]"
+          className="inline-flex size-[22px] shrink-0 p-[4px] items-center justify-center rounded-[4px] text-text-muted hover:bg-surface-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-border-faint"
         >
           <LeadingIcon size={14} />
         </button>
@@ -86,12 +86,12 @@ export function KBBreadcrumbBar({
         {sidebarCollapsed ? (
           <span
             aria-hidden="true"
-            className="inline-flex items-center justify-center text-[14px] leading-5 text-[#cbd5e1] px-[6px] shrink-0 select-none"
+            className="inline-flex items-center justify-center text-[14px] leading-5 text-border-faint px-[6px] shrink-0 select-none"
           >
             /
           </span>
         ) : (
-          <span aria-hidden="true" className="h-5 w-px shrink-0 bg-[#e2e8f0]" />
+          <span aria-hidden="true" className="h-5 w-px shrink-0 bg-card-border" />
         )}
 
         <nav aria-label="Breadcrumb" className="flex items-center min-w-0">
@@ -108,7 +108,7 @@ export function KBBreadcrumbBar({
                     // Current-item pill per spec: bg #f8fafc, radius 4, padding 0/6
                     <span
                       data-kb-part="breadcrumb-current"
-                      className="inline-flex items-center h-5 px-[6px] py-0 rounded-[4px] bg-[#f8fafc] text-[14px] font-medium leading-5 text-[#0f172a] truncate max-w-[320px]"
+                      className="inline-flex items-center h-5 px-[6px] py-0 rounded-[4px] bg-surface-subtle text-[14px] font-medium leading-5 text-text-primary truncate max-w-[320px]"
                       title={item.label}
                     >
                       {item.label}
@@ -120,7 +120,7 @@ export function KBBreadcrumbBar({
                     <a
                       href="#"
                       onClick={(e) => e.preventDefault()}
-                      className="text-[14px] font-normal leading-5 text-[#64748b] hover:bg-[#f8fafc] hover:text-[#0f172a] rounded-[4px] px-[6px] py-0 truncate max-w-[260px]"
+                      className="text-[14px] font-normal leading-5 text-text-muted hover:bg-surface-subtle hover:text-text-primary rounded-[4px] px-[6px] py-0 truncate max-w-[260px]"
                       title={item.label}
                     >
                       {item.label}
@@ -129,7 +129,7 @@ export function KBBreadcrumbBar({
                   {!isLast && (
                     <span
                       aria-hidden="true"
-                      className="inline-flex items-center justify-center text-[14px] leading-5 text-[#cbd5e1] px-[6px] shrink-0 select-none"
+                      className="inline-flex items-center justify-center text-[14px] leading-5 text-border-faint px-[6px] shrink-0 select-none"
                     >
                       /
                     </span>


### PR DESCRIPTION
Finishes the kb-ui sweep — shell/, nav/, overlays/, brand/ inline hex usages migrated to token classes.

- Swept ~59 inline hex usages across 7 files (AppShell, KBBreadcrumbBar, EditorBreadcrumbActions, SideSheet, SourcesSideSheet, SideNavRail, FileExplorerNav)
- Brand icon mark hex preserved per rules: AiIcon (#D92FFF/#FFC987 gradient stops), CompanyLogo (#2D2D2D), CursorClickIcon (JSDoc-only)
- SideNavRail/FileExplorerNav dark-theme #1a1a1a left inline — flagged for later removal per "no dark mode" rule, not in scope for tokenization
- Status-dot spec hexes preserved inline (#42cd83 published, #898989 draft) — outside token system
- Verification gate: typecheck, build, build-storybook all pass