### PR TITLE
refactor(demo): tokenize inline hex (D3)

### DIFF
--- a/apps/demo/src/components/ArticleSeoCard.tsx
+++ b/apps/demo/src/components/ArticleSeoCard.tsx
@@ -162,10 +162,10 @@ export function ArticleSeoCard({
     >
       <header className="flex items-start justify-between gap-2">
         <div className="flex flex-col gap-0.5">
-          <h2 className="text-[14px] font-semibold leading-[20px] text-[#0f172a]">
+          <h2 className="text-[14px] font-semibold leading-[20px] text-text-primary">
             SEO
           </h2>
-          <p className="text-[12px] font-normal leading-[18px] text-[#64748b]">
+          <p className="text-[12px] font-normal leading-[18px] text-text-muted">
             Optimise how this article appears in search results.
           </p>
         </div>
@@ -176,7 +176,7 @@ export function ArticleSeoCard({
         <div className="flex items-center justify-between">
           <label
             htmlFor="seo-meta-description"
-            className="text-[13px] font-medium leading-[18px] text-[#0f172a]"
+            className="text-[13px] font-medium leading-[18px] text-text-primary"
           >
             Meta description
           </label>
@@ -210,19 +210,19 @@ export function ArticleSeoCard({
             maxLength={META_DESC_MAX + 40}
             className={cn(
               'w-full resize-y rounded-lg border bg-white px-3 py-2',
-              'text-[14px] font-normal leading-5 text-[#0f172a]',
-              'placeholder:text-[#94a3b8]',
-              'outline-none focus:border-[#94a3b8] focus:ring-2 focus:ring-black/5',
+              'text-[14px] font-normal leading-5 text-text-primary',
+              'placeholder:text-text-disabled',
+              'outline-none focus:border-text-disabled focus:ring-2 focus:ring-black/5',
               descLen > META_DESC_MAX
                 ? 'border-[#dc2626]'
-                : 'border-[#e5e5e5]',
+                : 'border-card-border',
             )}
           />
         )}
 
         <div className="flex items-center justify-between gap-2">
           <p
-            className="text-[12px] font-normal leading-[18px] text-[#64748b]"
+            className="text-[12px] font-normal leading-[18px] text-text-muted"
             id="ai-helper-text"
           >
             {aiReady
@@ -241,18 +241,18 @@ export function ArticleSeoCard({
         </div>
       </section>
 
-      <div className="h-px w-full bg-[#e2e8f0]" />
+      <div className="h-px w-full bg-card-border" />
 
       {/* ── Canonical URL ──────────────────────────────────── */}
       <section className="flex flex-col gap-2">
         <div className="flex items-center justify-between">
-          <span className="text-[13px] font-medium leading-[18px] text-[#0f172a]">
+          <span className="text-[13px] font-medium leading-[18px] text-text-primary">
             Canonical URL
           </span>
           <button
             type="button"
             onClick={() => setAdvancedOpen((o) => !o)}
-            className="text-[12px] font-medium leading-[18px] text-[#0f172a] underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20 rounded-sm"
+            className="text-[12px] font-medium leading-[18px] text-text-primary underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20 rounded-sm"
             aria-expanded={advancedOpen}
             aria-controls="seo-canonical-advanced"
           >
@@ -260,16 +260,16 @@ export function ArticleSeoCard({
           </button>
         </div>
 
-        <p className="text-[12px] font-normal leading-[18px] text-[#64748b]">
+        <p className="text-[12px] font-normal leading-[18px] text-text-muted">
           Auto-generated. Search engines treat this URL as the primary version
           when the same content is reachable via multiple paths.
         </p>
 
         <div
-          className="flex items-center gap-2 rounded-lg border border-dashed border-[#cbd5e1] bg-[#f8fafc] px-3 py-2"
+          className="flex items-center gap-2 rounded-lg border border-dashed border-border-faint bg-surface-subtle px-3 py-2"
           aria-label="Canonical URL preview"
         >
-          <code className="flex-1 truncate text-[13px] font-normal leading-[18px] text-[#0f172a]">
+          <code className="flex-1 truncate text-[13px] font-normal leading-[18px] text-text-primary">
             {canonicalEffective}
           </code>
           {value.canonicalUrlOverride.trim() && (
@@ -286,7 +286,7 @@ export function ArticleSeoCard({
           >
             <label
               htmlFor="seo-canonical-override"
-              className="text-[12px] font-medium leading-[18px] text-[#475569]"
+              className="text-[12px] font-medium leading-[18px] text-text-meta"
             >
               Override canonical URL
             </label>
@@ -299,7 +299,7 @@ export function ArticleSeoCard({
               placeholder={canonicalDefault}
             />
             <div className="flex items-center justify-between gap-2">
-              <p className="text-[11px] font-normal leading-[16px] text-[#94a3b8]">
+              <p className="text-[11px] font-normal leading-[16px] text-text-disabled">
                 Use only when this article is a duplicate of another canonical page.
               </p>
               {value.canonicalUrlOverride.trim() && (
@@ -340,20 +340,20 @@ function SuggestionPanel({
 }: SuggestionPanelProps) {
   return (
     <div
-      className="flex flex-col gap-3 rounded-lg border border-[#cbd5e1] bg-[#f8fafc] p-3"
+      className="flex flex-col gap-3 rounded-lg border border-border-faint bg-surface-subtle p-3"
       role="region"
       aria-label="AI-generated meta description suggestion"
     >
       <div className="flex items-center gap-1.5">
         <AiIcon size={14} />
-        <span className="text-[12px] font-semibold leading-[18px] text-[#0f172a]">
+        <span className="text-[12px] font-semibold leading-[18px] text-text-primary">
           AI suggestion
         </span>
-        <span className="text-[12px] font-normal leading-[18px] text-[#64748b]">
+        <span className="text-[12px] font-normal leading-[18px] text-text-muted">
           · {suggestion.length}/{META_DESC_MAX} chars
         </span>
       </div>
-      <p className="text-[14px] font-normal leading-[20px] text-[#0f172a]">
+      <p className="text-[14px] font-normal leading-[20px] text-text-primary">
         {suggestion}
       </p>
       <div className="flex flex-wrap items-center gap-2">

--- a/apps/demo/src/components/ConfirmDialog.tsx
+++ b/apps/demo/src/components/ConfirmDialog.tsx
@@ -61,7 +61,7 @@ export function ConfirmDialog({
       <Dialog.Portal>
         <Dialog.Overlay
           className={cn(
-            'fixed inset-0 z-[90] bg-[#0f172a]/40',
+            'fixed inset-0 z-[90] bg-text-primary/40',
             'animate-route-fade-in',
           )}
         />
@@ -71,7 +71,7 @@ export function ConfirmDialog({
           className={cn(
             'fixed left-1/2 top-1/2 z-[91] -translate-x-1/2 -translate-y-1/2',
             'w-[420px] max-w-[calc(100vw-32px)]',
-            'rounded-[8px] border border-[#e2e8f0] bg-white',
+            'rounded-[8px] border border-card-border bg-white',
             'shadow-[0_24px_48px_rgba(15,23,42,0.20)]',
             'p-6 flex flex-col gap-4',
             'animate-toast-in',
@@ -80,7 +80,7 @@ export function ConfirmDialog({
           )}
         >
           {title ? (
-            <Dialog.Title className="text-[16px] font-semibold leading-6 text-[#0f172a]">
+            <Dialog.Title className="text-[16px] font-semibold leading-6 text-text-primary">
               {title}
             </Dialog.Title>
           ) : (
@@ -90,7 +90,7 @@ export function ConfirmDialog({
             <Dialog.Title className="sr-only">{message}</Dialog.Title>
           )}
 
-          <Dialog.Description className="text-[14px] leading-5 text-[#475569]">
+          <Dialog.Description className="text-[14px] leading-5 text-text-meta">
             {message}
           </Dialog.Description>
 

--- a/apps/demo/src/components/EmptyState.tsx
+++ b/apps/demo/src/components/EmptyState.tsx
@@ -36,7 +36,7 @@ export function EmptyState({
       data-kb-part="empty-state"
       className={cn(
         'flex flex-col items-center justify-center gap-4 rounded-[8px]',
-        'border border-dashed border-[#e2e8f0] bg-[#fafafa]',
+        'border border-dashed border-card-border bg-[#fafafa]',
         'py-16 px-6 text-center',
         className,
       )}
@@ -44,17 +44,17 @@ export function EmptyState({
       {icon && (
         <div
           aria-hidden="true"
-          className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-[#64748b] [&>svg]:h-5 [&>svg]:w-5"
+          className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-text-muted [&>svg]:h-5 [&>svg]:w-5"
         >
           {icon}
         </div>
       )}
       <div className="flex flex-col gap-1">
-        <p className="text-[16px] font-medium leading-6 text-[#0f172a]">
+        <p className="text-[16px] font-medium leading-6 text-text-primary">
           {title}
         </p>
         {subtitle && (
-          <p className="text-[14px] leading-5 text-[#64748b]">{subtitle}</p>
+          <p className="text-[14px] leading-5 text-text-muted">{subtitle}</p>
         )}
       </div>
       {cta && (

--- a/apps/demo/src/components/PageProgressBar.tsx
+++ b/apps/demo/src/components/PageProgressBar.tsx
@@ -12,10 +12,10 @@ export function PageProgressBar() {
       aria-label="Loading"
       aria-busy="true"
       data-kb-part="page-progress-bar"
-      className="relative h-[2px] w-full overflow-hidden bg-[#f1f5f9]"
+      className="relative h-[2px] w-full overflow-hidden bg-surface-muted"
     >
       <div
-        className="absolute top-0 h-full w-[30%] bg-[#0f172a] animate-progress-slide"
+        className="absolute top-0 h-full w-[30%] bg-text-primary animate-progress-slide"
       />
     </div>
   );

--- a/apps/demo/src/components/RouteErrorBoundary.tsx
+++ b/apps/demo/src/components/RouteErrorBoundary.tsx
@@ -28,21 +28,21 @@ export function RouteErrorBoundary() {
       data-kb-part="route-error-boundary"
       className="flex h-full items-center justify-center py-16"
     >
-      <div className="flex max-w-[480px] flex-col items-center gap-4 rounded-[8px] border border-[#e2e8f0] bg-white p-8 text-center shadow-[0_8px_24px_rgba(15,23,42,0.06)]">
+      <div className="flex max-w-[480px] flex-col items-center gap-4 rounded-[8px] border border-card-border bg-white p-8 text-center shadow-[0_8px_24px_rgba(15,23,42,0.06)]">
         <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#fef2f2] text-[#dc2626]">
           <RiErrorWarningLine aria-hidden="true" className="h-5 w-5" />
         </div>
         <div className="flex flex-col gap-1">
-          <h2 className="text-[18px] font-semibold leading-7 text-[#0f172a]">
+          <h2 className="text-[18px] font-semibold leading-7 text-text-primary">
             Something went wrong
           </h2>
-          <p className="text-[14px] leading-5 text-[#475569]">
+          <p className="text-[14px] leading-5 text-text-meta">
             We hit an unexpected error rendering this page. Reload to try
             again — your in-memory data will reset to the seed.
           </p>
         </div>
         {message && (
-          <pre className="w-full overflow-auto rounded-[6px] bg-[#f8fafc] p-3 text-left text-[12px] leading-5 text-[#475569]">
+          <pre className="w-full overflow-auto rounded-[6px] bg-surface-subtle p-3 text-left text-[12px] leading-5 text-text-meta">
             {message}
           </pre>
         )}

--- a/apps/demo/src/components/ShortcutsCheatSheet.tsx
+++ b/apps/demo/src/components/ShortcutsCheatSheet.tsx
@@ -80,7 +80,7 @@ export function ShortcutsCheatSheet() {
       <Dialog.Portal>
         <Dialog.Overlay
           className={cn(
-            'fixed inset-0 z-[90] bg-[#0f172a]/40',
+            'fixed inset-0 z-[90] bg-text-primary/40',
             'animate-route-fade-in',
           )}
         />
@@ -88,7 +88,7 @@ export function ShortcutsCheatSheet() {
           className={cn(
             'fixed left-1/2 top-1/2 z-[91] -translate-x-1/2 -translate-y-1/2',
             'w-[480px] max-w-[calc(100vw-32px)] max-h-[calc(100vh-64px)] overflow-y-auto',
-            'rounded-[8px] border border-[#e2e8f0] bg-white',
+            'rounded-[8px] border border-card-border bg-white',
             'shadow-[0_24px_48px_rgba(15,23,42,0.20)]',
             'p-6 flex flex-col gap-5',
             'animate-toast-in',
@@ -97,10 +97,10 @@ export function ShortcutsCheatSheet() {
         >
           <header className="flex items-start justify-between gap-4">
             <div>
-              <Dialog.Title className="text-[16px] font-semibold leading-6 text-[#0f172a]">
+              <Dialog.Title className="text-[16px] font-semibold leading-6 text-text-primary">
                 Keyboard shortcuts
               </Dialog.Title>
-              <Dialog.Description className="mt-1 text-[13px] leading-5 text-[#64748b]">
+              <Dialog.Description className="mt-1 text-[13px] leading-5 text-text-muted">
                 Speed up common actions. Press{' '}
                 <Kbd>?</Kbd> any time to reopen this sheet.
               </Dialog.Description>
@@ -108,8 +108,8 @@ export function ShortcutsCheatSheet() {
             <Dialog.Close
               aria-label="Close shortcuts"
               className={cn(
-                'shrink-0 rounded-[4px] p-1 text-[#64748b]',
-                'hover:bg-[#f1f5f9] hover:text-[#0f172a]',
+                'shrink-0 rounded-[4px] p-1 text-text-muted',
+                'hover:bg-surface-muted hover:text-text-primary',
                 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20',
               )}
             >
@@ -125,7 +125,7 @@ export function ShortcutsCheatSheet() {
               >
                 <h3
                   id={`shortcut-group-${slug(group.title)}`}
-                  className="text-[11px] font-semibold uppercase tracking-wide text-[#64748b]"
+                  className="text-[11px] font-semibold uppercase tracking-wide text-text-muted"
                 >
                   {group.title}
                 </h3>
@@ -135,7 +135,7 @@ export function ShortcutsCheatSheet() {
                       key={`${group.title}-${i}`}
                       className="flex items-center justify-between"
                     >
-                      <span className="text-[14px] leading-5 text-[#0f172a]">
+                      <span className="text-[14px] leading-5 text-text-primary">
                         {s.label}
                       </span>
                       <span className="flex items-center gap-1">
@@ -164,8 +164,8 @@ function Kbd({ children }: { children: React.ReactNode }) {
     <kbd
       className={cn(
         'inline-flex h-6 min-w-[24px] items-center justify-center px-1.5',
-        'rounded-[4px] border border-[#cbd5e1] bg-[#f8fafc]',
-        'text-[12px] font-medium leading-none text-[#0f172a]',
+        'rounded-[4px] border border-border-faint bg-surface-subtle',
+        'text-[12px] font-medium leading-none text-text-primary',
         // Use system font for kbd so the on-platform mod symbols (⌘ ⏎)
         // render with their native glyph instead of the body font.
         'font-sans',

--- a/apps/demo/src/components/Toast.tsx
+++ b/apps/demo/src/components/Toast.tsx
@@ -178,12 +178,12 @@ function ToastUI({
   const variantClasses: Record<ToastVariant, string> = {
     success: 'border-l-[#16a34a]',
     error: 'border-l-[#dc2626]',
-    info: 'border-l-[#64748b]',
+    info: 'border-l-text-muted',
   };
   const iconColor: Record<ToastVariant, string> = {
     success: 'text-[#16a34a]',
     error: 'text-[#dc2626]',
-    info: 'text-[#64748b]',
+    info: 'text-text-muted',
   };
   const Icon =
     toast.variant === 'success'
@@ -199,7 +199,7 @@ function ToastUI({
       data-toast-variant={toast.variant}
       className={cn(
         'fixed top-4 right-4 z-[100] flex items-start gap-3',
-        'min-w-[280px] max-w-[420px] rounded-[8px] border border-[#e2e8f0] border-l-[3px] bg-white',
+        'min-w-[280px] max-w-[420px] rounded-[8px] border border-card-border border-l-[3px] bg-white',
         'px-4 py-3 shadow-[0_8px_24px_rgba(15,23,42,0.10)]',
         'animate-toast-in',
         variantClasses[toast.variant],
@@ -211,7 +211,7 @@ function ToastUI({
         aria-hidden="true"
         className={cn('mt-0.5 h-4 w-4 shrink-0', iconColor[toast.variant])}
       />
-      <p className="flex-1 text-[14px] leading-5 text-[#0f172a]">
+      <p className="flex-1 text-[14px] leading-5 text-text-primary">
         {toast.message}
       </p>
       <button
@@ -219,8 +219,8 @@ function ToastUI({
         onClick={onDismiss}
         aria-label="Dismiss notification"
         className={cn(
-          'shrink-0 rounded-[4px] p-0.5 text-[#64748b]',
-          'hover:bg-[#f1f5f9] hover:text-[#0f172a]',
+          'shrink-0 rounded-[4px] p-0.5 text-text-muted',
+          'hover:bg-surface-muted hover:text-text-primary',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20',
         )}
       >

--- a/apps/demo/src/routes/NotFoundPage.tsx
+++ b/apps/demo/src/routes/NotFoundPage.tsx
@@ -21,22 +21,22 @@ export default function NotFoundPage() {
           Hiver KB even when the URL was wrong. */}
       <div
         aria-hidden="true"
-        className="mb-8 flex h-10 w-10 items-center justify-center text-[#0f172a]"
+        className="mb-8 flex h-10 w-10 items-center justify-center text-text-primary"
       >
         <CompanyLogo size={28} />
       </div>
 
       <div className="flex max-w-[440px] flex-col items-center gap-3 text-center">
-        <p className="text-[12px] font-semibold uppercase tracking-[0.08em] text-[#64748b]">
+        <p className="text-[12px] font-semibold uppercase tracking-[0.08em] text-text-muted">
           Error 404
         </p>
         <h1
           tabIndex={-1}
-          className="text-[36px] font-semibold leading-[44px] text-[#0f172a]"
+          className="text-[36px] font-semibold leading-[44px] text-text-primary"
         >
           Page not found
         </h1>
-        <p className="text-[14px] leading-6 text-[#475569]">
+        <p className="text-[14px] leading-6 text-text-meta">
           The page you were looking for doesn't exist or has moved.
           Head back to the knowledge base to find what you need.
         </p>
@@ -56,9 +56,9 @@ export default function NotFoundPage() {
           <Link
             to={routes.aiOptimise.hub()}
             className={cn(
-              'inline-flex h-9 items-center rounded-[6px] border border-[#cbd5e1] bg-white px-4',
-              'text-[14px] font-medium leading-5 text-[#0f172a]',
-              'transition-colors hover:bg-[#f8fafc]',
+              'inline-flex h-9 items-center rounded-[6px] border border-border-faint bg-white px-4',
+              'text-[14px] font-medium leading-5 text-text-primary',
+              'transition-colors hover:bg-surface-subtle',
               'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20',
             )}
           >

--- a/apps/demo/src/routes/SettingsPlaceholder.tsx
+++ b/apps/demo/src/routes/SettingsPlaceholder.tsx
@@ -19,14 +19,14 @@ export default function SettingsPlaceholder() {
       <div className="flex max-w-[420px] flex-col items-center gap-3 text-center">
         <div
           aria-hidden="true"
-          className="flex h-10 w-10 items-center justify-center rounded-full bg-[#f1f5f9] text-[#475569]"
+          className="flex h-10 w-10 items-center justify-center rounded-full bg-surface-muted text-text-meta"
         >
           <RiSettings5Line className="h-5 w-5" />
         </div>
-        <h1 className="text-[24px] font-semibold leading-8 text-[#0f172a]">
+        <h1 className="text-[24px] font-semibold leading-8 text-text-primary">
           Settings — coming soon.
         </h1>
-        <p className="text-[14px] leading-5 text-[#64748b]">
+        <p className="text-[14px] leading-5 text-text-muted">
           This area is reserved for workspace configuration: members,
           permissions, branding, and billing.
         </p>

--- a/apps/demo/src/routes/ai-optimise/HubPage.tsx
+++ b/apps/demo/src/routes/ai-optimise/HubPage.tsx
@@ -57,10 +57,10 @@ export default function HubPage() {
     return (
       <div data-route="ai-optimise-hub" className="flex flex-col">
         <header data-kb-part="ai-hub-header" className="mb-6">
-          <h1 className="text-[24px] font-semibold leading-[32px] text-[#0f172a]">
+          <h1 className="text-[24px] font-semibold leading-[32px] text-text-primary">
             AI Optimise
           </h1>
-          <p className="mt-[4px] text-[14px] font-normal leading-5 text-[#475569]">
+          <p className="mt-[4px] text-[14px] font-normal leading-5 text-text-meta">
             AI-drafted improvements waiting on your review.
           </p>
         </header>
@@ -83,10 +83,10 @@ export default function HubPage() {
         `Patterns/KB AI Optimise Hub` in kb-ui.
       */}
       <header data-kb-part="ai-hub-header" className="mb-6">
-        <h1 className="text-[24px] font-semibold leading-[32px] text-[#0f172a]">
+        <h1 className="text-[24px] font-semibold leading-[32px] text-text-primary">
           AI Optimise
         </h1>
-        <p className="mt-[4px] text-[14px] font-normal leading-5 text-[#475569]">
+        <p className="mt-[4px] text-[14px] font-normal leading-5 text-text-meta">
           AI-drafted improvements waiting on your review.
         </p>
       </header>

--- a/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
+++ b/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
@@ -230,12 +230,12 @@ export default function ReviewPage() {
         data-route="ai-optimise-review"
         className="flex flex-col items-center justify-center py-24 text-center"
       >
-        <p className="text-[16px] font-medium leading-[24px] text-[#0f172a]">
+        <p className="text-[16px] font-medium leading-[24px] text-text-primary">
           Article not found.
         </p>
         <Link
           to={routes.aiOptimise.hub()}
-          className="mt-2 text-[14px] font-medium leading-[20px] text-[#0f172a] underline underline-offset-2 hover:text-[#1e293b]"
+          className="mt-2 text-[14px] font-medium leading-[20px] text-text-primary underline underline-offset-2 hover:text-[#1e293b]"
         >
           Back to AI Optimise
         </Link>

--- a/apps/demo/src/routes/ai-optimise/passwordResetRegions.tsx
+++ b/apps/demo/src/routes/ai-optimise/passwordResetRegions.tsx
@@ -32,7 +32,7 @@ import {
 
 function H1({ children }: { children: React.ReactNode }) {
   return (
-    <h1 className="mb-2 text-[24px] font-semibold leading-[32px] text-[#0f172a]">
+    <h1 className="mb-2 text-[24px] font-semibold leading-[32px] text-text-primary">
       {children}
     </h1>
   );
@@ -40,7 +40,7 @@ function H1({ children }: { children: React.ReactNode }) {
 
 function Subtitle({ children }: { children: React.ReactNode }) {
   return (
-    <p className="mb-6 text-[14px] font-normal leading-[20px] text-[#64748b]">
+    <p className="mb-6 text-[14px] font-normal leading-[20px] text-text-muted">
       {children}
     </p>
   );
@@ -48,7 +48,7 @@ function Subtitle({ children }: { children: React.ReactNode }) {
 
 function H2({ children }: { children: React.ReactNode }) {
   return (
-    <h2 className="mt-6 mb-3 text-[20px] font-semibold leading-[28px] text-[#0f172a]">
+    <h2 className="mt-6 mb-3 text-[20px] font-semibold leading-[28px] text-text-primary">
       {children}
     </h2>
   );
@@ -56,7 +56,7 @@ function H2({ children }: { children: React.ReactNode }) {
 
 function P({ children }: { children: React.ReactNode }) {
   return (
-    <p className="mb-4 text-[16px] font-normal leading-[24px] text-[#334155]">
+    <p className="mb-4 text-[16px] font-normal leading-[24px] text-text-secondary">
       {children}
     </p>
   );
@@ -64,7 +64,7 @@ function P({ children }: { children: React.ReactNode }) {
 
 function UL({ children }: { children: React.ReactNode }) {
   return (
-    <ul className="mb-4 list-disc pl-6 text-[16px] font-normal leading-[24px] text-[#334155] [&>li]:mb-2">
+    <ul className="mb-4 list-disc pl-6 text-[16px] font-normal leading-[24px] text-text-secondary [&>li]:mb-2">
       {children}
     </ul>
   );
@@ -72,7 +72,7 @@ function UL({ children }: { children: React.ReactNode }) {
 
 function Strong({ children }: { children: React.ReactNode }) {
   return (
-    <strong className="font-semibold text-[#0f172a]">{children}</strong>
+    <strong className="font-semibold text-text-primary">{children}</strong>
   );
 }
 
@@ -90,7 +90,7 @@ function NumberedItem({
   children: React.ReactNode;
 }) {
   return (
-    <span className="flex items-start text-[16px] leading-[24px] text-[#0f172a]">
+    <span className="flex items-start text-[16px] leading-[24px] text-text-primary">
       <span className="shrink-0 pr-2 tabular-nums">{index}.</span>
       <SuggestionHighlight>{children}</SuggestionHighlight>
     </span>
@@ -118,7 +118,7 @@ export const passwordResetRegions: ArticleBodyRegions = {
   s1: [
     <span
       key="h2"
-      className="block text-[20px] font-semibold leading-[28px] text-[#0f172a]"
+      className="block text-[20px] font-semibold leading-[28px] text-text-primary"
     >
       <SuggestionHighlight>
         Resetting Your Password via Mobile App
@@ -160,7 +160,7 @@ export const passwordResetRegions: ArticleBodyRegions = {
     before: [
       <span
         key="s2-before"
-        className="text-[16px] leading-[24px] text-[#0f172a]"
+        className="text-[16px] leading-[24px] text-text-primary"
       >
         <SuggestionHighlight>
           Navigate to the admin panel at{' '}
@@ -172,7 +172,7 @@ export const passwordResetRegions: ArticleBodyRegions = {
     after: [
       <span
         key="s2-after"
-        className="text-[16px] leading-[24px] text-[#0f172a]"
+        className="text-[16px] leading-[24px] text-text-primary"
       >
         <SuggestionHighlight>
           Navigate to the admin panel at{' '}
@@ -193,13 +193,13 @@ export const passwordResetRegions: ArticleBodyRegions = {
   s3: [
     <span
       key="s3-h2"
-      className="block text-[20px] font-semibold leading-[28px] text-[#0f172a]"
+      className="block text-[20px] font-semibold leading-[28px] text-text-primary"
     >
       <SuggestionHighlight>Troubleshooting</SuggestionHighlight>
     </span>,
     <span
       key="s3-h3"
-      className="block text-[16px] font-semibold leading-[24px] text-[#0f172a]"
+      className="block text-[16px] font-semibold leading-[24px] text-text-primary"
     >
       <SuggestionHighlight>
         Resetting via Chrome Extension

--- a/apps/demo/src/routes/analytics/AIAnswerPerformancePage.tsx
+++ b/apps/demo/src/routes/analytics/AIAnswerPerformancePage.tsx
@@ -63,7 +63,7 @@ const citedColumns: DataTableColumn<MostCitedRow>[] = [
       <span className="inline-flex items-center gap-2">
         <RiFile3Line
           size={16}
-          className="shrink-0 text-[#64748b]"
+          className="shrink-0 text-text-muted"
           aria-hidden="true"
         />
         <span>{r.title}</span>
@@ -126,10 +126,10 @@ export default function AIAnswerPerformancePage() {
       {/* Page header */}
       <header className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-[24px] font-semibold leading-[32px] text-[#0f172a]">
+          <h1 className="text-[24px] font-semibold leading-[32px] text-text-primary">
             AI Answer Performance
           </h1>
-          <p className="mt-1 text-[14px] font-normal leading-[20px] text-[#475569]">
+          <p className="mt-1 text-[14px] font-normal leading-[20px] text-text-meta">
             Is the AI search feature actually helping, or are people still
             needing human support?
           </p>
@@ -193,13 +193,13 @@ export default function AIAnswerPerformancePage() {
         emptyMessage="No cited articles"
         heading={
           <div className="flex items-center">
-            <h3 className="text-[14px] font-medium leading-[20px] text-[#0f172a]">
+            <h3 className="text-[14px] font-medium leading-[20px] text-text-primary">
               Most Cited KB Articles
             </h3>
             <span className="ml-2 inline-flex" aria-hidden>
               <RiInformationLine
                 size={16}
-                className="text-[#475569]"
+                className="text-text-meta"
                 aria-hidden="true"
               />
             </span>

--- a/apps/demo/src/routes/analytics/ArticlePerformancePage.tsx
+++ b/apps/demo/src/routes/analytics/ArticlePerformancePage.tsx
@@ -58,7 +58,7 @@ const attentionColumns: DataTableColumn<ArticleAttentionRow>[] = [
       <div className="flex items-center gap-2 min-w-0 pr-2">
         <RiFile3Line
           size={16}
-          className="shrink-0 text-[#64748b]"
+          className="shrink-0 text-text-muted"
           aria-hidden="true"
         />
         <span className="truncate">{r.title}</span>
@@ -82,7 +82,7 @@ const performanceColumns: DataTableColumn<ArticlePerformanceRow>[] = [
       <div className="flex items-center gap-2 min-w-0 pr-2">
         <RiFile3Line
           size={16}
-          className="shrink-0 text-[#64748b]"
+          className="shrink-0 text-text-muted"
           aria-hidden="true"
         />
         <span className="truncate">{r.title}</span>
@@ -96,7 +96,7 @@ const performanceColumns: DataTableColumn<ArticlePerformanceRow>[] = [
     headerClassName: 'pl-6',
     className: 'pl-6',
     render: (r) => (
-      <span className="inline-flex items-center px-2.5 py-1 rounded-full bg-[#f7f7f7] text-[13px] font-normal leading-[19px] text-[#0f172a]">
+      <span className="inline-flex items-center px-2.5 py-1 rounded-full bg-[#f7f7f7] text-[13px] font-normal leading-[19px] text-text-primary">
         {r.category}
       </span>
     ),
@@ -165,10 +165,10 @@ export default function ArticlePerformancePage() {
       {/* Page header — title + subtitle | DateRangePill */}
       <header className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-[24px] font-semibold leading-[32px] text-[#0f172a]">
+          <h1 className="text-[24px] font-semibold leading-[32px] text-text-primary">
             Article performance
           </h1>
-          <p className="mt-1 text-[14px] font-normal leading-[20px] text-[#475569]">
+          <p className="mt-1 text-[14px] font-normal leading-[20px] text-text-meta">
             How readers find and engage with your content.
           </p>
         </div>
@@ -216,26 +216,26 @@ export default function ArticlePerformancePage() {
             heading={
               <div>
                 <div className="flex items-center">
-                  <h3 className="text-[14px] font-medium leading-[20px] text-[#0f172a]">
+                  <h3 className="text-[14px] font-medium leading-[20px] text-text-primary">
                     Articles needs attention
                   </h3>
                   <RiInformationLine
                     size={16}
-                    className="ml-2 text-[#475569]"
+                    className="ml-2 text-text-meta"
                     aria-hidden="true"
                   />
                   <span className="flex-1" />
                   <span
-                    className="inline-flex items-center px-2 py-0.5 rounded-full bg-[#f7f7f7] text-[12px] font-medium leading-[18px] text-[#0f172a]"
+                    className="inline-flex items-center px-2 py-0.5 rounded-full bg-[#f7f7f7] text-[12px] font-medium leading-[18px] text-text-primary"
                     aria-label={`${needsAttentionRows.length} Articles`}
                   >
                     {`${needsAttentionRows.length} Articles`}
                   </span>
                 </div>
-                <p className="mt-1 text-[13px] font-normal leading-[19px] text-[#475569]">
+                <p className="mt-1 text-[13px] font-normal leading-[19px] text-text-meta">
                   Articles with very low helpfulness index
                 </p>
-                <div className="mt-4 h-px bg-[#e2e8f0]" />
+                <div className="mt-4 h-px bg-card-border" />
               </div>
             }
             headerDivider={false}
@@ -254,16 +254,16 @@ export default function ArticlePerformancePage() {
         heading={
           <div>
             <div className="flex items-center">
-              <h3 className="text-[14px] font-medium leading-[20px] text-[#0f172a]">
+              <h3 className="text-[14px] font-medium leading-[20px] text-text-primary">
                 Article Performance
               </h3>
               <RiInformationLine
                 size={16}
-                className="ml-2 text-[#475569]"
+                className="ml-2 text-text-meta"
                 aria-hidden="true"
               />
             </div>
-            <div className="mt-4 h-px bg-[#e2e8f0]" />
+            <div className="mt-4 h-px bg-card-border" />
           </div>
         }
         headerDivider={false}

--- a/apps/demo/src/routes/analytics/SearchPage.tsx
+++ b/apps/demo/src/routes/analytics/SearchPage.tsx
@@ -58,15 +58,15 @@ function WriteArticleButton({ onClick }: { onClick?: () => void }) {
       type="button"
       onClick={onClick}
       className={cn(
-        'inline-flex items-center gap-1.5 rounded-[6px] bg-[#f1f5f9] px-2 py-1',
-        'text-[14px] font-medium leading-[20px] text-[#0f172a]',
-        'transition-colors hover:bg-[#e2e8f0]',
+        'inline-flex items-center gap-1.5 rounded-[6px] bg-surface-muted px-2 py-1',
+        'text-[14px] font-medium leading-[20px] text-text-primary',
+        'transition-colors hover:bg-card-border',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
       )}
     >
       <RiQuillPenLine
         size={14}
-        className="text-[#475569]"
+        className="text-text-meta"
         aria-hidden="true"
       />
       Write Article
@@ -113,10 +113,10 @@ export default function SearchPage() {
       {/* Page header */}
       <header className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-[24px] font-semibold leading-[32px] text-[#0f172a]">
+          <h1 className="text-[24px] font-semibold leading-[32px] text-text-primary">
             Search
           </h1>
-          <p className="mt-1 text-[14px] font-normal leading-[20px] text-[#475569]">
+          <p className="mt-1 text-[14px] font-normal leading-[20px] text-text-meta">
             See what your readers are searching for and where the gaps are.
           </p>
         </div>
@@ -167,13 +167,13 @@ export default function SearchPage() {
         emptyMessage="No keywords"
         heading={
           <div className="flex items-center">
-            <h3 className="text-[14px] font-medium leading-[20px] text-[#0f172a]">
+            <h3 className="text-[14px] font-medium leading-[20px] text-text-primary">
               Top 5 Search Keywords
             </h3>
             <span className="ml-2 inline-flex" aria-hidden>
               <RiInformationLine
                 size={16}
-                className="text-[#475569]"
+                className="text-text-meta"
                 aria-hidden="true"
               />
             </span>
@@ -190,18 +190,18 @@ export default function SearchPage() {
         heading={
           <div>
             <div className="flex items-center">
-              <h3 className="text-[14px] font-medium leading-[20px] text-[#0f172a]">
+              <h3 className="text-[14px] font-medium leading-[20px] text-text-primary">
                 Content Gaps
               </h3>
               <span className="ml-2 inline-flex" aria-hidden>
                 <RiInformationLine
                   size={16}
-                  className="text-[#475569]"
+                  className="text-text-meta"
                   aria-hidden="true"
                 />
               </span>
             </div>
-            <p className="mt-1 text-[13px] font-normal leading-[19px] text-[#475569]">
+            <p className="mt-1 text-[13px] font-normal leading-[19px] text-text-meta">
               Topics users searched for but didn&apos;t find. Write articles
               to close these gaps
             </p>

--- a/apps/demo/src/routes/kb/CategoryPage.tsx
+++ b/apps/demo/src/routes/kb/CategoryPage.tsx
@@ -75,7 +75,7 @@ const subCategoryColumns: DataTableColumn<SubCategoryRow>[] = [
   {
     id: 'title',
     header: 'Sub-categories',
-    headerClassName: 'pl-4 pr-0 py-0 text-[#475569]',
+    headerClassName: 'pl-4 pr-0 py-0 text-text-meta',
     className: 'pl-4 pr-0',
     render: (item) => (
       <div className="flex items-center gap-1">
@@ -84,13 +84,13 @@ const subCategoryColumns: DataTableColumn<SubCategoryRow>[] = [
           aria-label={`Open ${item.title}`}
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-[#64748b]',
-            'hover:bg-[#f8fafc] focus:bg-[#f8fafc] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]',
+            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-text-muted',
+            'hover:bg-surface-subtle focus:bg-surface-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-border-faint',
           )}
         >
           <RiFolderLine size={16} aria-hidden="true" />
         </button>
-        <span className="text-[14px] font-normal leading-[20px] text-[#0f172a]">
+        <span className="text-[14px] font-normal leading-[20px] text-text-primary">
           {item.title}
         </span>
       </div>
@@ -107,7 +107,7 @@ const subCategoryColumns: DataTableColumn<SubCategoryRow>[] = [
       <div className="flex items-center justify-end">
         <RiArrowRightSLine
           size={16}
-          className="text-[#64748b]"
+          className="text-text-muted"
           aria-hidden="true"
         />
       </div>
@@ -119,7 +119,7 @@ const articleColumns: DataTableColumn<ArticleRow>[] = [
   {
     id: 'title',
     header: 'Articles',
-    headerClassName: 'pl-4 pr-0 py-0 text-[#475569]',
+    headerClassName: 'pl-4 pr-0 py-0 text-text-meta',
     className: 'px-4',
     render: (a) => (
       <div className="flex items-center gap-1 min-w-0">
@@ -128,13 +128,13 @@ const articleColumns: DataTableColumn<ArticleRow>[] = [
           aria-label={`Open ${a.title}`}
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-[#64748b]',
-            'hover:bg-[#f8fafc] focus:bg-[#f8fafc] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]',
+            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-text-muted',
+            'hover:bg-surface-subtle focus:bg-surface-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-border-faint',
           )}
         >
           <RiFile3Line size={16} aria-hidden="true" />
         </button>
-        <span className="text-[14px] font-normal leading-[20px] text-[#0f172a] truncate">
+        <span className="text-[14px] font-normal leading-[20px] text-text-primary truncate">
           {a.title}
         </span>
       </div>
@@ -154,8 +154,8 @@ const articleColumns: DataTableColumn<ArticleRow>[] = [
           aria-label={`More actions for ${a.title}`}
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-[#94a3b8]',
-            'hover:bg-[#f8fafc] focus:bg-[#f8fafc] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cbd5e1]',
+            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-text-disabled',
+            'hover:bg-surface-subtle focus:bg-surface-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-border-faint',
           )}
         >
           <RiMore2Line size={16} aria-hidden="true" />
@@ -167,7 +167,7 @@ const articleColumns: DataTableColumn<ArticleRow>[] = [
     id: 'status',
     header: 'Status',
     width: 127,
-    headerClassName: 'px-4 py-0 text-[#475569]',
+    headerClassName: 'px-4 py-0 text-text-meta',
     className: 'px-4',
     render: (a) => (
       <Badge variant={a.status}>
@@ -180,7 +180,7 @@ const articleColumns: DataTableColumn<ArticleRow>[] = [
     header: 'Author',
     align: 'center',
     width: 94,
-    headerClassName: 'px-4 py-0 text-[#475569]',
+    headerClassName: 'px-4 py-0 text-text-meta',
     className: 'px-4',
     render: (a) => (
       <div className="flex items-center justify-center">
@@ -192,9 +192,9 @@ const articleColumns: DataTableColumn<ArticleRow>[] = [
     id: 'updated',
     header: 'Last Updated',
     width: 251,
-    headerClassName: 'px-4 py-0 text-[#475569]',
+    headerClassName: 'px-4 py-0 text-text-meta',
     className: 'px-4',
-    render: (a) => <span className="text-[#64748b]">{a.lastUpdated}</span>,
+    render: (a) => <span className="text-text-muted">{a.lastUpdated}</span>,
   },
 ];
 
@@ -284,19 +284,19 @@ function CategoryNotFound({
       data-route="kb-category-not-found"
       className="flex flex-col items-start gap-3 py-8"
     >
-      <h1 className="text-[18px] font-semibold leading-[28px] text-[#0f172a]">
+      <h1 className="text-[18px] font-semibold leading-[28px] text-text-primary">
         Category not found
       </h1>
-      <p className="text-[14px] leading-[20px] text-[#475569]">
+      <p className="text-[14px] leading-[20px] text-text-meta">
         No category matches{' '}
-        <code className="rounded bg-[#f1f5f9] px-1 py-0.5 text-[13px] text-[#0f172a]">
+        <code className="rounded bg-surface-muted px-1 py-0.5 text-[13px] text-text-primary">
           {attemptedSlug ?? '(none)'}
         </code>
         .
       </p>
       <Link
         to={routes.kb.category(DEFAULT_KB_CATEGORY_SLUG)}
-        className="text-[14px] font-medium text-[#0f172a] underline underline-offset-2 hover:no-underline"
+        className="text-[14px] font-medium text-text-primary underline underline-offset-2 hover:no-underline"
       >
         Back to Getting Started
       </Link>

--- a/apps/demo/src/routes/kb/EditorPage.tsx
+++ b/apps/demo/src/routes/kb/EditorPage.tsx
@@ -204,19 +204,19 @@ function ArticleNotFound({ slug }: { slug: string | undefined }) {
       data-route="kb-editor-not-found"
       className="flex flex-col items-start gap-3 py-8"
     >
-      <h1 className="text-[18px] font-semibold leading-[28px] text-[#0f172a]">
+      <h1 className="text-[18px] font-semibold leading-[28px] text-text-primary">
         Article not found
       </h1>
-      <p className="text-[14px] leading-[20px] text-[#475569]">
+      <p className="text-[14px] leading-[20px] text-text-meta">
         No article with slug{' '}
-        <code className="rounded bg-[#f1f5f9] px-1 py-0.5 text-[13px] text-[#0f172a]">
+        <code className="rounded bg-surface-muted px-1 py-0.5 text-[13px] text-text-primary">
           {slug ?? '(none)'}
         </code>
         .
       </p>
       <Link
         to={routes.home()}
-        className="text-[14px] font-medium text-[#0f172a] underline underline-offset-2 hover:no-underline"
+        className="text-[14px] font-medium text-text-primary underline underline-offset-2 hover:no-underline"
       >
         Back to home
       </Link>

--- a/apps/demo/src/shell/AISubNav.tsx
+++ b/apps/demo/src/shell/AISubNav.tsx
@@ -64,16 +64,16 @@ function Row({ item, isActive, onClick }: RowProps) {
         'flex h-[44px] w-full items-center gap-[8px]',
         'mx-[16px] rounded-[8px] px-[8px]',
         'transition-colors duration-150',
-        'text-left text-[14px] font-medium leading-5 text-[#0f172a]',
+        'text-left text-[14px] font-medium leading-5 text-text-primary',
         // Section rows aren't really click targets — sections are containers, not nav.
         // Keep them focusable for a11y but show a default cursor and skip hover bg.
         item.kind === 'section'
           ? 'cursor-default'
           : 'cursor-pointer',
         showActivePill
-          ? 'bg-[#f1f5f9]'
+          ? 'bg-surface-muted'
           : item.kind === 'item'
-            ? 'bg-transparent hover:bg-[#f8fafc]'
+            ? 'bg-transparent hover:bg-surface-subtle'
             : 'bg-transparent',
       )}
       // mx-16 + w-full would double-count; subtract manually so the row is


### PR DESCRIPTION
## Summary
- Sweep ~133 inline hex usages across `apps/demo/src/` (18 files) to kb-ui token classes (`text-text-primary`, `bg-surface-muted`, `border-card-border`, etc.)
- Demo now reflects post-Phase-15 visual state — card border resolves through `--color-card-border` (#e2e8f0) instead of the legacy #e5e5e5 inline hex
- Intentional residuals: Tailwind-palette one-offs (`#dc2626`, `#15803d`, `#16a34a`, `#fef2f2`, `#fef3c7`, `#92400e`, `#1e293b`), demo-local near-whites (`#f7f7f7`, `#fafafa`, `#f5f5f5` DataTable prop value), user avatar palette in `users.ts`, hex inside JSDoc/comments and `counterTone()` inline-style constants

## Test plan
- [x] `npm run --workspace=apps/demo build` — vite build green (Tailwind v4 resolved every token class)
- [x] `npm run --workspace=packages/kb-ui typecheck` — green
- [x] `npm run --workspace=packages/kb-ui build-storybook` — green