### PR TITLE
feat(kb-ui): Textarea + NewCategoryModal + Modal extensions + FileExplorerNav.renderRowAction

### DIFF
--- a/packages/kb-ui/src/components/nav/FileExplorerNav.stories.tsx
+++ b/packages/kb-ui/src/components/nav/FileExplorerNav.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import * as React from 'react';
+import { DotsVertical } from '@untitledui/icons';
 import '../../tokens.css';
 import { FileExplorerNav, type NavItem } from './FileExplorerNav';
 
@@ -127,4 +128,50 @@ export default meta;
 
 export const Playground: StoryObj<typeof FileExplorerNav> = {
   render: () => <FileExplorerNavPlayground />,
+};
+
+/* ─────────────────────────────────────────────────────────────
+ * WithRowActions — demonstrates the `renderRowAction` prop:
+ * a per-row 3-dot button that reveals on hover, replacing the
+ * count badge (folders) / status dot (articles). Click stops
+ * propagation so it does not trigger row navigation.
+ * ───────────────────────────────────────────────────────────── */
+function FileExplorerNavWithRowActions() {
+  const [activeId, setActiveId] = React.useState<string>('tut-organize');
+  const activeTitle = findTitle(tree, activeId) ?? activeId;
+
+  return (
+    <div className="flex h-screen">
+      <FileExplorerNav
+        title="Editor"
+        items={tree}
+        activeId={activeId}
+        onItemClick={(id) => setActiveId(id)}
+        variant="tree"
+        renderRowAction={(item) => (
+          <button
+            type="button"
+            aria-label="Open menu"
+            className="flex h-7 w-7 items-center justify-center rounded-[4px] hover:bg-[#f1f5f9] text-text-meta"
+            onClick={(e) => {
+              e.stopPropagation();
+              // eslint-disable-next-line no-console
+              console.log('row menu', item.id);
+            }}
+          >
+            <DotsVertical className="h-4 w-4" />
+          </button>
+        )}
+      />
+      <div className="flex-1 bg-[#f5f5f5] flex items-center justify-center">
+        <span className="text-[14px] text-[#64748b]">
+          Editing: {activeTitle}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export const WithRowActions: StoryObj<typeof FileExplorerNav> = {
+  render: () => <FileExplorerNavWithRowActions />,
 };

--- a/packages/kb-ui/src/components/nav/FileExplorerNav.tsx
+++ b/packages/kb-ui/src/components/nav/FileExplorerNav.tsx
@@ -46,6 +46,20 @@ export type FileExplorerNavProps = {
   activeId?: string;
   onItemClick?: (id: string) => void;
   /**
+   * Optional render-prop returning a trailing action element per row. Renders
+   * to the right of the row, opacity-0 by default → opacity-100 on row hover,
+   * REPLACING the count badge (folders) or status dot (articles) on hover.
+   * Use to surface contextual menus / extra actions per row.
+   *
+   * The action is rendered inside a wrapper that stops click propagation, so
+   * clicks on the action do NOT trigger the row's `onItemClick`. Keyboard
+   * focus inside the wrapper also reveals the action (via `focus-within`).
+   *
+   * When undefined, no change to existing behavior — kb-ui's built-in
+   * hover-kebab continues to swap in over the count/status on hover.
+   */
+  renderRowAction?: (item: NavItem) => React.ReactNode;
+  /**
    * Tree variant (default): renders chevron, folder/file icon, count/kebab —
    * the canonical Editor explorer.
    *
@@ -100,8 +114,8 @@ const HOVER_BG_CLASS = 'hover:bg-[rgba(230,230,230,0.32)]';
 /* ---------------------------- flat row -------------------------------- */
 //
 // Flat mode (Analytics): full-width inset row, 36 tall, 12px horizontal pad,
-// no chevron / no file icon / no count / no kebab. Active pill is #f8fafc
-// (Figma `background/neutral/faint`) — matches `1974:53328`.
+// no chevron / no file icon / no count / no kebab. Active + hover bg match
+// the tree variant (`stateBg`) for cross-surface consistency.
 
 type FlatRowProps = {
   item: NavItem;
@@ -135,8 +149,8 @@ function FlatRow({ item, isActive, onClick }: FlatRowProps) {
           isSection
             ? 'cursor-default font-medium'
             : isActive
-              ? 'bg-surface-subtle font-medium'
-              : 'font-normal hover:bg-surface-subtle',
+              ? cn(stateBg('active'), 'font-medium')
+              : cn('font-normal', HOVER_BG_CLASS),
         )}
       >
         {item.icon && (
@@ -186,6 +200,8 @@ type FolderRowProps = {
   isActiveSub: boolean;
   isExpanded: boolean;
   onToggle: () => void;
+  /** Consumer-supplied trailing action — REPLACES the built-in kebab on hover. */
+  rowAction?: React.ReactNode;
 };
 
 function FolderRow({
@@ -195,6 +211,7 @@ function FolderRow({
   isActiveSub,
   isExpanded,
   onToggle,
+  rowAction,
 }: FolderRowProps) {
   const state: RowState = isActive ? 'active' : isActiveSub ? 'active-sub' : 'default';
   const ChevronIcon = isExpanded ? ChevronDown : ChevronRight;
@@ -240,15 +257,29 @@ function FolderRow({
             <span
               className={cn(
                 'text-[14px] font-normal text-text-meta',
-                showHoverSwap && 'group-hover:hidden',
+                // Count badge hides on hover when there's a swappable action
+                // (either the built-in kebab or a consumer-supplied action).
+                // It also hides when keyboard focus is inside the action
+                // wrapper, so the action stays revealed for a11y.
+                showHoverSwap && 'group-hover:hidden group-focus-within:hidden',
               )}
             >
               {item.count ?? ''}
             </span>
             {showHoverSwap && (
-              <span className="hidden group-hover:flex items-center justify-center text-text-meta">
-                <DotsVertical size={16} />
-              </span>
+              rowAction !== undefined ? (
+                /* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
+                <span
+                  className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {rowAction}
+                </span>
+              ) : (
+                <span className="hidden group-hover:flex group-focus-within:flex items-center justify-center text-text-meta">
+                  <DotsVertical size={16} />
+                </span>
+              )
             )}
           </span>
         </div>
@@ -262,9 +293,11 @@ type ArticleRowProps = {
   depth: number;
   isActive: boolean;
   onClick: () => void;
+  /** Consumer-supplied trailing action — REPLACES the built-in kebab on hover. */
+  rowAction?: React.ReactNode;
 };
 
-function ArticleRow({ item, depth, isActive, onClick }: ArticleRowProps) {
+function ArticleRow({ item, depth, isActive, onClick, rowAction }: ArticleRowProps) {
   const state: RowState = isActive ? 'active' : 'default';
 
   // Spec colors: published = #42cd83, draft = #898989. 4×4 size.
@@ -315,14 +348,26 @@ function ArticleRow({ item, depth, isActive, onClick }: ArticleRowProps) {
                 className={cn(
                   'size-[4px] rounded-full',
                   statusDotColor,
-                  showHoverSwap && 'group-hover:hidden',
+                  // Status dot hides on hover when a swappable action is present.
+                  // Also hides while keyboard focus is inside the action wrapper.
+                  showHoverSwap && 'group-hover:hidden group-focus-within:hidden',
                 )}
               />
             )}
             {showHoverSwap && (
-              <span className="hidden group-hover:flex items-center justify-center text-text-meta">
-                <DotsVertical size={16} />
-              </span>
+              rowAction !== undefined ? (
+                /* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
+                <span
+                  className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {rowAction}
+                </span>
+              ) : (
+                <span className="hidden group-hover:flex group-focus-within:flex items-center justify-center text-text-meta">
+                  <DotsVertical size={16} />
+                </span>
+              )
             )}
           </span>
         </div>
@@ -339,6 +384,7 @@ export function FileExplorerNav({
   items,
   activeId,
   onItemClick,
+  renderRowAction,
   variant = 'tree',
   showSearch,
   className,
@@ -426,6 +472,7 @@ export function FileExplorerNav({
                 isActiveSub={isActiveSub && !isActive}
                 isExpanded={isExpanded}
                 onToggle={() => toggleFolder(item.id)}
+                rowAction={renderRowAction?.(item)}
               />
             )}
             {isExpanded && item.children && item.children.length > 0 && (
@@ -444,6 +491,7 @@ export function FileExplorerNav({
           depth={depth}
           isActive={item.id === activeId}
           onClick={() => onItemClick?.(item.id)}
+          rowAction={renderRowAction?.(item)}
         />
       );
     });
@@ -481,15 +529,17 @@ export function FileExplorerNav({
             {title}
           </span>
         </div>
-        {renderSearch && (
-          <button
-            type="button"
-            aria-label="Search"
-            className="flex size-6 items-center justify-center rounded-[6px] cursor-pointer transition-colors duration-150 text-text-muted hover:bg-surface-subtle hover:text-text-primary"
-          >
-            <SearchLg size={16} />
-          </button>
-        )}
+        <div className="flex items-center gap-2">
+          {renderSearch && (
+            <button
+              type="button"
+              aria-label="Search"
+              className="flex size-6 items-center justify-center rounded-[6px] cursor-pointer transition-colors duration-150 text-text-muted hover:bg-surface-subtle hover:text-text-primary"
+            >
+              <SearchLg size={16} />
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Inset 1px divider at Y=54 — 16L / 16R inset (effective width 256) */}

--- a/packages/kb-ui/src/components/overlays/Modal.tsx
+++ b/packages/kb-ui/src/components/overlays/Modal.tsx
@@ -13,6 +13,9 @@ import { cn } from '../../utils/cn';
  *
  * Mirrors SideSheet's `inline` mode so a Modal can also be hosted
  * inside a review pane without escaping to document.body.
+ *
+ * Optional radius / bodyPadding / footerLayout props let consumers
+ * match modals with chunkier chrome — see NewCategoryModal.
  * ───────────────────────────────────────────────────────────── */
 
 export type ModalProps = {
@@ -50,6 +53,17 @@ export type ModalProps = {
    * to close.
    */
   inline?: boolean;
+  /** Outer corner radius in px. Defaults to 8 (existing Convert-to-External-KB modal). */
+  radius?: number;
+  /** Body padding in px (uniform). Defaults to 16. */
+  bodyPadding?: number;
+  /**
+   * When `'inside'` (default), footer renders inside the body
+   * container with `pt-2` (existing behavior).
+   * When `'section'`, footer renders as a separate section below
+   * the body with its own padding (`pb-5 pt-4 px-5`, white bg).
+   */
+  footerLayout?: 'inside' | 'section';
 };
 
 /* ─────────────────────────────────────────────────────────────
@@ -69,15 +83,23 @@ export type ModalProps = {
  * actions row.
  * ───────────────────────────────────────────────────────────── */
 
-const headerClass =
-  'flex shrink-0 items-center justify-between gap-2 rounded-t-[8px] border-b border-card-border bg-surface-subtle px-4 py-3';
+const headerBaseClass =
+  'flex shrink-0 items-center justify-between gap-2 border-b border-card-border bg-surface-subtle px-4 py-3';
 const headerLeftClass = 'flex items-center gap-2 min-w-0';
 const headerIconClass =
   'flex h-4 w-4 shrink-0 items-center justify-center text-text-primary [&_svg]:h-4 [&_svg]:w-4';
 const titleClass =
   'text-[16px] font-medium leading-6 text-text-primary truncate';
-const bodyClass = 'flex flex-col gap-4 p-4';
-const footerClass = 'flex items-end justify-end gap-2 pt-2';
+const bodyBaseClass = 'flex flex-col gap-4';
+/* Footer (inside mode): renders inside the body container with a
+ * pt-2 (8px) gap on top of the body's `gap-4` → 24px total above
+ * the actions row, matching Figma `_Modal-Actions`. */
+const footerInsideClass = 'flex items-end justify-end gap-2 pt-2';
+/* Footer (section mode): renders as a separate, white-bg section
+ * BELOW the body container. Padding `pb-5 pt-4 px-5` per Figma
+ * 1958:34896 (New Category). */
+const footerSectionClass =
+  'flex items-end justify-end gap-2 bg-white pb-5 pt-4 px-5';
 
 /* ─────────────────────────────────────────────────────────────
  * Internal — renders the visual chrome (header + body + footer).
@@ -93,6 +115,12 @@ type ChromeProps = Pick<
 > & {
   /** When true, wrap the title in `Dialog.Title` (portal mode). */
   asDialogTitle: boolean;
+  /** Outer corner radius — header consumes the top radius. */
+  radius: number;
+  /** Body padding (uniform). */
+  bodyPadding: number;
+  /** Where the footer renders relative to the body container. */
+  footerLayout: 'inside' | 'section';
 };
 
 function ModalChrome({
@@ -102,6 +130,9 @@ function ModalChrome({
   children,
   footer,
   asDialogTitle,
+  radius,
+  bodyPadding,
+  footerLayout,
 }: ChromeProps) {
   const titleNode =
     title !== undefined ? (
@@ -121,7 +152,11 @@ function ModalChrome({
 
   return (
     <>
-      <div data-kb-part="modal-header" className={headerClass}>
+      <div
+        data-kb-part="modal-header"
+        className={headerBaseClass}
+        style={{ borderTopLeftRadius: radius, borderTopRightRadius: radius }}
+      >
         <div className={headerLeftClass}>
           {titleIcon !== undefined ? (
             <span
@@ -142,14 +177,24 @@ function ModalChrome({
         ) : null}
       </div>
 
-      <div data-kb-part="modal-body" className={bodyClass}>
+      <div
+        data-kb-part="modal-body"
+        className={bodyBaseClass}
+        style={{ padding: bodyPadding }}
+      >
         {children}
-        {footer !== undefined ? (
-          <div data-kb-part="modal-footer" className={footerClass}>
+        {footer !== undefined && footerLayout === 'inside' ? (
+          <div data-kb-part="modal-footer" className={footerInsideClass}>
             {footer}
           </div>
         ) : null}
       </div>
+
+      {footer !== undefined && footerLayout === 'section' ? (
+        <div data-kb-part="modal-footer" className={footerSectionClass}>
+          {footer}
+        </div>
+      ) : null}
     </>
   );
 }
@@ -169,6 +214,9 @@ export function Modal({
   width = 384,
   className,
   inline = false,
+  radius = 8,
+  bodyPadding = 16,
+  footerLayout = 'inside',
 }: ModalProps) {
   /* Inline mode — render chrome directly (no Radix Dialog/Portal/
    * Overlay). Mirrors SideSheet's inline mode for use inside review
@@ -178,9 +226,9 @@ export function Modal({
       <div
         data-kb-component="modal"
         data-kb-mode="inline"
-        style={{ width: `${width}px` }}
+        style={{ width: `${width}px`, borderRadius: radius }}
         className={cn(
-          'flex flex-col bg-white rounded-[8px] border border-card-border',
+          'flex flex-col bg-white border border-card-border overflow-hidden',
           'shadow-[0_24px_48px_rgba(15,23,42,0.20)]',
           'focus:outline-none',
           className,
@@ -192,6 +240,9 @@ export function Modal({
           titleTrailing={titleTrailing}
           footer={footer}
           asDialogTitle={false}
+          radius={radius}
+          bodyPadding={bodyPadding}
+          footerLayout={footerLayout}
         >
           {children}
         </ModalChrome>
@@ -212,11 +263,11 @@ export function Modal({
 
         <Dialog.Content
           data-kb-component="modal"
-          style={{ width: `${width}px` }}
+          style={{ width: `${width}px`, borderRadius: radius }}
           className={cn(
             'fixed left-1/2 top-1/2 z-[91] -translate-x-1/2 -translate-y-1/2',
             'max-w-[calc(100vw-32px)]',
-            'flex flex-col bg-white rounded-[8px] border border-card-border',
+            'flex flex-col bg-white border border-card-border overflow-hidden',
             'shadow-[0_24px_48px_rgba(15,23,42,0.20)]',
             'animate-toast-in focus:outline-none',
             className,
@@ -240,6 +291,9 @@ export function Modal({
             titleTrailing={titleTrailing}
             footer={footer}
             asDialogTitle={title !== undefined}
+            radius={radius}
+            bodyPadding={bodyPadding}
+            footerLayout={footerLayout}
           >
             {children}
           </ModalChrome>

--- a/packages/kb-ui/src/components/overlays/NewCategoryModal.stories.tsx
+++ b/packages/kb-ui/src/components/overlays/NewCategoryModal.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import '../../tokens.css';
+import { NewCategoryModal, type ParentCategoryOption } from './NewCategoryModal';
+import { Button } from '../primitives/Button';
+
+/* ─────────────────────────────────────────────────────────────
+ * Two stories — both share the chrome verified against Figma
+ * node 1958:34896 ("New Category") from file
+ * 251DTRmxl2L6jmXd3FWzHe.
+ *
+ *   - Playground: mode="create" (default). Empty form, CTA reads
+ *     "Create Category".
+ *   - EditMode:   mode="edit". Pre-filled fields, CTA reads
+ *     "Save changes", title reads "Edit Category".
+ *
+ * Per project convention, sibling stories collapse via argTypes
+ * only when there is value in interactive switching. These two
+ * exist as discrete stories so each appears in the Storybook
+ * sidebar — `mode` is set inline in each `render`.
+ * ───────────────────────────────────────────────────────────── */
+
+const parentOptions: ParentCategoryOption[] = [
+  { id: 'getting-started', label: 'Getting Started' },
+  { id: 'live-chat', label: 'Live Chat & Multi-channel' },
+  { id: 'managing-emails', label: 'Managing Emails' },
+  { id: 'automations-workflows', label: 'Automations & Workflows' },
+  { id: 'reporting-analytics', label: 'Reporting & Analytics' },
+];
+
+const meta: Meta<typeof NewCategoryModal> = {
+  title: 'Components/Overlays/New Category Modal',
+  component: NewCategoryModal,
+  parameters: { layout: 'centered' },
+  globals: { backgrounds: { value: 'canvas' } },
+};
+export default meta;
+
+function NewCategoryModalPlayground() {
+  const [open, setOpen] = useState(true);
+  return (
+    <>
+      <Button variant="primary" onClick={() => setOpen(true)}>
+        Open New Category Modal
+      </Button>
+      <NewCategoryModal
+        open={open}
+        onOpenChange={setOpen}
+        parentOptions={parentOptions}
+        onSubmit={(values) => {
+          // eslint-disable-next-line no-console
+          console.log('create category', values);
+        }}
+      />
+    </>
+  );
+}
+
+export const Playground: StoryObj<typeof NewCategoryModal> = {
+  render: () => <NewCategoryModalPlayground />,
+};
+
+function NewCategoryModalEditMode() {
+  const [open, setOpen] = useState(true);
+  return (
+    <>
+      <Button variant="primary" onClick={() => setOpen(true)}>
+        Open Edit Category Modal
+      </Button>
+      <NewCategoryModal
+        open={open}
+        onOpenChange={setOpen}
+        mode="edit"
+        parentOptions={parentOptions}
+        initialValues={{
+          name: 'Setting up Hiver',
+          parentCategoryId: 'getting-started',
+          description:
+            'Install the extension, connect Gmail, and verify your workspace.',
+        }}
+        onSubmit={(values) => {
+          // eslint-disable-next-line no-console
+          console.log('edit category', values);
+        }}
+      />
+    </>
+  );
+}
+
+export const EditMode: StoryObj<typeof NewCategoryModal> = {
+  render: () => <NewCategoryModalEditMode />,
+};

--- a/packages/kb-ui/src/components/overlays/NewCategoryModal.tsx
+++ b/packages/kb-ui/src/components/overlays/NewCategoryModal.tsx
@@ -1,0 +1,265 @@
+import * as React from 'react';
+import { ChevronDown, Mail01, XClose } from '@untitledui/icons';
+import { cn } from '../../utils/cn';
+import { Modal } from './Modal';
+import { Button } from '../primitives/Button';
+import { Field } from '../primitives/Field';
+import { TextInput } from '../primitives/TextInput';
+import { Textarea } from '../primitives/Textarea';
+
+/* ─────────────────────────────────────────────────────────────
+ * NewCategoryModal — matches Figma node 1958:34896 from file
+ * 251DTRmxl2L6jmXd3FWzHe.
+ *
+ * Built on the kb-ui `Modal` primitive with three chunkier-chrome
+ * overrides (radius=12, bodyPadding=20, footerLayout="section").
+ *
+ * Two Figma quirks ship verbatim per spec:
+ *   1. Parent Category dropdown counter sits AFTER the chevron
+ *      (chevron-first, "14/32" second). This is intentionally
+ *      different from kb-ui Dropdown — we bypass Dropdown and
+ *      compose TextInput with a custom suffix.
+ *   2. Description label is 13px medium while other labels are
+ *      14px medium. Achieved via Field's `className` arbitrary
+ *      selector — see field 4 below.
+ *
+ * v1 scope: icon picker and parent-category dropdown are click
+ * stubs (console.log on click). No popover/menu UI. No form
+ * validation. No required-field markers (Figma shows none).
+ * ───────────────────────────────────────────────────────────── */
+
+export type NewCategoryFormValues = {
+  /** Icon identifier (free-form string for now; this is a placeholder field). */
+  iconKey?: string;
+  name: string;
+  parentCategoryId?: string;
+  description: string;
+};
+
+export type ParentCategoryOption = {
+  id: string;
+  label: string;
+};
+
+export type NewCategoryModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Optional parent-category options. When undefined, the dropdown is a static placeholder (no menu). */
+  parentOptions?: ParentCategoryOption[];
+  /**
+   * Modal mode. `'create'` (default) renders the New Category chrome — title
+   * "New Category" and CTA "Create Category". `'edit'` renders the Edit
+   * Category chrome — title "Edit Category" and CTA "Save changes". Form
+   * fields and submit shape are identical across modes.
+   */
+  mode?: 'create' | 'edit';
+  /**
+   * Submit handler — called with form values when the user clicks the primary
+   * CTA. Receives all four fields regardless of mode.
+   */
+  onSubmit?: (values: NewCategoryFormValues) => void;
+  /** Pre-fill values (rare — useful for editing). */
+  initialValues?: Partial<NewCategoryFormValues>;
+};
+
+type FormState = {
+  iconKey: string;
+  name: string;
+  parentCategoryId: string;
+  description: string;
+};
+
+function buildInitialState(
+  initialValues?: Partial<NewCategoryFormValues>,
+): FormState {
+  return {
+    iconKey: initialValues?.iconKey ?? '',
+    name: initialValues?.name ?? '',
+    parentCategoryId: initialValues?.parentCategoryId ?? '',
+    description: initialValues?.description ?? '',
+  };
+}
+
+export function NewCategoryModal({
+  open,
+  onOpenChange,
+  parentOptions,
+  mode = 'create',
+  onSubmit,
+  initialValues,
+}: NewCategoryModalProps) {
+  const [state, setState] = React.useState<FormState>(() =>
+    buildInitialState(initialValues),
+  );
+
+  const isEdit = mode === 'edit';
+  const titleText = isEdit ? 'Edit Category' : 'New Category';
+  const ctaLabel = isEdit ? 'Save changes' : 'Create Category';
+
+  /* Figma shows the Parent Category field rendering the selected
+   * parent's label inside the input (or the "Category name"
+   * placeholder when nothing is picked). The 14/32 char counter
+   * counts the rendered label's length. Both behaviors fall out
+   * naturally from looking up the matching option below. */
+  const selectedParent = React.useMemo(
+    () =>
+      parentOptions?.find((opt) => opt.id === state.parentCategoryId) ?? null,
+    [parentOptions, state.parentCategoryId],
+  );
+  const parentDisplay = selectedParent?.label ?? '';
+
+  const handleSubmit = () => {
+    onSubmit?.({
+      iconKey: state.iconKey || undefined,
+      name: state.name,
+      parentCategoryId: state.parentCategoryId || undefined,
+      description: state.description,
+    });
+    onOpenChange(false);
+  };
+
+  /* Close X button — small unstyled button hosted in the Modal
+   * header's `titleTrailing` slot. */
+  const closeButton = (
+    <button
+      type="button"
+      aria-label="Close"
+      onClick={() => onOpenChange(false)}
+      className={cn(
+        'flex h-6 w-6 items-center justify-center rounded-[4px] cursor-pointer',
+        'text-text-meta hover:bg-surface-muted',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20',
+      )}
+    >
+      <XClose aria-hidden="true" className="h-[14px] w-[14px]" />
+    </button>
+  );
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      width={420}
+      radius={12}
+      bodyPadding={20}
+      footerLayout="section"
+      title={titleText}
+      titleTrailing={closeButton}
+      /* Figma renders the title at 14px medium here, while the
+       * Modal primitive's default is 16px medium (Convert-to-
+       * External-KB style). Override via arbitrary selector on
+       * the data-kb-part hook so we don't touch the primitive. */
+      className="[&_[data-kb-part=modal-title]]:text-[14px] [&_[data-kb-part=modal-title]]:leading-5"
+      footer={
+        <Button variant="primary" onClick={handleSubmit}>
+          {ctaLabel}
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-5">
+        {/* Field 1 — Icon picker (click stub) */}
+        <Field label="Icon">
+          <button
+            type="button"
+            aria-label="Pick an icon"
+            onClick={() => {
+              // v1: no real picker — log for prototype reviewers.
+              // eslint-disable-next-line no-console
+              console.log('icon-picker open');
+            }}
+            className={cn(
+              'flex h-11 w-11 items-center justify-center rounded-[7px]',
+              'border-[1.5px] border-dashed border-[#cbd5e1]',
+              'hover:border-[#94a3b8] transition-colors',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20',
+            )}
+          >
+            <Mail01 className="h-[22px] w-[22px] text-[#6634ef]" />
+          </button>
+        </Field>
+
+        {/* Field 2 — Category Name */}
+        <Field label="Category Name">
+          <TextInput
+            value={state.name}
+            onChange={(e) =>
+              setState((s) => ({ ...s, name: e.target.value }))
+            }
+            placeholder="Category name"
+            charCount={{ current: state.name.length, max: 32 }}
+          />
+        </Field>
+
+        {/* Field 3 — Parent Category (Figma quirk: chevron BEFORE counter)
+         *
+         * TextInput renders charCount BEFORE suffix, so to get
+         * chevron-first / counter-second on the right edge we
+         * skip charCount entirely and pack BOTH into the suffix
+         * slot — chevron, then counter.
+         *
+         * v1: clicking is a no-op (`console.log`). The real menu
+         * UI is out of scope; the field looks-and-feels like a
+         * dropdown but doesn't have one. */}
+        <Field label="Parent Category">
+          <div
+            role="button"
+            tabIndex={0}
+            onClick={() => {
+              // eslint-disable-next-line no-console
+              console.log('parent-category open');
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                // eslint-disable-next-line no-console
+                console.log('parent-category open');
+              }
+            }}
+            className={cn(
+              'cursor-pointer',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20 rounded-lg',
+            )}
+            aria-label="Choose parent category"
+          >
+            <TextInput
+              value={parentDisplay}
+              /* Read-only display: clicking the wrapper opens the
+               * (future) menu. We still wire onChange so React
+               * doesn't warn about controlled-without-onChange. */
+              onChange={() => undefined}
+              placeholder="Category name"
+              suffix={
+                <span className="flex items-center gap-1.5">
+                  <ChevronDown
+                    aria-hidden="true"
+                    className="h-[14px] w-[14px] text-text-meta"
+                  />
+                  <span className="text-[12px] font-normal leading-[18px] text-text-muted tabular-nums">
+                    {parentDisplay.length}/32
+                  </span>
+                </span>
+              }
+              inputClassName="cursor-pointer pointer-events-none"
+            />
+          </div>
+        </Field>
+
+        {/* Field 4 — Description (Figma quirk: 13px label instead of 14px) */}
+        <Field
+          label="Description"
+          className="[&>div>label]:text-[13px] [&>div>label]:leading-[19px]"
+        >
+          <Textarea
+            value={state.description}
+            onChange={(e) =>
+              setState((s) => ({ ...s, description: e.target.value }))
+            }
+            placeholder="Text goes here"
+            initialHeight={80}
+            charCount={{ current: state.description.length, max: 120 }}
+          />
+        </Field>
+      </div>
+    </Modal>
+  );
+}

--- a/packages/kb-ui/src/components/overlays/index.ts
+++ b/packages/kb-ui/src/components/overlays/index.ts
@@ -9,3 +9,9 @@ export { SideSheet } from './SideSheet';
 export type { SideSheetProps } from './SideSheet';
 export { Modal } from './Modal';
 export type { ModalProps } from './Modal';
+export { NewCategoryModal } from './NewCategoryModal';
+export type {
+  NewCategoryModalProps,
+  NewCategoryFormValues,
+  ParentCategoryOption,
+} from './NewCategoryModal';

--- a/packages/kb-ui/src/components/primitives/Textarea.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Textarea.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import '../../tokens.css';
+import { Textarea } from './Textarea';
+
+const meta: Meta<typeof Textarea> = {
+  title: 'Components/Primitives/Textarea',
+  component: Textarea,
+  parameters: { layout: 'padded' },
+  globals: { backgrounds: { value: 'white' } },
+};
+export default meta;
+
+function TextareaPlayground() {
+  const [value, setValue] = useState('');
+
+  return (
+    <div className="w-96 font-sans">
+      <Textarea
+        placeholder="Describe what this category contains — agents will see this on the category landing."
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        charCount={{ current: value.length, max: 120 }}
+      />
+    </div>
+  );
+}
+
+function TextareaWithoutCounter() {
+  const [value, setValue] = useState('');
+
+  return (
+    <div className="w-96 font-sans">
+      <Textarea
+        placeholder="Describe what this category contains — agents will see this on the category landing."
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    </div>
+  );
+}
+
+export const Playground: StoryObj<typeof Textarea> = {
+  render: () => <TextareaPlayground />,
+};
+
+export const WithoutCounter: StoryObj<typeof Textarea> = {
+  render: () => <TextareaWithoutCounter />,
+};

--- a/packages/kb-ui/src/components/primitives/Textarea.tsx
+++ b/packages/kb-ui/src/components/primitives/Textarea.tsx
@@ -1,0 +1,71 @@
+import { cn } from '../../utils/cn';
+
+export type TextareaProps = {
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  placeholder?: string;
+  charCount?: { current: number; max: number };
+  disabled?: boolean;
+  id?: string;
+  name?: string;
+  /** Initial height in pixels. Default 80. */
+  initialHeight?: number;
+  /** Resize behavior. Default 'vertical'. */
+  resize?: 'vertical' | 'horizontal' | 'both' | 'none';
+  className?: string;
+  /** Override classes applied to the inner <textarea>. */
+  textareaClassName?: string;
+};
+
+const resizeClassMap: Record<NonNullable<TextareaProps['resize']>, string> = {
+  vertical: 'resize-y',
+  horizontal: 'resize-x',
+  both: 'resize',
+  none: 'resize-none',
+};
+
+export function Textarea({
+  value,
+  onChange,
+  placeholder,
+  charCount,
+  disabled,
+  id,
+  name,
+  initialHeight = 80,
+  resize = 'vertical',
+  className,
+  textareaClassName,
+}: TextareaProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-1.5 overflow-hidden rounded-lg border border-[#e2e8f0] bg-white px-3 py-2',
+        disabled && 'opacity-50 cursor-not-allowed',
+        className,
+      )}
+    >
+      <textarea
+        id={id}
+        name={name}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        disabled={disabled}
+        style={{ minHeight: `${initialHeight}px` }}
+        className={cn(
+          'min-w-0 flex-1 border-0 bg-transparent p-0 text-[14px] font-normal leading-5 text-text-primary outline-none placeholder:text-text-muted disabled:cursor-not-allowed',
+          resizeClassMap[resize],
+          textareaClassName,
+        )}
+      />
+      {charCount && (
+        <div className="flex justify-end">
+          <span className="shrink-0 text-[12px] font-normal leading-[18px] text-text-muted tabular-nums">
+            {charCount.current}/{charCount.max}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/kb-ui/src/components/primitives/index.ts
+++ b/packages/kb-ui/src/components/primitives/index.ts
@@ -12,6 +12,8 @@ export { Divider } from './Divider';
 export type { DividerProps } from './Divider';
 export { Field } from './Field';
 export type { FieldProps } from './Field';
+export { Textarea } from './Textarea';
+export type { TextareaProps } from './Textarea';
 export { TextInput } from './TextInput';
 export type { TextInputProps } from './TextInput';
 export { Dropdown } from './Dropdown';


### PR DESCRIPTION
## Summary
- New `Textarea` primitive — `value`/`onChange`/`placeholder`/`charCount`/`disabled` + `initialHeight` (default 80px) + native `resize-y` handle. 8px radius, slate-200 border per Figma 1958:34919.
- New `NewCategoryModal` pattern composing Modal + Field + TextInput + Textarea + Button + inline 44x44 dashed-border icon swatch with purple `Mail01` glyph. Modes: `create` (CTA "Create Category") / `edit` (CTA "Save changes"). Per Figma 1958:34896.
- `Modal` gains three backward-compatible props: `radius` (default 8), `bodyPadding` (default 16), `footerLayout` (`'inside'` default | `'section'`). ConfirmDialog + ShortcutsCheatSheet unchanged.
- `FileExplorerNav.renderRowAction` slot — per-row trailing action that reveals on hover, replacing the count badge / status dot. Row width stable. `focus-within` keeps the action visible during keyboard nav.
- `FileExplorerNav` flat-mode row backgrounds routed through `stateBg('active')` + `HOVER_BG_CLASS` for visual consistency with the tree variant.

## Stories added
- `Components/Primitives/Textarea` — Playground + WithoutCounter
- `Components/Overlays/New Category Modal` — Playground + EditMode
- `Components/Nav/FileExplorerNav` — WithRowActions

## Verification
- [x] `npm run --workspace=packages/kb-ui typecheck`
- [x] `npm run --workspace=packages/kb-ui build-storybook`