### PR TITLE
docs(kb-ui): sync design.md + Foundations story (chunk 4)

### DIFF
--- a/design.md
+++ b/design.md
@@ -85,7 +85,8 @@ File key: `9aGp5t9fH1d0PXi4LMhOdb` — **Note: `get_design_context` returns "not
 --color-btn-primary:     #000000
 --color-btn-danger-bg:   #feeeec
 --color-border:          #f1f5f9
---color-border-input:    #e5e5e5
+--color-border-input:    #e2e8f0   /* Phase 15 — unified to slate-200 (was #e5e5e5) */
+--color-border-faint:    #cbd5e1   /* Phase 15 — slate-300, soft hairlines / chevron separators / pressed-state bg */
 
 /* AI Gaps semantic palette */
 --color-ai-addition:       #22c55e
@@ -95,9 +96,12 @@ File key: `9aGp5t9fH1d0PXi4LMhOdb` — **Note: `get_design_context` returns "not
 --color-ai-addition-wash:  rgba(34,197,94,0.12)
 --color-ai-removal-wash:   rgba(239,68,68,0.10)
 
-/* Card semantics (distinct from input borders) */
---color-card-border:       #e5e5e5
---color-card-divider:      #e5e5e5
+/* Semantic washes (Phase 15) */
+--color-success-wash-subtle: #f2fcf6   /* softest success wash — HelpfulnessTag up + Badge published */
+
+/* Card semantics */
+--color-card-border:       #e2e8f0   /* Phase 15 — unified to slate-200 (was #e5e5e5) */
+--color-card-divider:      #e2e8f0   /* Phase 15 — unified to slate-200 (was #e5e5e5) */
 
 /* Analytics — trend indicators (Figma SupportPerformanceCard 1974:53911) */
 --color-trend-up:          #086e3f   /* Figma text/success/default + icon/success/subtle */
@@ -126,9 +130,16 @@ File key: `9aGp5t9fH1d0PXi4LMhOdb` — **Note: `get_design_context` returns "not
 --color-donut-6:           #4b5468   /* Figma NeutralLight/nl700 */
 ```
 
-**Why card-border vs border-input:** `border-input` is for form fields (inputs/dropdowns). `card-border` is for surface cards. Same hex, different semantic — keeps the two from drifting independently.
+**Card + input borders unified to #e2e8f0 (slate-200) in Phase 15.** `--color-border-input` is preserved as an alias for semantic clarity in input components.
 
-*Why trend tokens duplicate ai- hexes:** AI gaps semantics (`addition`/`replace`/`removal`) are about diff direction in an article; analytics trend tokens are about a metric going up or down. Same hex, distinct semantic — don't conflate the two in component code.
+**Why trend tokens duplicate ai- hexes:** AI gaps semantics (`addition`/`replace`/`removal`) are about diff direction in an article; analytics trend tokens are about a metric going up or down. Same hex, distinct semantic — don't conflate the two in component code.
+
+**Phase 15 foundation consolidation:**
+
+- slate-500 typo fixed across 107 lines → `#64748b`
+- card-border family unified to `#e2e8f0` (was `#e5e5e5`): `--color-card-border`, `--color-card-divider`, `--color-border-input`
+- new tokens: `--color-border-faint` (`#cbd5e1`), `--color-success-wash-subtle` (`#f2fcf6`)
+- `--color-text-faint` dropped as duplicate of `--color-text-muted`; components migrated to token classes (`text-text-primary`, `bg-canvas`, `border-card-border`, etc.) — minimal raw inline hex remains in `packages/kb-ui/src/components/**/*.tsx`
 
 ### Typography (all Inter)
 

