### PR TITLE
feat(kb-ui): mount agentation overlay in local Storybook variant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8138,6 +8138,7 @@
         "@tailwindcss/vite": "^4.2.2",
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
+        "agentation": "^3.0.2",
         "autoprefixer": "^10.4.0",
         "chromatic": "^16.6.1",
         "playwright": "^1.59.1",

--- a/packages/kb-ui/.storybook/preview.tsx
+++ b/packages/kb-ui/.storybook/preview.tsx
@@ -1,5 +1,10 @@
 import type { Preview } from '@storybook/react-vite';
+import { Agentation } from 'agentation';
 import '../src/tokens.css';
+
+// Mount Agentation only in the local dev variant; Chromatic sets STORYBOOK_PUBLIC=1.
+// Vite builder exposes STORYBOOK_-prefixed env vars via import.meta.env.
+const isPublicBuild = import.meta.env.STORYBOOK_PUBLIC === '1';
 
 const preview: Preview = {
   parameters: {
@@ -44,7 +49,18 @@ const preview: Preview = {
     backgrounds: {
       value: 'canvas'
     }
-  }
+  },
+
+  decorators: isPublicBuild
+    ? []
+    : [
+        (Story) => (
+          <>
+            <Story />
+            <Agentation />
+          </>
+        ),
+      ],
 };
 
 export default preview;

--- a/packages/kb-ui/.storybook/preview.tsx
+++ b/packages/kb-ui/.storybook/preview.tsx
@@ -2,7 +2,10 @@ import type { Preview } from '@storybook/react-vite';
 import { Agentation } from 'agentation';
 import '../src/tokens.css';
 
-// Mount Agentation only in the local dev variant; Chromatic sets STORYBOOK_PUBLIC=1.
+// Mount Agentation only on Review/* stories in the local dev variant.
+// The isPublicBuild gate is defense-in-depth: Chromatic sets STORYBOOK_PUBLIC=1
+// and filters out *.review.stories.tsx, but we still want to ensure the overlay
+// never ships in the public build even if a Review story leaks in.
 // Vite builder exposes STORYBOOK_-prefixed env vars via import.meta.env.
 const isPublicBuild = import.meta.env.STORYBOOK_PUBLIC === '1';
 
@@ -51,16 +54,18 @@ const preview: Preview = {
     }
   },
 
-  decorators: isPublicBuild
-    ? []
-    : [
-        (Story) => (
-          <>
-            <Story />
-            <Agentation />
-          </>
-        ),
-      ],
+  decorators: [
+    (Story, context) => {
+      const showAgentation =
+        !isPublicBuild && context.title.startsWith('Review/');
+      return (
+        <>
+          <Story />
+          {showAgentation ? <Agentation /> : null}
+        </>
+      );
+    },
+  ],
 };
 
 export default preview;

--- a/packages/kb-ui/package.json
+++ b/packages/kb-ui/package.json
@@ -66,6 +66,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
+    "agentation": "^3.0.2",
     "autoprefixer": "^10.4.0",
     "chromatic": "^16.6.1",
     "playwright": "^1.59.1",


### PR DESCRIPTION
## Summary
- Mount `<Agentation />` as a per-story decorator in `packages/kb-ui/.storybook/preview.tsx`, scoped to stories whose title starts with `Review/` (the Figma-side-by-side review variant).
- Defense-in-depth gate on `import.meta.env.STORYBOOK_PUBLIC !== '1'` so it never ships in the Chromatic public build.
- Adds `agentation@^3.0.2` as a kb-ui devDependency.

## Test plan
- [x] typecheck + build
- [x] `STORYBOOK_PUBLIC=1 build-storybook` — overlay tree-shaken from runtime chunks
- [x] Default `build-storybook` — overlay bundled
- [x] Local boot — Review/* story shows overlay; non-Review story does not