### PR TITLE
feat(kb-ui): suggestion-id anchor attribute + useAnchorPositions hook

### DIFF
--- a/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
+++ b/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
@@ -360,6 +360,18 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
     slotMap,
   );
 
+  // Inverse of `slotMap` — `{ s1: suggestionId, s2: ..., s3: ... }`.
+  // `ArticleBody` propagates each entry to the matching SuggestionBlock
+  // as `data-suggestion-id`. Built from the same fixture sort the slot
+  // mapping uses so the two sides can never disagree.
+  const articleSuggestionIds = React.useMemo(() => {
+    const out: { s1?: string; s2?: string; s3?: string } = {};
+    for (const [id, slot] of slotMap.entries()) {
+      out[slot] = id;
+    }
+    return out;
+  }, [slotMap]);
+
   return (
     <div data-route="ai-optimise-review" className="w-full">
       <div
@@ -369,6 +381,7 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
         <ArticleBody
           decisions={articleDecisions}
           regions={passwordResetRegions}
+          suggestionIds={articleSuggestionIds}
           className="max-w-[720px] w-full"
         />
         <aside

--- a/packages/kb-ui/src/components/content/ArticleBody.tsx
+++ b/packages/kb-ui/src/components/content/ArticleBody.tsx
@@ -104,6 +104,20 @@ export type ArticleBodyRegions = {
   afterS3?: React.ReactNode;
 };
 
+/**
+ * Optional map from slot key (`s1`/`s2`/`s3`) to the originating
+ * suggestion's stable id (the data model's `AISuggestion.id`). When set,
+ * the matching slot's `SuggestionBlock` emits `data-suggestion-id` so
+ * consumers can resolve DOM anchors via `useAnchorPositions`. Decoupled
+ * from `regions` because the article markup is static while the
+ * suggestion ids are derived at runtime from a per-article fixture.
+ */
+export type ArticleBodySuggestionIds = {
+  s1?: string;
+  s2?: string;
+  s3?: string;
+};
+
 export type ArticleBodyProps = {
   /**
    * Per-suggestion state.
@@ -126,6 +140,12 @@ export type ArticleBodyProps = {
    * `decisions`; the consumer owns the surrounding HTML between regions.
    */
   regions: ArticleBodyRegions;
+  /**
+   * Optional — suggestion ids per slot. When provided, propagated to the
+   * matching SuggestionBlock as `data-suggestion-id`. The legacy
+   * `id="s1|s2|s3"` anchors are preserved alongside.
+   */
+  suggestionIds?: ArticleBodySuggestionIds;
   className?: string;
 };
 
@@ -165,9 +185,11 @@ function PlainSentences({ sentences }: { sentences: SuggestionSentence[] }) {
 function S1Region({
   decision,
   content,
+  suggestionId,
 }: {
   decision: ArticleSuggestionDecision;
   content: SuggestionSentence[];
+  suggestionId?: string;
 }) {
   if (decision === 'accepted') {
     // Addition accepted → content kept as plain body text.
@@ -182,6 +204,7 @@ function S1Region({
     <SuggestionBlock
       type="addition"
       id="s1"
+      suggestionId={suggestionId}
       className="mb-4"
       sentences={content}
     />
@@ -192,10 +215,12 @@ function S2Region({
   decision,
   before,
   after,
+  suggestionId,
 }: {
   decision: ArticleSuggestionDecision;
   before: SuggestionSentence[];
   after: SuggestionSentence[];
+  suggestionId?: string;
 }) {
   if (decision === 'accepted') {
     // Replace accepted → new content remains as plain text.
@@ -210,6 +235,7 @@ function S2Region({
     <SuggestionBlock
       type="replace"
       id="s2"
+      suggestionId={suggestionId}
       className="mb-4"
       oldSentences={before}
       newSentences={after}
@@ -220,9 +246,11 @@ function S2Region({
 function S3Region({
   decision,
   content,
+  suggestionId,
 }: {
   decision: ArticleSuggestionDecision;
   content: SuggestionSentence[];
+  suggestionId?: string;
 }) {
   if (decision === 'accepted') {
     // Removal accepted → content deleted.
@@ -237,6 +265,7 @@ function S3Region({
     <SuggestionBlock
       type="removal"
       id="s3"
+      suggestionId={suggestionId}
       className="mb-4"
       sentences={content}
     />
@@ -250,6 +279,7 @@ function S3Region({
 export function ArticleBody({
   decisions,
   regions,
+  suggestionIds,
   className,
 }: ArticleBodyProps) {
   return (
@@ -267,15 +297,24 @@ export function ArticleBody({
     >
       {regions.header}
       {regions.beforeS1}
-      <S1Region decision={decisions.s1} content={regions.s1} />
+      <S1Region
+        decision={decisions.s1}
+        content={regions.s1}
+        suggestionId={suggestionIds?.s1}
+      />
       {regions.betweenS1AndS2}
       <S2Region
         decision={decisions.s2}
         before={regions.s2.before}
         after={regions.s2.after}
+        suggestionId={suggestionIds?.s2}
       />
       {regions.betweenS2AndS3}
-      <S3Region decision={decisions.s3} content={regions.s3} />
+      <S3Region
+        decision={decisions.s3}
+        content={regions.s3}
+        suggestionId={suggestionIds?.s3}
+      />
       {regions.afterS3}
     </article>
   );

--- a/packages/kb-ui/src/components/content/SuggestionBlock.stories.tsx
+++ b/packages/kb-ui/src/components/content/SuggestionBlock.stories.tsx
@@ -258,3 +258,26 @@ function SuggestionBlockPlayground() {
 export const Playground: StoryObj<typeof SuggestionBlock> = {
   render: () => <SuggestionBlockPlayground />,
 };
+
+/* ─────────────────────────────────────────────────────────────
+ * WithSuggestionId — DOM-only verification that `suggestionId`
+ * propagates to `data-suggestion-id` on the SuggestionBlock root.
+ * Visual rendering is incidental; this story exists for the
+ * `useAnchorPositions` hook to target a deterministic anchor.
+ * Inspect the rendered element to confirm
+ * `[data-suggestion-id="suggestion-abc"]` is present on the root.
+ * ───────────────────────────────────────────────────────────── */
+
+export const WithSuggestionId: StoryObj<typeof SuggestionBlock> = {
+  render: () => (
+    <div style={{ width: 720, padding: 16 }}>
+      <SuggestionBlock
+        type="addition"
+        suggestionId="suggestion-abc"
+        sentences={[
+          'This block carries a stable suggestion id on its root element so consumers can resolve its DOM anchor without coupling to the legacy s1/s2/s3 ids.',
+        ]}
+      />
+    </div>
+  ),
+};

--- a/packages/kb-ui/src/components/content/SuggestionBlock.tsx
+++ b/packages/kb-ui/src/components/content/SuggestionBlock.tsx
@@ -52,6 +52,14 @@ export type SuggestionBlockProps = {
   newContent?: React.ReactNode;
   /** Optional anchor id — used by the editor to `scrollIntoView`. */
   id?: string;
+  /**
+   * Optional suggestion identifier. When set, emitted as
+   * `data-suggestion-id` on the outermost element so consumers (e.g. the
+   * AI Gaps editor) can resolve a suggestion's DOM anchor via
+   * `useAnchorPositions` without coupling to the legacy `id="s1|s2|s3"`
+   * convention.
+   */
+  suggestionId?: string;
   className?: string;
 };
 
@@ -203,12 +211,17 @@ export function SuggestionBlock({
   oldContent,
   newContent,
   id,
+  suggestionId,
   className,
 }: SuggestionBlockProps) {
+  // Emit `data-suggestion-id` only when the consumer provides one — keeps
+  // the DOM clean for legacy callers and gives `useAnchorPositions` a
+  // single deterministic selector.
   const rootProps = {
     id,
     'data-kb-component': 'suggestion-block',
     'data-kb-type': type,
+    ...(suggestionId ? { 'data-suggestion-id': suggestionId } : {}),
   } as const;
 
   /* ── Replace ─────────────────────────────────────────────── */

--- a/packages/kb-ui/src/components/content/index.ts
+++ b/packages/kb-ui/src/components/content/index.ts
@@ -57,6 +57,7 @@ export type {
   ArticleBodyProps,
   ArticleBodyDecisions,
   ArticleBodyRegions,
+  ArticleBodySuggestionIds,
   ArticleSuggestionDecision,
 } from './ArticleBody';
 export type {

--- a/packages/kb-ui/src/hooks/useAnchorPositions.ts
+++ b/packages/kb-ui/src/hooks/useAnchorPositions.ts
@@ -1,0 +1,206 @@
+// `useAnchorPositions` — read-only DOM-position tracker for anchored
+// content. Given a container ref and a list of stable ids, the hook
+// returns a map of `{ id → offsetTop }` where `offsetTop` is measured
+// relative to `containerRef.current` (NOT the viewport).
+//
+// Designed for the AI Gaps review flow: the suggestion rail needs to
+// know where each `SuggestionBlock` lives inside the scrollable article
+// container so it can scroll the active block into view or render a
+// vertical mini-map. The contract is intentionally narrow so the hook
+// can be reused for any anchor-id-based scroll target (TOCs, jump
+// menus, etc.).
+//
+// Behaviour:
+//   - Measures on mount, after layout has settled.
+//   - Re-measures on `window` resize. Coalesced via `requestAnimationFrame`
+//     so a burst of resize events produces one measurement per frame.
+//   - Re-measures when the container subtree changes — a `MutationObserver`
+//     with `{ subtree: true, childList: true, characterData: true }` is
+//     attached to `containerRef.current`. Same rAF coalescing.
+//   - Re-measures when the `ids` array's CONTENTS change (not its
+//     identity — consumers building `ids` inline in render shouldn't
+//     trigger spurious re-measures). We key effects on the sorted-joined
+//     id string for stable equality.
+//   - Returns are memoized: a new object identity is only produced when
+//     the position map actually changes (deep compare keys + values).
+//
+// If an id has no matching element in the DOM, it is OMITTED from the
+// returned map (rather than reported as `0`). Consumers can distinguish
+// "anchor not yet mounted" from "anchor at top of container" by checking
+// `id in result`.
+//
+// No new dependencies — `ResizeObserver` and `MutationObserver` are both
+// native browser APIs. SSR-safe: all DOM reads are gated on the existence
+// of `containerRef.current`, which is `null` on the server.
+import * as React from 'react';
+
+/* ─────────────────────────────────────────────────────────────
+ * Types
+ * ───────────────────────────────────────────────────────────── */
+
+export type UseAnchorPositionsOptions = {
+  /** Scrollable parent. All offsets are measured against this element. */
+  containerRef: React.RefObject<HTMLElement | null>;
+  /** Stable ids to look up in the container's subtree. */
+  ids: string[];
+  /** Data attribute on the anchor element. Defaults to `data-suggestion-id`. */
+  attribute?: string;
+};
+
+/* ─────────────────────────────────────────────────────────────
+ * Helpers
+ * ───────────────────────────────────────────────────────────── */
+
+const DEFAULT_ATTRIBUTE = 'data-suggestion-id';
+
+function shallowEqualMap(
+  a: Record<string, number>,
+  b: Record<string, number>,
+): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const k of aKeys) {
+    if (!(k in b)) return false;
+    if (a[k] !== b[k]) return false;
+  }
+  return true;
+}
+
+/**
+ * Compute `{ id → offsetTop }` for every id whose anchor is present in
+ * the container's subtree. `offsetTop` is computed by walking the
+ * element's `offsetParent` chain up to (and stopping at) `container`,
+ * which handles arbitrary positioning ancestors between the anchor and
+ * the container — `el.offsetTop` alone is relative to the nearest
+ * positioned ancestor, which may not be our container.
+ */
+function measure(
+  container: HTMLElement,
+  ids: string[],
+  attribute: string,
+): Record<string, number> {
+  const next: Record<string, number> = {};
+  for (const id of ids) {
+    // Escape characters that would break a CSS attribute selector.
+    // The double quotes around the value cover most realistic ids
+    // (uuids, slugs); we strip any embedded double quotes defensively.
+    const safe = id.replace(/"/g, '\\"');
+    const el = container.querySelector<HTMLElement>(
+      `[${attribute}="${safe}"]`,
+    );
+    if (!el) continue;
+
+    let top = 0;
+    let cur: HTMLElement | null = el;
+    while (cur && cur !== container) {
+      top += cur.offsetTop;
+      cur = cur.offsetParent as HTMLElement | null;
+    }
+    // If we walked off the offsetParent chain without hitting the
+    // container (e.g. the anchor lives in a fixed-positioned subtree),
+    // skip it rather than report a misleading offset.
+    if (!cur) continue;
+    next[id] = top;
+  }
+  return next;
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Hook
+ * ───────────────────────────────────────────────────────────── */
+
+/**
+ * Track the `offsetTop` of one or more DOM anchors inside a scrollable
+ * container. See file-top JSDoc for the full contract.
+ *
+ * Returns a stable object reference: a new identity is only emitted
+ * when the resulting position map differs by key or value.
+ */
+export function useAnchorPositions({
+  containerRef,
+  ids,
+  attribute = DEFAULT_ATTRIBUTE,
+}: UseAnchorPositionsOptions): Record<string, number> {
+  // Sort + join the ids so the effect dependency is stable across
+  // identity-only re-creations of the array (e.g. consumers building
+  // `[a, b, c]` inline each render).
+  const idsKey = React.useMemo(() => {
+    return [...ids].sort().join('\x00');
+  }, [ids]);
+
+  // The measured map. Stored in state so React re-renders the consumer
+  // when positions change. The reducer only commits a new identity when
+  // the contents differ (see `commit` below).
+  const [positions, setPositions] = React.useState<Record<string, number>>(
+    () => ({}),
+  );
+
+  // Keep the latest `ids` and `attribute` accessible inside long-lived
+  // observer callbacks without re-creating the observer for every
+  // identity change.
+  const idsRef = React.useRef(ids);
+  idsRef.current = ids;
+  const attributeRef = React.useRef(attribute);
+  attributeRef.current = attribute;
+
+  // Track the latest committed map so the rAF-driven measure callback
+  // can compare against it without going through React state (which is
+  // asynchronous).
+  const positionsRef = React.useRef(positions);
+  positionsRef.current = positions;
+
+  React.useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let rafId: number | null = null;
+    let cancelled = false;
+
+    const commit = (next: Record<string, number>) => {
+      if (shallowEqualMap(positionsRef.current, next)) return;
+      positionsRef.current = next;
+      setPositions(next);
+    };
+
+    const schedule = () => {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        if (cancelled) return;
+        const c = containerRef.current;
+        if (!c) return;
+        commit(measure(c, idsRef.current, attributeRef.current));
+      });
+    };
+
+    // Initial measurement — synchronous so the first render after mount
+    // already has accurate offsets if the DOM is ready.
+    commit(measure(container, idsRef.current, attributeRef.current));
+
+    // Subsequent updates — coalesced via rAF.
+    const onResize = () => schedule();
+    window.addEventListener('resize', onResize);
+
+    const mo = new MutationObserver(schedule);
+    mo.observe(container, {
+      subtree: true,
+      childList: true,
+      characterData: true,
+    });
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener('resize', onResize);
+      mo.disconnect();
+      if (rafId !== null) cancelAnimationFrame(rafId);
+    };
+    // `idsKey` and `attribute` re-trigger the effect when the
+    // measurement target changes. `containerRef` is intentionally not
+    // a dependency — React refs don't trigger re-runs and the closure
+    // reads `containerRef.current` lazily inside `schedule`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [idsKey, attribute]);
+
+  return positions;
+}

--- a/packages/kb-ui/src/index.ts
+++ b/packages/kb-ui/src/index.ts
@@ -26,3 +26,5 @@ export type {
   AIGapsMode,
   UseAIGapsReducerResult,
 } from './hooks/useAIGapsReducer';
+export { useAnchorPositions } from './hooks/useAnchorPositions';
+export type { UseAnchorPositionsOptions } from './hooks/useAnchorPositions';


### PR DESCRIPTION
Chunk 2 of the AI Gaps interaction refactor. Self-contained — no consumer wiring of the new hook yet (that lands in chunk 3).

## Summary
- `SuggestionBlock` accepts an optional `suggestionId` prop and emits it as `data-suggestion-id` on the root when set
- `ArticleBody` propagates per-slot suggestion ids (`{ s1?, s2?, s3? }`) to the matching SuggestionBlock; `ReviewPage` wires them from the existing slotMap
- New `useAnchorPositions` hook measures offsetTop of `[data-suggestion-id]` anchors relative to a container, with rAF-coalesced resize + MutationObserver re-measurement and shallow-equal output memoization

## Verification
- `tsc -p packages/kb-ui --noEmit` clean
- `tsc -p apps/demo --noEmit` clean
- `npm run --workspace=packages/kb-ui build` clean
- `npm run --workspace=packages/kb-ui build-storybook` clean
- DOM check via Playwright confirmed `[data-suggestion-id="suggestion-abc"]` is emitted on the SuggestionBlock root
- Hook check via Playwright harness confirmed `{alpha:0, beta:100, gamma:250}` for known offsets and the missing id was omitted (not reported as 0)