### PR TITLE
feat(demo): refresh analytics (D2)

### DIFF
--- a/apps/demo/src/routes/analytics/AIAnswerPerformancePage.tsx
+++ b/apps/demo/src/routes/analytics/AIAnswerPerformancePage.tsx
@@ -10,7 +10,11 @@
 //   1. Custom <header>: title + subtitle | DateRangePill
 //   2. StatCardGrid "AI Search Performance" — 4 metrics
 //   3. AnalyticsChartCard "AI deflection rate over time" (positive area + Goal:70%)
-//   4. AIConversationLogsCard with 5 anonymised entries
+//   4. AIConversationLogsCard with 6 anonymised entries (default chrome:
+//      title + subtitle + Sort dropdown + Ticket Created toggle). Phase 15d
+//      added a `header` slot (null = no chrome, ReactNode = custom) — the
+//      demo keeps the default chrome for realism, matching the manager-view
+//      story for this card.
 //   5. DataTable "Most Cited KB Articles"
 //
 // Interactions (PRD §7.8):
@@ -39,6 +43,7 @@ import {
 import { useMockStore } from '../../store/MockStoreContext';
 import { selectArticleById } from '../../store/selectors';
 import {
+  ANALYTICS_X_TICKS,
   aiAnswerFixtures,
   type MostCitedRow,
 } from '../../store/fixtures/analytics';
@@ -150,6 +155,7 @@ export default function AIAnswerPerformancePage() {
           xKey="x"
           series={deflectionSeries}
           yTicks={[0, 25, 50, 75, 100]}
+          xTicks={ANALYTICS_X_TICKS}
           goalLine={deflectionGoal}
           showLegend={false}
         />

--- a/apps/demo/src/routes/analytics/ArticlePerformancePage.tsx
+++ b/apps/demo/src/routes/analytics/ArticlePerformancePage.tsx
@@ -37,6 +37,7 @@ import {
 import { useMockStore } from '../../store/MockStoreContext';
 import { selectArticleById } from '../../store/selectors';
 import {
+  ANALYTICS_X_TICKS,
   articlePerformanceFixtures,
   type ArticleAttentionRow,
   type ArticlePerformanceRow,
@@ -191,6 +192,7 @@ export default function ArticlePerformancePage() {
           xKey="x"
           series={areaSeries}
           yTicks={[0, 3000, 6000, 9000, 12000]}
+          xTicks={ANALYTICS_X_TICKS}
         />
       </AnalyticsChartCard>
 

--- a/apps/demo/src/routes/analytics/SearchPage.tsx
+++ b/apps/demo/src/routes/analytics/SearchPage.tsx
@@ -30,6 +30,7 @@ import {
   type DataTableColumn,
 } from '@test-kb-ui/kb-ui';
 import {
+  ANALYTICS_X_TICKS,
   searchFixtures,
   type ContentGapRow,
   type SearchKeywordRow,
@@ -134,6 +135,7 @@ export default function SearchPage() {
               xKey="x"
               series={searchVolumeSeries}
               yTicks={[0, 500, 1000, 1500, 2000]}
+              xTicks={ANALYTICS_X_TICKS}
               showLegend={false}
             />
           </AnalyticsChartCard>
@@ -149,6 +151,7 @@ export default function SearchPage() {
               xKey="x"
               series={missedSearchSeries}
               yTicks={[0, 25, 50, 75, 100]}
+              xTicks={ANALYTICS_X_TICKS}
               goalLine={missedSearchGoal}
               showLegend={false}
             />

--- a/apps/demo/src/store/fixtures/analytics.ts
+++ b/apps/demo/src/store/fixtures/analytics.ts
@@ -138,6 +138,23 @@ function zipSeries(
   });
 }
 
+/**
+ * Subsample the 30-label series to 6 evenly-spaced labels for the
+ * x-axis. Phase 15d.B exposed `AnalyticsAreaChart.xTicks` so callers
+ * with dense data series can cap the rendered tick set — without it,
+ * Recharts crams 30 labels into the axis and they overlap.
+ *
+ * Indices: 0, 5, 10, 15, 20, 25 → ~5 days apart over the 30-day window.
+ * Concrete values with REFERENCE_DATE_MS = Apr 26, 2026:
+ *   ['Mar 28', 'Apr 2', 'Apr 7', 'Apr 12', 'Apr 17', 'Apr 22']
+ *
+ * Exported so each analytics page can pass the same axis labels.
+ */
+export const ANALYTICS_X_TICKS: string[] = (() => {
+  const labels = dayLabels();
+  return [0, 5, 10, 15, 20, 25].map((i) => labels[i]);
+})();
+
 /* ─────────────────────────────────────────────────────────────
  * Article Performance fixtures (analytics tab 1)
  * ───────────────────────────────────────────────────────────── */
@@ -457,7 +474,21 @@ const deflectionGoal: AnalyticsAreaChartGoalLine = {
   label: 'Goal : 70%',
 };
 
-/* ── Conversation log entries — 5 anonymised AI Q&A items ── */
+/* ── Conversation log entries — 6 anonymised AI Q&A items ──
+ *
+ * `tail` variants supported (kb-ui `AIConversationTail`):
+ *   - 'ticket-created'         — escalation; appended after answer or follow-up
+ *   - 'source-clicked'         — user opened one of the cited sources
+ *   - 'search-result-clicked'  — user fell back to a search result instead
+ *                                (Phase 15d.C variant — shown when the AI
+ *                                answer did not satisfy and the user clicked
+ *                                a non-cited article from the search panel)
+ */
+type ConversationTail =
+  | { kind: 'ticket-created'; actor?: string }
+  | { kind: 'source-clicked'; actor?: string }
+  | { kind: 'search-result-clicked'; actor?: string };
+
 type AnonymisedQA = {
   id: string;
   question: string;
@@ -470,13 +501,9 @@ type AnonymisedQA = {
     question: string;
     answer: string;
     sourceCount: number;
-    tail?:
-      | { kind: 'ticket-created'; actor?: string }
-      | { kind: 'source-clicked'; actor?: string };
+    tail?: ConversationTail;
   };
-  tail?:
-    | { kind: 'ticket-created'; actor?: string }
-    | { kind: 'source-clicked'; actor?: string };
+  tail?: ConversationTail;
 };
 
 const aiConversationLogs: AnonymisedQA[] = [
@@ -533,6 +560,23 @@ const aiConversationLogs: AnonymisedQA[] = [
     answer:
       'There is no built-in bulk-archive UI yet. The supported workaround is to filter by status + date in the conversations list, select all, and use the Archive bulk action from the table toolbar. We are tracking native bulk-archive as an upcoming feature.',
     sourceCount: 2,
+  },
+  {
+    // Phase 15d.C: new 'search-result-clicked' tail variant.
+    // Realistic narrative — the AI couldn't confidently answer a niche
+    // routing question; the user fell back to a search result rather
+    // than opening a cited source. PRD §13.4 source pattern: auto-reply
+    // rules sit on the AI-targeted articles list, so the timezone /
+    // schedule scenarios from §13.4 inspire the question shape here.
+    id: 'log-6',
+    question:
+      'Can I pause SLA timers automatically during company-wide holidays?',
+    timestamp: 'Apr 19, 10:48 AM',
+    feedback: 'negative',
+    answer:
+      "I'm not able to confirm whether SLA timers can be auto-paused on workspace holiday calendars. The closest configurable option I found is per-rule schedule exclusions, but that does not propagate to SLA policies.",
+    sourceCount: 1,
+    tail: { kind: 'search-result-clicked', actor: 'the user' },
   },
 ];
 


### PR DESCRIPTION
## Summary

- Adopts Phase 15d analytics improvements in the analytics surfaces of `apps/demo` (`/analytics/*`).
- `AIConversationLogsCard` keeps default chrome (title + Sort dropdown + Ticket Created toggle) — the new `header` slot would suppress chrome, but the manager-facing demo benefits from the full surface.
- All four area charts now pass the new `xTicks` prop so the 30-point daily series renders 6 evenly-spaced labels instead of cramming 30 labels into the axis.
- New `'search-result-clicked'` tail variant (Phase 15d.C) seeded on a 6th conversation log entry, demonstrating the latest kb-ui surface in the demo.

## Test plan

- [x] `npm run --workspace=packages/kb-ui typecheck`
- [x] `npm run --workspace=apps/demo build`
- [ ] Visual check: `/analytics/article-performance`, `/analytics/search`, `/analytics/ai-answer-performance` — axes show 6 ticks; conversation log entry #6 renders the new tail row

🤖 Generated with [Claude Code](https://claude.com/claude-code)