### PR TITLE
feat(demo): refresh editor + AI Gaps (D1)

### DIFF
--- a/apps/demo/src/components/ConfirmDialog.tsx
+++ b/apps/demo/src/components/ConfirmDialog.tsx
@@ -99,19 +99,14 @@ export function ConfirmDialog({
               {cancelLabel}
             </Button>
             {confirmVariant === 'destructive' ? (
-              <button
-                type="button"
-                onClick={onConfirm}
-                className={cn(
-                  'inline-flex items-center justify-center rounded-[6px] px-3 py-1.5',
-                  'text-[14px] font-medium leading-5 text-white',
-                  'bg-[#dc2626] hover:bg-[#b91c1c]',
-                  'transition-colors',
-                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#dc2626]/30',
-                )}
-              >
+              // Phase 15a — adopted Button's `variant="danger"` (introduced
+              // alongside `outline` / `danger-outline` with uniform 32 px
+              // height). Replaces an inline `<button>` styled with raw red
+              // hex values so destructive confirmations match the kb-ui
+              // canonical danger color (#f03f33) instead of red-600.
+              <Button variant="danger" onClick={onConfirm}>
                 {confirmLabel}
-              </button>
+              </Button>
             ) : (
               <Button variant="primary" onClick={onConfirm}>
                 {confirmLabel}

--- a/apps/demo/src/routes/ai-optimise/passwordResetRegions.tsx
+++ b/apps/demo/src/routes/ai-optimise/passwordResetRegions.tsx
@@ -1,29 +1,34 @@
 // Password-reset article markup for the AI Gaps Review experience.
 //
-// Duplicated from kb-ui's `KBAIGapsExperience.stories.tsx` (the canonical
-// example) — we cannot import internal kb-ui stories from the demo, and
-// the regions are deliberately not part of kb-ui's public API (consumers
-// own their article HTML; ArticleBody just owns the SuggestionBlock
-// wrapping per `decisions`).
+// Mirrors `packages/kb-ui/src/pages/KBAIGapsExperience.stories.tsx`'s
+// canonical `passwordResetRegions` — the demo cannot import private
+// story symbols, so we replicate the shape locally. The article body
+// is the same source-of-truth content used by every kb-ui AI Gaps
+// review story.
 //
-// The slot semantics match `ArticleBodyRegions` exactly:
-//   - header           → article title + byline
-//   - beforeS1         → intro paragraph
-//   - s1               → addition: mobile-app instructions section
-//   - betweenS1AndS2   → "Resetting via Admin Panel" heading + intro
-//   - s2.before/.after → admin panel URL paragraph (legacy → new)
-//   - betweenS2AndS3   → null (s3 follows directly)
-//   - s3               → removal: Troubleshooting section
-//   - afterS3          → password requirements section
+// Phase 15a migrated `ArticleBody` to per-sentence `SuggestionBlock`
+// highlights — `s1`/`s3` are now `SuggestionSentence[]` arrays and
+// `s2` is `{ before: SuggestionSentence[]; after: SuggestionSentence[] }`.
+// Each entry renders as one highlighted block with a 4px gap between
+// entries (matches Figma 137:4022 / 137:4132). JSX entries preserve
+// their typography (headings, list items); strings render as 16px
+// body text inside a single `<SuggestionHighlight>` span.
 //
-// Pre-existing behaviour: this is the only article body the demo's review
-// route ships in v1. The other two AI-targeted articles (auto-reply rules,
-// chat widget) reuse this same content because the mock store doesn't
-// model per-article body HTML — see `ReviewPage.tsx`'s notes on the slot
-// mapping for the rationale.
+// Slot order rendered by `ArticleBody`:
+//   header → beforeS1 → s1 region → betweenS1AndS2 → s2 region
+//          → betweenS2AndS3 → s3 region → afterS3
 
 import * as React from 'react';
-import type { ArticleBodyRegions } from '@test-kb-ui/kb-ui';
+import {
+  SuggestionHighlight,
+  type ArticleBodyRegions,
+} from '@test-kb-ui/kb-ui';
+
+/* ─────────────────────────────────────────────────────────────
+ * Typography helpers — duplicated locally so the demo's article
+ * markup matches the kb-ui canonical example 1:1. Values pulled
+ * from Figma `9aGp5t9fH1d0PXi4LMhOdb#74:10788`.
+ * ───────────────────────────────────────────────────────────── */
 
 function H1({ children }: { children: React.ReactNode }) {
   return (
@@ -49,27 +54,11 @@ function H2({ children }: { children: React.ReactNode }) {
   );
 }
 
-function H3({ children }: { children: React.ReactNode }) {
-  return (
-    <h3 className="mt-4 mb-2 text-[16px] font-semibold leading-[24px] text-[#0f172a]">
-      {children}
-    </h3>
-  );
-}
-
 function P({ children }: { children: React.ReactNode }) {
   return (
     <p className="mb-4 text-[16px] font-normal leading-[24px] text-[#334155]">
       {children}
     </p>
-  );
-}
-
-function OL({ children }: { children: React.ReactNode }) {
-  return (
-    <ol className="mb-4 list-decimal pl-6 text-[16px] font-normal leading-[24px] text-[#334155] [&>li]:mb-2">
-      {children}
-    </ol>
   );
 }
 
@@ -87,6 +76,27 @@ function Strong({ children }: { children: React.ReactNode }) {
   );
 }
 
+/**
+ * Numbered list item where the numeral renders OUTSIDE the highlight —
+ * matches Figma 137:4022 / 137:4132. Used inside s1 entries so each
+ * numbered step gets its own green block while the numeral stays on
+ * the white page.
+ */
+function NumberedItem({
+  index,
+  children,
+}: {
+  index: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <span className="flex items-start text-[16px] leading-[24px] text-[#0f172a]">
+      <span className="shrink-0 pr-2 tabular-nums">{index}.</span>
+      <SuggestionHighlight>{children}</SuggestionHighlight>
+    </span>
+  );
+}
+
 export const passwordResetRegions: ArticleBodyRegions = {
   header: (
     <>
@@ -101,23 +111,39 @@ export const passwordResetRegions: ArticleBodyRegions = {
       or use the password recovery flow if you&rsquo;ve forgotten it.
     </P>
   ),
-  s1: (
-    <>
-      <H2>Resetting Your Password via Mobile App</H2>
-      <P>
-        If you&rsquo;re using the Hiver mobile app, follow these steps to
-        reset your password:
-      </P>
-      <OL>
-        <li>Open the Hiver mobile app on your device</li>
-        <li>Tap on &ldquo;Forgot Password&rdquo; on the login screen</li>
-        <li>Enter your registered email address</li>
-        <li>Check your email for a password reset link</li>
-        <li>Tap the link and follow the instructions to set a new password</li>
-        <li>Log in with your new password</li>
-      </OL>
-    </>
-  ),
+  /* Per-sentence sentence array. The H2 entry is JSX so it keeps its
+   * 20/28 semibold typography; numbered list entries place the
+   * "1. ", "2. ", … prefixes outside the highlighted span so the
+   * numerals stay on the white background (Figma 137:4022). */
+  s1: [
+    <span
+      key="h2"
+      className="block text-[20px] font-semibold leading-[28px] text-[#0f172a]"
+    >
+      <SuggestionHighlight>
+        Resetting Your Password via Mobile App
+      </SuggestionHighlight>
+    </span>,
+    'If you’re using the Hiver mobile app, follow these steps to reset your password:',
+    <NumberedItem key="li-1" index={1}>
+      Open the Hiver mobile app on your device
+    </NumberedItem>,
+    <NumberedItem key="li-2" index={2}>
+      Tap on “Forgot Password” on the login screen
+    </NumberedItem>,
+    <NumberedItem key="li-3" index={3}>
+      Enter your registered email address
+    </NumberedItem>,
+    <NumberedItem key="li-4" index={4}>
+      Check your email for a password reset link
+    </NumberedItem>,
+    <NumberedItem key="li-5" index={5}>
+      Tap the link and follow the instructions to set a new password
+    </NumberedItem>,
+    <NumberedItem key="li-6" index={6}>
+      Log in with your new password
+    </NumberedItem>,
+  ],
   betweenS1AndS2: (
     <>
       <H2>Resetting Password via Admin Panel</H2>
@@ -127,36 +153,61 @@ export const passwordResetRegions: ArticleBodyRegions = {
       </P>
     </>
   ),
+  /* Replace s2 — each half is one JSX entry containing inline emphasis
+   * (the admin URL is wrapped in <Strong>). The <SuggestionHighlight>
+   * wraps the whole sentence including the bolded URL inside it. */
   s2: {
-    before: (
-      <P>
-        Navigate to the admin panel at{' '}
-        <Strong>admin.hiver.com/legacy/users</Strong> and select the user
-        whose password needs to be reset.
-      </P>
-    ),
-    after: (
-      <P>
-        Navigate to the admin panel at{' '}
-        <Strong>admin.hiver.com/settings/users</Strong> and select the user
-        whose password needs to be reset. You can also use the search bar
-        to quickly find users by name or email.
-      </P>
-    ),
+    before: [
+      <span
+        key="s2-before"
+        className="text-[16px] leading-[24px] text-[#0f172a]"
+      >
+        <SuggestionHighlight>
+          Navigate to the admin panel at{' '}
+          <Strong>admin.hiver.com/legacy/users</Strong>
+          {' '}and select the user whose password needs to be reset.
+        </SuggestionHighlight>
+      </span>,
+    ],
+    after: [
+      <span
+        key="s2-after"
+        className="text-[16px] leading-[24px] text-[#0f172a]"
+      >
+        <SuggestionHighlight>
+          Navigate to the admin panel at{' '}
+          <Strong>admin.hiver.com/settings/users</Strong>
+          {' '}and select the user whose password needs to be reset. You
+          can also use the search bar to quickly find users by name or
+          email.
+        </SuggestionHighlight>
+      </span>,
+    ],
   },
   betweenS2AndS3: null,
-  s3: (
-    <>
-      <H2>Troubleshooting</H2>
-      <H3>Resetting via Chrome Extension</H3>
-      <P>
-        If you&rsquo;re using the Hiver Chrome Extension and experiencing
-        issues resetting your password, try clearing your browser cache,
-        restarting Chrome, and attempting the reset flow again. If issues
-        persist, contact support.
-      </P>
-    </>
-  ),
+  /* Removal s3 — each entry is one highlighted block, separated by
+   * 4px gaps so the white background reads through between entries.
+   * The H2 and H3 keep their heading typography via JSX entries; the
+   * body paragraph is split into two sentences (matches the natural
+   * sentence breaks in the source text). */
+  s3: [
+    <span
+      key="s3-h2"
+      className="block text-[20px] font-semibold leading-[28px] text-[#0f172a]"
+    >
+      <SuggestionHighlight>Troubleshooting</SuggestionHighlight>
+    </span>,
+    <span
+      key="s3-h3"
+      className="block text-[16px] font-semibold leading-[24px] text-[#0f172a]"
+    >
+      <SuggestionHighlight>
+        Resetting via Chrome Extension
+      </SuggestionHighlight>
+    </span>,
+    'If you’re using the Hiver Chrome Extension and experiencing issues resetting your password, try clearing your browser cache, restarting Chrome, and attempting the reset flow again.',
+    'If issues persist, contact support.',
+  ],
   afterS3: (
     <>
       <H2>Password Requirements</H2>


### PR DESCRIPTION
## Summary
Refreshes the `apps/demo` editor + AI Gaps journey (PRD §6 Journey A + B) so it compiles against current `@test-kb-ui/kb-ui` v2.0.0+ APIs and picks up Phase 15 improvements where they visibly land.

- **Phase 15a SuggestionBlock `sentences[]` migration** — `passwordResetRegions.tsx` re-written to use `s1: SuggestionSentence[]`, `s2: { before, after }`, `s3: SuggestionSentence[]`. Per-sentence highlights with 4 px gaps; numbered list items keep their numerals outside the wash via a local `NumberedItem` helper; H2/H3 entries preserve heading typography. Mirrors the canonical `KBAIGapsExperience.stories.tsx` shape.
- **Phase 15a `<Button variant="danger">` adoption** — `ConfirmDialog.tsx` destructive confirm migrated from inline-styled `bg-[#dc2626]` button to `<Button variant="danger">`. Used by both the editor close-with-unsaved-changes dialog and the AI Gaps "Discard review?" confirm, so the canonical kb-ui danger color (#f03f33) + uniform 32 px height now flow through both surfaces.
- **No changes needed elsewhere in scope** — `EditorPage`, `CategoryPage`, `HubPage`, `ReviewPage`, `BreadcrumbBar`, `EditorPageController` already use current APIs: `KBBreadcrumbBar.actions` slot + `EditorBreadcrumbActions`, `AISuggestionsCard` (`pre-review` / `terminal` modes), `AIGapSuggestionCard`, `ArticleBody.regions`, `ContentEditor`, `ArticleSettingsPanel` (compact + defaultCollapsed). No demo-side prop overrides fight Phase 15d round-1 changes (KBBreadcrumbBar `/` separator + inactive-item font weight, EditorBreadcrumbActions subtle close button, AISuggestionsCard `Button variant="subtle"` CTA).

## Test plan
- [x] `npm run --workspace=packages/kb-ui typecheck` — clean
- [x] `npm run --workspace=apps/demo build` — clean (1226 modules, no TS errors, no warnings)
- [ ] Spot-check demo at `/ai-optimise/how-to-reset-your-password/review` in dev — per-sentence highlights render with 4 px gaps; numerals sit outside the green wash; admin URL bold remains inside the highlight (chunk D4 manual boot)
- [ ] Spot-check editor close-with-unsaved-changes + AI Gaps "Discard review?" — danger button is `#f03f33` not red-600 (chunk D4 manual boot)