### PR TITLE
feat(kb-ui): AIGapSuggestionCard idle state

### DIFF
--- a/packages/kb-ui/src/components/content/AIGapSuggestionCard.stories.tsx
+++ b/packages/kb-ui/src/components/content/AIGapSuggestionCard.stories.tsx
@@ -103,3 +103,32 @@ function AIGapSuggestionCardPlayground() {
 export const Playground: StoryObj<typeof AIGapSuggestionCard> = {
   render: () => <AIGapSuggestionCardPlayground />,
 };
+
+/* ─────────────────────────────────────────────────────────────
+ * Idle — recessed paired-card look. Same affordances as active
+ * but with canvas-grey BG, faint border, drop shadow, and title
+ * color stepped down to text-secondary. Mirrors Figma node
+ * 251DTRmxl2L6jmXd3FWzHe#2829:9484 (suggestion-cards, state=default).
+ * Rendered on the canvas-grey background that the card lives on in
+ * production so the contrast vs. the active card is legible.
+ * ───────────────────────────────────────────────────────────── */
+function AIGapSuggestionCardIdleStory() {
+  return (
+    <div className="w-[452px]">
+      <AIGapSuggestionCard
+        suggestion={SUGGESTION_ADDITION}
+        state="idle"
+        onPrev={() => {}}
+        onNext={() => {}}
+        onOpenSources={() => {}}
+        onAccept={() => {}}
+        onReject={() => {}}
+        onUndo={() => {}}
+      />
+    </div>
+  );
+}
+
+export const Idle: StoryObj<typeof AIGapSuggestionCard> = {
+  render: () => <AIGapSuggestionCardIdleStory />,
+};

--- a/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
+++ b/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
@@ -2,6 +2,7 @@
 //        9aGp5t9fH1d0PXi4LMhOdb#81:16926 (active Addition in context)
 //        9aGp5t9fH1d0PXi4LMhOdb#81:16342 (active Replace in context)
 //        9aGp5t9fH1d0PXi4LMhOdb#81:15737 (active Removal in context)
+//        251DTRmxl2L6jmXd3FWzHe#2829:9484 (idle / state=default — recessed paired card)
 import * as React from 'react';
 import {
   Check,
@@ -176,7 +177,7 @@ export function AIGapSuggestionCard({
   typeRegistry,
 }: AIGapSuggestionCardProps) {
   const resolvedRegistry = typeRegistry ?? DEFAULT_GAP_TYPES;
-  if (state !== 'active') {
+  if (state === 'accepted' || state === 'dismissed') {
     const decisionLabel =
       state === 'accepted'
         ? (decisionLabels?.accepted ?? 'ACCEPTED')
@@ -211,12 +212,34 @@ export function AIGapSuggestionCard({
     );
   }
 
+  /* ─────────────────────────────────────────────────────────────
+   * Active + Idle share the same slot composition (header /
+   * meta+title+description / footer) — only the chrome differs:
+   *
+   *   active  → bg=white, AICard default geometry, hairline divider
+   *             above the footer, title=text-primary.
+   *
+   *   idle    → bg=canvas (#f5f5f5), border=#f1f5f9 (border-border),
+   *             shadow-lg, px-[22px] py-[24px], NO divider, footerGap
+   *             20px, title=text-secondary (#334155). Matches Figma
+   *             251DTRmxl2L6jmXd3FWzHe#2829:9484 (state=default) — the
+   *             recessed paired-card look that peeks under the active
+   *             AI Suggestions summary card in the editor rail.
+   * ───────────────────────────────────────────────────────────── */
+  const isIdle = state === 'idle';
+
   return (
     <AICard
       mode="active"
-      className={className}
+      className={cn(
+        isIdle &&
+          // Override AICard defaults: grey BG + faint border + shadow +
+          // Figma-exact padding. twMerge resolves the conflicts.
+          'bg-canvas border-border shadow-lg px-[22px] py-[24px]',
+        className,
+      )}
       data-kb-component="ai-gap-suggestion-card"
-      data-kb-state="active"
+      data-kb-state={state}
       data-kb-type={suggestion.type}
       header={<TypeChip type={suggestion.type} registry={resolvedRegistry} />}
       body={
@@ -224,7 +247,11 @@ export function AIGapSuggestionCard({
           {meta}
           <h3
             data-kb-part="ai-gap-title"
-            className="mt-2 text-[14px] font-medium leading-[20px] text-text-primary"
+            className={cn(
+              'mt-2 text-[14px] font-medium leading-[20px]',
+              // Idle title steps down to slateTextBody per Figma 2829:9484.
+              isIdle ? 'text-text-secondary' : 'text-text-primary',
+            )}
           >
             {suggestion.title}
           </h3>
@@ -236,7 +263,8 @@ export function AIGapSuggestionCard({
           </p>
         </>
       }
-      showFooterDivider
+      showFooterDivider={!isIdle}
+      footerGap={isIdle ? 20 : 12}
       footer={
         actions !== undefined ? (
           actions

--- a/packages/kb-ui/src/components/content/ai-suggestion-types.ts
+++ b/packages/kb-ui/src/components/content/ai-suggestion-types.ts
@@ -23,4 +23,16 @@ export type AISuggestion = {
   sourceCount: number;
 };
 
-export type AISuggestionState = 'active' | AISuggestionDecision;
+/**
+ * Visual + lifecycle state of an AI gap suggestion card.
+ *
+ *   idle       → paired with a suggestion but not the currently-active one.
+ *                Recessed look: canvas-grey BG, faint border, drop shadow,
+ *                title color steps down to text-secondary. Sits behind the
+ *                active summary card in the editor's right rail.
+ *   active     → the card under review. White BG, body type-primary,
+ *                full set of arrows / sources / accept-reject affordances.
+ *   accepted   → terminal chip — collapsed card with "ACCEPTED" label.
+ *   dismissed  → terminal chip — collapsed card with "DISMISSED" label.
+ */
+export type AISuggestionState = 'idle' | 'active' | AISuggestionDecision;


### PR DESCRIPTION
## Summary
- Adds `'idle'` to `AIGapSuggestionCard` for the recessed paired-card look (Figma 251DTRmxl2L6jmXd3FWzHe#2829:9484 — bg-canvas, border-border, shadow-lg, title text-secondary, no divider, 20px footer gap).
- Same slot composition as `active` — accept/reject/sources/arrows all render via the existing primitives, no behavior coupled in.
- Standalone: no consumer (EditorPage, ReviewPage, useAIGapsReducer) was touched. Chunk 1 of 5 in the AI Gaps interaction refactor.

## Test plan
- [x] `npm run --workspace=packages/kb-ui build` clean
- [x] `npm run --workspace=packages/kb-ui build-storybook` clean
- [x] `npx tsc -p packages/kb-ui --noEmit` clean
- [x] `npx tsc -p apps/demo --noEmit` clean (existing consumers unaffected)
- [x] New `Idle` story renders 1:1 against Figma raster (Playwright capture vs Figma PNG)