### PR TITLE
feat(demo): category authoring entry points + template-gallery empty state

### DIFF
--- a/apps/demo/src/components/EmptyStateVariants.tsx
+++ b/apps/demo/src/components/EmptyStateVariants.tsx
@@ -1,0 +1,139 @@
+// Empty-state — Round 2 Variant A (winning design).
+//
+// Template gallery: a centered 2×2 grid of pre-structured article
+// templates plus a "browse all" tertiary link. Sits flush on the
+// white content surface — no card chrome, no border around the
+// gallery itself.
+//
+// `onCreate` is kept on the prop signature for API parity with
+// CategoryPage.tsx (which still passes it). It's intentionally
+// unused — the page-header "+ New article" remains the only
+// blank-start entrypoint.
+
+import type { ComponentType, SVGProps } from 'react';
+import {
+  BookOpen01,
+  FileShield02,
+  MessageQuestionCircle,
+  Tool01,
+} from '@untitledui/icons';
+
+export type EmptyStateGalleryProps = {
+  /** Kept for API parity with CategoryPage.tsx — intentionally unused. */
+  onCreate: () => void;
+};
+
+type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
+
+type TemplateCardProps = {
+  Icon: IconComponent;
+  title: string;
+  description: string;
+  /** Accent palette for the icon container. */
+  containerClass: string;
+  iconClass: string;
+  onClick: () => void;
+};
+
+function TemplateCard({
+  Icon,
+  title,
+  description,
+  containerClass,
+  iconClass,
+  onClick,
+}: TemplateCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex cursor-pointer flex-col rounded-[12px] border border-[#e2e8f0] bg-white p-5 text-left transition-all hover:-translate-y-[1px] hover:border-[#cbd5e1] hover:shadow-sm"
+    >
+      <div
+        className={`flex h-10 w-10 items-center justify-center rounded-full ${containerClass}`}
+      >
+        <Icon className={`h-5 w-5 ${iconClass}`} aria-hidden="true" />
+      </div>
+      <p className="mt-3 text-[15px] font-semibold leading-5 text-text-primary">
+        {title}
+      </p>
+      <p className="mt-1 line-clamp-2 text-[13px] leading-[20px] text-text-muted">
+        {description}
+      </p>
+    </button>
+  );
+}
+
+export function EmptyStateGallery({
+  onCreate: _onCreate,
+}: EmptyStateGalleryProps) {
+  return (
+    <div
+      data-route="kb-category-empty-template-gallery"
+      className="py-16"
+    >
+      <div className="mx-auto flex max-w-[720px] flex-col items-center gap-8">
+        {/* Eyebrow pill */}
+        <span className="rounded-full bg-sky-50 px-2.5 py-1 text-[11px] font-medium uppercase tracking-wider text-sky-700">
+          Quick start
+        </span>
+
+        {/* Headline */}
+        <h2 className="text-center text-[24px] font-medium leading-[32px] text-text-primary">
+          Start with a template — or write from scratch.
+        </h2>
+
+        {/* Subtitle */}
+        <p className="max-w-[480px] text-center text-[14px] leading-[22px] text-text-muted">
+          Templates are pre-structured drafts. You can edit anything, including
+          the structure.
+        </p>
+
+        {/* 2×2 template grid */}
+        <div className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2">
+          <TemplateCard
+            Icon={BookOpen01}
+            title="Step-by-step guide"
+            description="Walk users through a multi-step process. Best for onboarding flows, setup guides, integrations."
+            containerClass="bg-sky-50 border border-sky-100"
+            iconClass="text-sky-600"
+            onClick={() => console.log('template:step-by-step-guide')}
+          />
+          <TemplateCard
+            Icon={MessageQuestionCircle}
+            title="FAQ collection"
+            description="Group common questions with concise answers. Best for support hubs, policy clarifications."
+            containerClass="bg-violet-50 border border-violet-100"
+            iconClass="text-violet-600"
+            onClick={() => console.log('template:faq-collection')}
+          />
+          <TemplateCard
+            Icon={FileShield02}
+            title="Policy / overview"
+            description="Explain a rule, decision, or principle. Best for HR policies, security overviews, code of conduct."
+            containerClass="bg-emerald-50 border border-emerald-100"
+            iconClass="text-emerald-600"
+            onClick={() => console.log('template:policy-overview')}
+          />
+          <TemplateCard
+            Icon={Tool01}
+            title="Troubleshooting"
+            description="Diagnose-and-fix format. Best for product issues, error explainers, recovery flows."
+            containerClass="bg-amber-50 border border-amber-100"
+            iconClass="text-amber-600"
+            onClick={() => console.log('template:troubleshooting')}
+          />
+        </div>
+
+        {/* Browse all templates link */}
+        <button
+          type="button"
+          onClick={() => console.log('all-templates')}
+          className="text-[13px] text-[#475569] underline-offset-2 hover:text-[#0f172a] hover:underline"
+        >
+          Or, browse all templates →
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/demo/src/hooks/useCreateArticle.ts
+++ b/apps/demo/src/hooks/useCreateArticle.ts
@@ -1,0 +1,76 @@
+// Shared `+ New article` creation logic.
+//
+// Lives in a hook so both `CategoryPage` (via PageHeader's `onNewClick`) and
+// `EditorExplorer` (via the "+ New" header dropdown) can fire the same
+// flow: pick a unique `untitled-N` slug, dispatch `editor/createNew`, and
+// navigate to the new draft's editor URL.
+
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useMockStore } from '../store/MockStoreContext';
+import { routes } from '../lib/routes';
+
+/**
+ * Walk existing article slugs and return the smallest `untitled-N` (N>=1)
+ * that is not already taken. Defensive crypto-uuid fallback prevents a
+ * runaway loop if the slug-generation invariant is ever broken.
+ */
+function nextUntitledSlug(existingSlugs: Set<string>): string {
+  let n = 1;
+  while (existingSlugs.has(`untitled-${n}`)) {
+    n += 1;
+    if (n > 9999) return `untitled-${crypto.randomUUID()}`;
+  }
+  return `untitled-${n}`;
+}
+
+/**
+ * Returns a callable that creates a brand-new draft article inside the
+ * given category and navigates to its editor route.
+ *
+ * Pass `targetCategoryId` at call time so the caller can decide which
+ * category the new draft lands in (the URL-active category in
+ * CategoryPage's case; the explorer's active category in
+ * EditorExplorer's case).
+ *
+ * If `targetCategoryId` is missing or doesn't resolve to a category in
+ * the store, the call is a no-op and logs a dev warning — surfaces the
+ * "no active category" edge case during prototype use without crashing.
+ */
+export function useCreateArticle(): (targetCategoryId?: string) => void {
+  const navigate = useNavigate();
+  const { state, dispatch } = useMockStore();
+
+  return useCallback(
+    (targetCategoryId?: string) => {
+      if (!targetCategoryId) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[useCreateArticle] no targetCategoryId — cannot create article',
+        );
+        return;
+      }
+      const category = state.categories[targetCategoryId];
+      if (!category) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[useCreateArticle] unknown categoryId="${targetCategoryId}"`,
+        );
+        return;
+      }
+      const existingSlugs = new Set<string>();
+      for (const a of Object.values(state.articles)) existingSlugs.add(a.slug);
+      const newSlug = nextUntitledSlug(existingSlugs);
+      const newArticleId = `art-${newSlug}-${crypto.randomUUID().slice(0, 8)}`;
+      dispatch({
+        type: 'editor/createNew',
+        categoryId: category.id,
+        newArticleId,
+        newSlug,
+        now: new Date().toISOString(),
+      });
+      navigate(routes.article(newSlug));
+    },
+    [state.articles, state.categories, dispatch, navigate],
+  );
+}

--- a/apps/demo/src/routes/kb/CategoryPage.tsx
+++ b/apps/demo/src/routes/kb/CategoryPage.tsx
@@ -13,22 +13,28 @@
 // state when the category has neither children nor articles. Both are
 // intentionally simple — Phase 7.5.8 owns the polished empty-state pass.
 
-import { useCallback, useMemo } from 'react';
+import * as React from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
+import * as RxDropdownMenu from '@radix-ui/react-dropdown-menu';
 import {
   BookOpen01,
   ChevronRight,
   DotsVertical,
   File02,
   Folder,
+  Plus,
 } from '@untitledui/icons';
 import {
   Avatar,
   Badge,
   cn,
   DataTable,
+  NewCategoryModal,
   PageHeader,
   type DataTableColumn,
+  type NewCategoryFormValues,
+  type ParentCategoryOption,
 } from '@test-kb-ui/kb-ui';
 import { useMockStore } from '../../store/MockStoreContext';
 import {
@@ -39,7 +45,12 @@ import {
 import type { Article, Category, User } from '../../store/types';
 import { DEFAULT_KB_CATEGORY_SLUG, routes } from '../../lib/routes';
 import { formatRelativeDate } from '../../lib/relativeDate';
-import { EmptyState } from '../../components/EmptyState';
+import { EmptyStateGallery } from '../../components/EmptyStateVariants';
+import { useCreateArticle } from '../../hooks/useCreateArticle';
+import {
+  DropdownMenuItem,
+  DROPDOWN_CONTENT_CLASSES,
+} from '../../shell/DropdownMenuItem';
 
 /* ─────────────────────────────────────────────────────────────
  * Row types — co-located with the page that owns them.
@@ -253,23 +264,45 @@ function buildChildCategoryUrl(
   return routes.kb.deep(topLevel, mid, child.slug);
 }
 
-/**
- * Generate a unique `untitled-N` slug for a brand-new draft. Walks the
- * existing article slugs and finds the smallest N (>=1) that is not
- * already taken. O(M) over articles where M is small (~20) — fine.
- */
-function nextUntitledSlug(existingSlugs: Set<string>): string {
-  let n = 1;
-  while (existingSlugs.has(`untitled-${n}`)) {
-    n += 1;
-    if (n > 9999) {
-      // Defensive cap. Should never trip; prevents a runaway loop if
-      // the slug-generation invariant is ever broken.
-      return `untitled-${crypto.randomUUID()}`;
-    }
-  }
-  return `untitled-${n}`;
-}
+/* ─────────────────────────────────────────────────────────────
+ * "+ New" dropdown trigger
+ *
+ * Radix `Trigger asChild` requires a child that forwards refs so the
+ * menu can compute the trigger's bounding box. The kb-ui `Button`
+ * does NOT forward refs, so we use a native `<button>` styled to
+ * match Button's `primary` variant (h-8, px-3, rounded-[6px], black
+ * bg, 14/medium label, focus ring) — keeping the visual rhythm of
+ * the existing PageHeader CTA intact.
+ * ───────────────────────────────────────────────────────────── */
+
+const NewButtonTrigger = React.forwardRef<
+  HTMLButtonElement,
+  React.ButtonHTMLAttributes<HTMLButtonElement>
+>(function NewButtonTrigger({ className, children, ...rest }, ref) {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      className={cn(
+        'box-border inline-flex items-center justify-center gap-1.5',
+        'font-sans text-[14px] font-medium leading-5 transition-colors',
+        'h-8 px-3 rounded-[6px] bg-black text-white',
+        'hover:bg-black/90 active:bg-black/80',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-faint focus-visible:ring-offset-1',
+        className,
+      )}
+      {...rest}
+    >
+      <span
+        aria-hidden
+        className="flex size-[14px] shrink-0 items-center justify-center [&>svg]:h-[14px] [&>svg]:w-[14px]"
+      >
+        <Plus aria-hidden="true" />
+      </span>
+      {children}
+    </button>
+  );
+});
 
 /* ─────────────────────────────────────────────────────────────
  * Inline states
@@ -306,17 +339,12 @@ function CategoryNotFound({
 }
 
 function EmptyCategoryState({ onCreate }: { onCreate: () => void }) {
-  // Phase 7.5.8 — switched from a one-off inline render to the shared
-  // <EmptyState /> component so every "nothing here yet" surface in
-  // the demo looks the same (PRD §12.5).
-  return (
-    <EmptyState
-      icon={<File02 />}
-      title="No content here yet."
-      subtitle="Add the first article to start building this section of the KB."
-      cta={{ label: '+ Create the first article', onClick: onCreate }}
-    />
-  );
+  // Phase 7.5.8 — variant gallery prototype. Three spot-graphic
+  // treatments stacked for side-by-side review. Once the user picks a
+  // winner we promote it into kb-ui and restore the single <EmptyState />
+  // render here. Demo-local EmptyState.tsx is intentionally left
+  // untouched — other surfaces (AI Optimise hub etc.) still use it.
+  return <EmptyStateGallery onCreate={onCreate} />;
 }
 
 /* ─────────────────────────────────────────────────────────────
@@ -330,7 +358,8 @@ export default function CategoryPage() {
     depth2?: string;
   }>();
   const navigate = useNavigate();
-  const { state, dispatch } = useMockStore();
+  const { state } = useMockStore();
+  const createArticle = useCreateArticle();
 
   // Deepest URL segment is the active category slug. (`depth2` may be
   // undefined on /kb/<top> or /kb/<top>/<mid>; we fall back through
@@ -345,19 +374,21 @@ export default function CategoryPage() {
 
   const handleNewArticle = useCallback(() => {
     if (!category) return;
-    const existingSlugs = new Set<string>();
-    for (const a of Object.values(state.articles)) existingSlugs.add(a.slug);
-    const newSlug = nextUntitledSlug(existingSlugs);
-    const newArticleId = `art-${newSlug}-${crypto.randomUUID().slice(0, 8)}`;
-    dispatch({
-      type: 'editor/createNew',
-      categoryId: category.id,
-      newArticleId,
-      newSlug,
-      now: new Date().toISOString(),
-    });
-    navigate(routes.article(newSlug));
-  }, [category, state.articles, dispatch, navigate]);
+    createArticle(category.id);
+  }, [category, createArticle]);
+
+  /* ── Create-folder modal state ─────────────────────────────── */
+
+  const [createModalOpen, setCreateModalOpen] = useState(false);
+
+  // Depth-0 categories drive the modal's "parent" dropdown options.
+  const parentOptions = useMemo<ParentCategoryOption[]>(
+    () =>
+      Object.values(state.categories)
+        .filter((c) => c.parentId === null)
+        .map((c) => ({ id: c.id, label: c.title })),
+    [state.categories],
+  );
 
   /* ── 404 path ──────────────────────────────────────────────── */
 
@@ -391,6 +422,45 @@ export default function CategoryPage() {
     navigate(routes.article(article.slug));
   };
 
+  /* ── PageHeader "+ New" dropdown ───────────────────────────── */
+  //
+  // Replaces the previous "+ New article" Button. Trigger label is
+  // intentionally "+ New" — the menu items disambiguate Folder /
+  // Article. Matches Figma 1958:33465 / image #7.
+  //
+  // Folder  → opens NewCategoryModal in create mode, parent pre-filled
+  //           with the current category.
+  // Article → reuses the existing useCreateArticle() flow scoped to
+  //           the current category.
+
+  const onNewFolder = () => setCreateModalOpen(true);
+
+  const newCta = (
+    <RxDropdownMenu.Root>
+      <RxDropdownMenu.Trigger asChild>
+        <NewButtonTrigger aria-label="Create new">New</NewButtonTrigger>
+      </RxDropdownMenu.Trigger>
+      <RxDropdownMenu.Portal>
+        <RxDropdownMenu.Content
+          align="end"
+          sideOffset={4}
+          className={DROPDOWN_CONTENT_CLASSES}
+        >
+          <DropdownMenuItem
+            label="Folder"
+            icon={<Folder aria-hidden="true" />}
+            onSelect={onNewFolder}
+          />
+          <DropdownMenuItem
+            label="Article"
+            icon={<File02 aria-hidden="true" />}
+            onSelect={handleNewArticle}
+          />
+        </RxDropdownMenu.Content>
+      </RxDropdownMenu.Portal>
+    </RxDropdownMenu.Root>
+  );
+
   /* ── Render ────────────────────────────────────────────────── */
 
   const isEmpty = subCategoryRows.length === 0 && articleRows.length === 0;
@@ -401,8 +471,7 @@ export default function CategoryPage() {
         icon={<BookOpen01 className="size-[22px] text-blue-500" />}
         title={category.title}
         subtitle={category.subtitle}
-        newButtonLabel="New article"
-        onNewClick={handleNewArticle}
+        cta={newCta}
       />
 
       {isEmpty ? (
@@ -434,6 +503,28 @@ export default function CategoryPage() {
             />
           )}
         </>
+      )}
+
+      {/* Conditional render: NewCategoryModal seeds form state on first
+       *  mount, so to ensure parent pre-fill applies on every open we
+       *  mount/unmount on each cycle. Mirrors the pattern in
+       *  EditorExplorer for edit-mode opens.
+       */}
+      {createModalOpen && (
+        <NewCategoryModal
+          open
+          onOpenChange={(next) => {
+            if (!next) setCreateModalOpen(false);
+          }}
+          mode="create"
+          parentOptions={parentOptions}
+          initialValues={{ parentCategoryId: category.id }}
+          onSubmit={(values: NewCategoryFormValues) => {
+            // eslint-disable-next-line no-console
+            console.log('TODO: create category', values);
+            setCreateModalOpen(false);
+          }}
+        />
       )}
     </div>
   );

--- a/apps/demo/src/shell/DropdownMenuItem.tsx
+++ b/apps/demo/src/shell/DropdownMenuItem.tsx
@@ -1,0 +1,69 @@
+// Shared dropdown menu chrome — matches Figma node 1958:34638.
+//
+// Used by both:
+//   - `EditorExplorer` — the per-row 3-dot menu surfaced via
+//     `FileExplorerNav.renderRowAction`.
+//   - `CategoryPage`   — the PageHeader "+ New" dropdown with
+//     "Folder" / "Article" items.
+//
+// Container: white bg, 1px #e2e8f0 border, 8px radius, py-2 px-1,
+//            two-layer shadow per Figma `Shadows/md`.
+// Item:      flex w/ 16px icon + 14px label, p-2, 6px radius, slate-100
+//            hover bg, destructive variant uses ai-removal red.
+//
+// Composes Radix DropdownMenu primitives so we keep keyboard a11y,
+// portal positioning, and focus management for free.
+
+import * as React from 'react';
+import * as RxDropdownMenu from '@radix-ui/react-dropdown-menu';
+import { cn } from '@test-kb-ui/kb-ui';
+
+export type DropdownItemProps = {
+  label: string;
+  icon: React.ReactNode;
+  onSelect: () => void;
+  destructive?: boolean;
+};
+
+export function DropdownMenuItem({
+  label,
+  icon,
+  onSelect,
+  destructive,
+}: DropdownItemProps) {
+  return (
+    <RxDropdownMenu.Item
+      onSelect={(e) => {
+        // Default behavior closes the menu — that's what we want.
+        // Just guard against the synthetic event swallowing navigation
+        // by deferring to a microtask.
+        e.preventDefault();
+        onSelect();
+      }}
+      className={cn(
+        'flex items-center gap-2 p-2 rounded-[6px]',
+        'text-[14px] leading-5 cursor-pointer outline-none select-none',
+        'data-[highlighted]:bg-[#f1f5f9] data-[disabled]:opacity-50',
+        destructive ? 'text-[#d52c1f]' : 'text-text-primary',
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          'flex size-4 shrink-0 items-center justify-center',
+          '[&>svg]:w-4 [&>svg]:h-4',
+          destructive ? 'text-[#d52c1f]' : 'text-text-meta',
+        )}
+      >
+        {icon}
+      </span>
+      <span className="flex-1">{label}</span>
+    </RxDropdownMenu.Item>
+  );
+}
+
+export const DROPDOWN_CONTENT_CLASSES = cn(
+  'bg-white border border-card-border rounded-[8px] py-2 px-1',
+  'shadow-[0_4px_3px_rgba(0,0,0,0.05),_0_2px_2px_rgba(0,0,0,0.1)]',
+  'min-w-[160px] z-50',
+);

--- a/apps/demo/src/shell/EditorExplorer.tsx
+++ b/apps/demo/src/shell/EditorExplorer.tsx
@@ -14,10 +14,30 @@
 //     keeps its own local expansion state) AND, if the folder is a
 //     category, navigate to its category page.
 //   - Article click → navigate to the editor URL for that article slug.
+//
+// Per-row actions (2026-05-14 — dispatch B + C):
+//   - `renderRowAction` → per-row 3-dot trigger + "Edit" item. On a
+//     folder row Edit opens NewCategoryModal in `edit` mode pre-filled
+//     from the matching category; on an article row Edit navigates to the
+//     article's editor URL.
+//   - Modal is edit-mode only here. The create-mode entry-point lives in
+//     CategoryPage's PageHeader "+ New" dropdown — see CategoryPage.tsx.
+//   - The dropdown chrome (container + item) is shared from
+//     `./DropdownMenuItem.tsx` so EditorExplorer and CategoryPage stay
+//     pixel-identical — see Figma node `1958:34638`.
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import * as RxDropdownMenu from '@radix-ui/react-dropdown-menu';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { FileExplorerNav, type NavItem } from '@test-kb-ui/kb-ui';
+import { DotsVertical, Pencil02 } from '@untitledui/icons';
+import {
+  FileExplorerNav,
+  NewCategoryModal,
+  cn,
+  type NavItem,
+  type NewCategoryFormValues,
+  type ParentCategoryOption,
+} from '@test-kb-ui/kb-ui';
 import { useMockStore } from '../store/MockStoreContext';
 import {
   selectArticleBySlug,
@@ -25,6 +45,14 @@ import {
   selectExplorerTree,
 } from '../store/selectors';
 import { routes } from '../lib/routes';
+import {
+  DropdownMenuItem,
+  DROPDOWN_CONTENT_CLASSES,
+} from './DropdownMenuItem';
+
+/* ──────────────────────────────────────────────────────────────
+ * Flatten helpers
+ * ────────────────────────────────────────────────────────────── */
 
 /**
  * Recursively flatten the tree into a list of (node, parents-from-root)
@@ -43,6 +71,20 @@ function flattenTree(items: NavItem[], ancestors: NavItem[] = []): FlatNode[] {
   }
   return out;
 }
+
+/* ──────────────────────────────────────────────────────────────
+ * Modal state — edit-mode only here. (Create-mode lives in
+ * CategoryPage, behind the PageHeader "+ New > Folder" item.)
+ * ────────────────────────────────────────────────────────────── */
+
+type ModalState =
+  | { open: false }
+  | {
+      open: true;
+      mode: 'edit';
+      initialValues: Partial<NewCategoryFormValues>;
+      categoryId: string;
+    };
 
 export function EditorExplorer() {
   const navigate = useNavigate();
@@ -75,6 +117,35 @@ export function EditorExplorer() {
     return cat?.id;
   }, [pathname, params, state]);
 
+  /* ── Parent options for NewCategoryModal (depth-0 categories) ── */
+
+  const parentOptions = useMemo<ParentCategoryOption[]>(
+    () =>
+      Object.values(state.categories)
+        .filter((c) => c.parentId === null)
+        .map((c) => ({ id: c.id, label: c.title })),
+    [state.categories],
+  );
+
+  /* ── Modal state ────────────────────────────────────────────── */
+
+  const [modalState, setModalState] = useState<ModalState>({ open: false });
+  const closeModal = useCallback(() => setModalState({ open: false }), []);
+
+  const handleModalSubmit = useCallback(
+    (values: NewCategoryFormValues) => {
+      // The store reducer doesn't currently expose categories/update —
+      // mutating mock data is out of scope for this dispatch. Log + close
+      // so reviewers can see the payload.
+      if (modalState.open && modalState.mode === 'edit') {
+        // eslint-disable-next-line no-console
+        console.log('TODO: update category', modalState.categoryId, values);
+      }
+      closeModal();
+    },
+    [modalState, closeModal],
+  );
+
   /* ── Click handler ──────────────────────────────────────────── */
 
   const handleItemClick = useCallback(
@@ -106,20 +177,122 @@ export function EditorExplorer() {
         .filter((c): c is NonNullable<typeof c> => Boolean(c));
       const slugs = allCats.map((c) => c.slug);
 
-      if (slugs.length === 1) navigate(routes.kb.category(slugs[0]));
-      else if (slugs.length === 2) navigate(routes.kb.sub(slugs[0], slugs[1]));
+      let targetUrl: string | undefined;
+      if (slugs.length === 1) targetUrl = routes.kb.category(slugs[0]);
+      else if (slugs.length === 2) targetUrl = routes.kb.sub(slugs[0], slugs[1]);
       else if (slugs.length >= 3)
-        navigate(routes.kb.deep(slugs[0], slugs[1], slugs[2]));
+        targetUrl = routes.kb.deep(slugs[0], slugs[1], slugs[2]);
+
+      // Guard the navigate() call: same-URL navigations generate a new
+      // location.key and would trigger a spurious route-fade replay.
+      // The toggleExpanded dispatch above still runs unconditionally so
+      // the folder collapse/expand toggle works on same-route clicks.
+      if (targetUrl && targetUrl !== pathname) navigate(targetUrl);
     },
-    [flat, state, dispatch, navigate],
+    [flat, state, dispatch, navigate, pathname],
   );
 
+  /* ── renderRowAction — per-row 3-dot menu ──────────────────── */
+
+  const openEditFolderModal = useCallback(
+    (categoryId: string) => {
+      const cat = state.categories[categoryId];
+      if (!cat) return;
+      const initialValues: Partial<NewCategoryFormValues> = {
+        name: cat.title,
+        parentCategoryId: cat.parentId ?? undefined,
+        description: cat.subtitle,
+        // iconKey intentionally left undefined — the demo store doesn't
+        // track icon identifiers (the modal's icon picker is a stub).
+      };
+      setModalState({
+        open: true,
+        mode: 'edit',
+        initialValues,
+        categoryId,
+      });
+    },
+    [state.categories],
+  );
+
+  const renderRowAction = useCallback(
+    (item: NavItem) => {
+      const onEdit = () => {
+        if (item.type === 'folder') {
+          openEditFolderModal(item.id);
+        } else {
+          // Article: navigate to its editor URL.
+          const article = state.articles[item.id];
+          if (article) navigate(routes.article(article.slug));
+        }
+      };
+      return (
+        <RxDropdownMenu.Root>
+          <RxDropdownMenu.Trigger asChild>
+            <button
+              type="button"
+              aria-label={`Actions for ${item.title}`}
+              // Stop propagation on mousedown so Radix-managed focus
+              // shifts don't also trigger the row button's onClick.
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={(e) => e.stopPropagation()}
+              className={cn(
+                'flex h-7 w-7 items-center justify-center rounded-[4px]',
+                'text-text-meta hover:bg-[#f1f5f9]',
+                'focus:outline-none focus:ring-2 focus:ring-[#cbd5e1]',
+              )}
+            >
+              <DotsVertical aria-hidden="true" className="h-4 w-4" />
+            </button>
+          </RxDropdownMenu.Trigger>
+          <RxDropdownMenu.Portal>
+            <RxDropdownMenu.Content
+              align="end"
+              sideOffset={4}
+              className={DROPDOWN_CONTENT_CLASSES}
+            >
+              <DropdownMenuItem
+                label="Edit"
+                icon={<Pencil02 aria-hidden="true" />}
+                onSelect={onEdit}
+              />
+            </RxDropdownMenu.Content>
+          </RxDropdownMenu.Portal>
+        </RxDropdownMenu.Root>
+      );
+    },
+    [openEditFolderModal, navigate, state.articles],
+  );
+
+  /* ── Render ────────────────────────────────────────────────── */
+
   return (
-    <FileExplorerNav
-      title="Editor"
-      items={items}
-      activeId={activeId}
-      onItemClick={handleItemClick}
-    />
+    <>
+      <FileExplorerNav
+        title="Editor"
+        items={items}
+        activeId={activeId}
+        onItemClick={handleItemClick}
+        renderRowAction={renderRowAction}
+      />
+      {/* Conditionally render the modal so its internal form state
+       *  resets between open/close cycles — the modal seeds `useState`
+       *  from `initialValues` only on first mount, so a long-lived
+       *  instance would otherwise carry stale Edit-mode pre-fills into
+       *  subsequent opens.
+       */}
+      {modalState.open && (
+        <NewCategoryModal
+          open
+          onOpenChange={(next) => {
+            if (!next) closeModal();
+          }}
+          mode={modalState.mode}
+          initialValues={modalState.initialValues}
+          parentOptions={parentOptions}
+          onSubmit={handleModalSubmit}
+        />
+      )}
+    </>
   );
 }

--- a/apps/demo/src/store/fixtures/articles.ts
+++ b/apps/demo/src/store/fixtures/articles.ts
@@ -518,4 +518,37 @@ export const articles: Article[] = [
       reviewerIds: ['user-aanya'],
     },
   },
+  {
+    // Overview article living directly on the top-level "Automations & Workflows"
+    // category — sibling to the 3 sub-folders (Rule-based / SLAs / Notifications).
+    // Demonstrates that articles can sit at any depth, not only on leaf categories.
+    id: 'art-choosing-the-right-automation-type',
+    slug: 'choosing-the-right-automation-type',
+    categoryId: 'cat-automations-workflows',
+    title: 'Choosing the right automation type',
+    status: 'published',
+    authorId: 'user-rohan',
+    lastUpdatedAt: daysAgo(3),
+    bodyHTML: `<p>Most teams reach for the same kind of automation regardless of the problem in front of them — a rule, every time. That works for triage, but it leaves SLAs and notifications on the table when they would have been a better fit. This overview maps the three automation primitives Hiver supports to the cases each one is genuinely good at, so your team picks the right tool the first time.</p>
+<h2>Rule-based automations</h2>
+<p>Rules are stateless event-to-action mappings — when an inbound conversation matches a filter, run an action. A canonical example: <em>if the inbound subject contains "refund", apply the billing tag and assign to the billing inbox</em>. Rules don't track time, don't escalate, and don't notify anyone outside the action list. They're the right choice for high-volume, deterministic triage on shared inboxes — tagging, routing, auto-replies, and template insertion. See <a href="#">Rule-based automations →</a> for the full trigger and action catalogue.</p>
+<h2>SLAs &amp; escalations</h2>
+<p>SLAs add time to the picture. Where a rule fires once on arrival, an SLA tracks a conversation against a deadline and can fire follow-up actions when that deadline is at risk or breached. Pair an SLA with an escalation chain when the cost of a slow response is high — paying customers, security tickets, anything with a contractual response window. Good fits include:</p>
+<ul>
+<li>First-response deadlines per shared inbox, with different targets for billing vs general support.</li>
+<li>Tier-2 escalation on customer-blocker tickets — auto-assign to a manager when the SLA passes 75% elapsed.</li>
+<li>Weekend coverage notifications — page the on-call agent if a tagged conversation arrives outside business hours.</li>
+</ul>
+<p>See <a href="#">SLAs &amp; escalations →</a> for policy authoring and the breach-action catalogue.</p>
+<h2>Notifications</h2>
+<p>Notifications are the lightweight third primitive — no triggers, no deadlines, just per-agent preferences for what events should ping them and through which channel. Most agents tune their own notifications; managers tune team-wide defaults. Use notifications when you want awareness without action — "tell me when I'm mentioned in a note" rather than "auto-assign this to me." The three primitives compose: a rule routes a conversation, an SLA times it, and a notification pings the right agent the moment either fires.</p>`,
+    settings: {
+      slug: 'choosing-the-right-automation-type',
+      tags: ['automations', 'overview', 'workflows'],
+      publishDate: daysAgo(3),
+      seoTitle: 'When to use rules, SLAs, and notifications in Hiver',
+      visibility: 'public',
+      reviewerIds: ['user-mira'],
+    },
+  },
 ];


### PR DESCRIPTION
## Summary
- PageHeader "+ New article" replaced with "+ New" Radix DropdownMenu — Folder option opens `NewCategoryModal` (create mode, parent pre-filled); Article option calls the extracted `useCreateArticle` hook. Per Figma 1958:33465.
- Per-row 3-dot menu on `EditorExplorer` rows via the new `FileExplorerNav.renderRowAction` slot. Folders open `NewCategoryModal` in edit mode with `initialValues` from the category record; articles navigate to the editor route. Per Figma 1958:34638.
- Shared Radix dropdown chrome extracted to `apps/demo/src/shell/DropdownMenuItem.tsx`.
- Demo-only template-gallery empty state (`apps/demo/src/components/EmptyStateVariants.tsx`) wired into `CategoryPage`'s `EmptyCategoryState`. Round-2 Variant A: 2x2 tinted-icon-container grid + tertiary "browse all templates" link. Not promoted to kb-ui per user decision.
- New article fixture `art-choosing-the-right-automation-type` sitting at the `cat-automations-workflows` root (sibling to the 3 sub-folders) — demonstrates articles can live at any depth.

## Builds on
- #74 (kb-ui `NewCategoryModal`, `Textarea`, `Modal` extensions, `FileExplorerNav.renderRowAction`)

## Verification
- [x] `npm run --workspace=apps/demo typecheck`
- [x] `npm run --workspace=apps/demo build`