--- a/packages/kb-ui/src/components/foundations/Foundations.stories.tsx
+++ b/packages/kb-ui/src/components/foundations/Foundations.stories.tsx
@@ -61,7 +61,7 @@ function Row({ name, meta, children }: RowProps) {
           {name}
         </code>
         {meta ? (
-          <span className="text-[12px] leading-[18px] text-[#64758b] font-mono">
+          <span className="text-[12px] leading-[18px] text-[#64748b] font-mono">
             {meta}
           </span>
         ) : null}
@@ -153,6 +153,8 @@ const backgroundColors = [
   { name: 'background/black/static', hex: '#000000' },
   { name: 'background/accents/green/default', hex: '#42cd83' },
   { name: 'background/accents/green/soft', hex: '#f2fdf6' },
+  // Phase 15 — added: softest success wash, HelpfulnessTag up + Badge published.
+  { name: 'background/success/wash-subtle', hex: '#f2fcf6' },
   { name: 'background/accents/gray/soft', hex: '#e5e5e5' },
   { name: 'background/accents/gray/default', hex: '#898989' },
   { name: 'background/accents/gray/strong', hex: '#2d2d2d' },
@@ -160,14 +162,20 @@ const backgroundColors = [
 
 const borderColors = [
   { name: 'border/slate_blue/subtle', hex: '#e2e8f0' },
+  // Phase 15 — added: new `--color-border-faint` token (slate-300). Same hex as `default`,
+  // distinct semantic (soft hairlines, chevron separators, pressed-state bg).
+  { name: 'border/slate_blue/faint', hex: '#cbd5e1' },
   { name: 'border/slate_blue/default', hex: '#cbd5e1' },
-  { name: 'border/neutral/subtle', hex: '#e5e5e5' },
+  // Phase 15 — unified to #e2e8f0 (neutral-200 → slate-200, card + input borders unified).
+  { name: 'border/neutral/subtle', hex: '#e2e8f0' },
 ] as const;
 
 const iconColors = [
   { name: 'icon/neutral/default', hex: '#0f172a' },
   { name: 'icon/neutral/subtle', hex: '#475569' },
-  { name: 'icon/neutral/faint', hex: '#64758b' },
+  // Phase 15 — `icon/neutral/faint` (typo'd hex) consolidated into `muted` (#64748b).
+  // Backing token `--color-text-faint` was dropped as a duplicate of `--color-text-muted`.
+  { name: 'icon/neutral/muted', hex: '#64748b' },
   { name: 'icon/white/static', hex: '#ffffff', onDark: true },
   { name: 'icon/success/subtle', hex: '#086e3f' },
   { name: 'icon/accents/green/default', hex: '#086e3f' },
@@ -456,7 +464,7 @@ function IconCatalogSection() {
                   <code className="text-[11px] leading-[16px] font-mono text-[#475569] text-center">
                     {entry.name}
                   </code>
-                  <code className="text-[10px] leading-[14px] font-mono text-[#64758b]">
+                  <code className="text-[10px] leading-[14px] font-mono text-[#64748b]">
                     {entry.size}px
                   </code>
                 </div>
@@ -510,7 +518,7 @@ function SpacingSection() {
         {spacingScale.map((s) => (
           <Row key={s.name} name={`space/${s.name}`} meta={`${s.px}px`}>
             {s.px === 0 ? (
-              <span className="text-[12px] leading-[18px] text-[#64758b] font-mono">
+              <span className="text-[12px] leading-[18px] text-[#64748b] font-mono">
                 (zero — no bar)
               </span>
             ) : (
@@ -545,7 +553,7 @@ function RadiusSection() {
               <code className="text-[12px] leading-[18px] font-mono text-[#0f172a]">
                 radius/{r.name}
               </code>
-              <code className="text-[11px] leading-[16px] font-mono text-[#64758b]">
+              <code className="text-[11px] leading-[16px] font-mono text-[#64748b]">
                 {r.px}px
               </code>
             </div>

--- a/plan.md
+++ b/plan.md
@@ -9,7 +9,7 @@
 | Component base | **Radix UI primitives** | Accessible, unstyled — we own the visual layer 100% |
 | Design tokens | **Style Dictionary** | Single source of truth; generates CSS vars, JS tokens, Tailwind config from one JSON |
 | Build | **tsup** | Zero-config, fast, ESM + CJS dual output |
-| Storybook | **Storybook 8** | Component playground, visual regression baseline |
+| Storybook | **Storybook 10** | Component playground, visual regression baseline |
 | Distribution | **npm package** | Consumed via `import { KBSidebar } from '@hiver/kb-ui'` |
 
 ## Distribution — DECIDED


### PR DESCRIPTION
## Summary
- Foundations swatches updated for the Phase 15 token state: `#64748b` slate-500 typo fixed, card-border family unified to `#e2e8f0`
- New swatches added — `border/slate_blue/faint` (`#cbd5e1`) and `background/success/wash-subtle` (`#f2fcf6`); stale `icon/neutral/faint` swatch relabeled to `icon/neutral/muted`
- `design.md` Colors block aligned with `tokens.css`; rationale comment on card-border vs border-input replaced; brief consolidation note appended
- `plan.md` Tech Stack: Storybook 8 → 10 (matches `package.json` 10.3.5)

## Test plan
- [x] `npm run --workspace=packages/kb-ui typecheck` clean
- [x] `npm run --workspace=packages/kb-ui build-storybook` clean
- [x] `grep -rn '#64758b' packages/kb-ui/src design.md plan.md` returns empty

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>