### PR TITLE
chore(kb-ui): enable grayscale font smoothing on html

### DIFF
--- a/packages/kb-ui/src/tokens.css
+++ b/packages/kb-ui/src/tokens.css
@@ -1,5 +1,10 @@
 @import "tailwindcss";
 
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 /* Hiver KB Design Tokens
    Extracted from Figma file 251DTRmxl2L6jmXd3FWzHe
    Pages: KB revamp (1952:10869), KB gaps (1958:32263), Analytics (1952:10867)


### PR DESCRIPTION
Tailwind v4 dropped the v3 preflight default for font smoothing. macOS now renders Inter with subpixel AA, making weights look ~0.5-1 step heavier than Figma. Setting on `html` cascades through both `apps/demo` and Storybook (both import `@test-kb-ui/kb-ui/styles`).

## Verify
- `npm run --workspace=packages/kb-ui build` — passes
- `npm run --workspace=packages/kb-ui build-storybook` — passes
- `npm run --workspace=apps/demo build` — passes

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>