### PR TITLE
feat(kb-ui): AI gaps rail Y-paired layout (chunk 3)

### DIFF
--- a/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
+++ b/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
@@ -27,11 +27,13 @@
 import * as React from 'react';
 import { Link, useParams } from 'react-router-dom';
 import {
+  AIGapRail,
   AIGapSuggestionCard,
   AISuggestionsCard,
   ArticleBody,
   ArticleSettingsPanel,
   SourcesSideSheet,
+  type AIGapRailItem,
   type AISuggestion as KbUiAISuggestion,
   type AISuggestionDecision,
   type ArticleBodyDecisions,
@@ -372,6 +374,102 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
     return out;
   }, [slotMap]);
 
+  // Ref to the ArticleBody root — passed to AIGapRail so cards can be
+  // Y-paired to their `data-suggestion-id` anchors. ArticleBody renders
+  // an `<article>` so we widen the type accordingly.
+  const articleRef = React.useRef<HTMLElement>(null);
+
+  /* ── Rail composition — chunk 3: paired layout ────────────────
+   * Summary card stays sticky at the rail top in every mode. In
+   * `pre-review` the paired idle cards render anchored to highlights;
+   * during `reviewing` we swap the matching item to its active card and
+   * other paired cards stay as decision chips or idle (chunks 4/5 wire
+   * the activation logic). In `terminal` the decision chips replace the
+   * paired idle cards.
+   * ───────────────────────────────────────────────────────────── */
+  const summaryNode = (
+    <>
+      <ArticleSettingsPanel
+        compact
+        defaultCollapsed
+        value={panelSettings}
+      />
+      {effectiveMode === 'pre-review' && (
+        <AISuggestionsCard
+          mode="pre-review"
+          count={kbSuggestions.length}
+          summary={SUMMARY}
+          onReview={() => dispatch({ type: 'review' })}
+          onPrev={() => dispatch({ type: 'prev' })}
+          onNext={() => dispatch({ type: 'next' })}
+        />
+      )}
+      {effectiveMode === 'terminal' && (
+        <AISuggestionsCard
+          mode="terminal"
+          count={kbSuggestions.length}
+          summary={SUMMARY}
+          onPrev={() => dispatch({ type: 'prev' })}
+          onNext={() => dispatch({ type: 'next' })}
+        />
+      )}
+    </>
+  );
+
+  const railItems = React.useMemo<AIGapRailItem[]>(() => {
+    return kbSuggestions.map((s) => {
+      const decision = effectiveDecisions[s.id];
+      if (decision) {
+        return {
+          id: s.id,
+          node: (
+            <AIGapSuggestionCard
+              suggestion={s}
+              state={decision}
+              onUndo={
+                isAlreadyPublished
+                  ? undefined
+                  : (id) => dispatch({ type: 'undo', id })
+              }
+            />
+          ),
+        };
+      }
+      if (effectiveMode === 'reviewing' && s.id === activeSuggestion?.id) {
+        return {
+          id: s.id,
+          node: (
+            <AIGapSuggestionCard
+              suggestion={s}
+              state="active"
+              onPrev={() => dispatch({ type: 'prev' })}
+              onNext={() => dispatch({ type: 'next' })}
+              onOpenSources={(id) =>
+                dispatch({ type: 'openSources', id })
+              }
+              onAccept={(id) => dispatch({ type: 'accept', id })}
+              onReject={(id) => dispatch({ type: 'reject', id })}
+            />
+          ),
+        };
+      }
+      // pre-review + reviewing-non-active → idle paired card. Chunk 3
+      // explicitly bypasses the legacy visibility gate so every
+      // suggestion's idle card renders from page load.
+      return {
+        id: s.id,
+        node: <AIGapSuggestionCard suggestion={s} state="idle" />,
+      };
+    });
+  }, [
+    kbSuggestions,
+    effectiveMode,
+    effectiveDecisions,
+    activeSuggestion,
+    isAlreadyPublished,
+    dispatch,
+  ]);
+
   return (
     <div data-route="ai-optimise-review" className="w-full">
       <div
@@ -379,100 +477,17 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
         className="flex flex-row justify-between items-start gap-6"
       >
         <ArticleBody
+          ref={articleRef}
           decisions={articleDecisions}
           regions={passwordResetRegions}
           suggestionIds={articleSuggestionIds}
           className="max-w-[720px] w-full"
         />
-        <aside
-          data-kb-part="ai-gaps-rail"
-          className="w-[380px] shrink-0 flex flex-col gap-4 sticky top-4"
-        >
-          <ArticleSettingsPanel
-            compact
-            defaultCollapsed
-            value={panelSettings}
-          />
-
-          {effectiveMode === 'pre-review' && (
-            <AISuggestionsCard
-              mode="pre-review"
-              count={kbSuggestions.length}
-              summary={SUMMARY}
-              onReview={() => dispatch({ type: 'review' })}
-              onPrev={() => dispatch({ type: 'prev' })}
-              onNext={() => dispatch({ type: 'next' })}
-            />
-          )}
-
-          {effectiveMode === 'reviewing' &&
-            kbSuggestions.map((s) => {
-              const decision = effectiveDecisions[s.id];
-              if (decision) {
-                return (
-                  <AIGapSuggestionCard
-                    key={s.id}
-                    suggestion={s}
-                    state={decision}
-                    onUndo={(id) => dispatch({ type: 'undo', id })}
-                  />
-                );
-              }
-              if (s.id === activeSuggestion?.id) {
-                return (
-                  <AIGapSuggestionCard
-                    key={s.id}
-                    suggestion={s}
-                    state="active"
-                    onPrev={() => dispatch({ type: 'prev' })}
-                    onNext={() => dispatch({ type: 'next' })}
-                    onOpenSources={(id) =>
-                      dispatch({ type: 'openSources', id })
-                    }
-                    onAccept={(id) => dispatch({ type: 'accept', id })}
-                    onReject={(id) => dispatch({ type: 'reject', id })}
-                  />
-                );
-              }
-              // Un-decided non-active suggestions are invisible in the rail
-              // during `reviewing` — matches the kb-ui Interactive story.
-              return null;
-            })}
-
-          {effectiveMode === 'terminal' && (
-            <>
-              <AISuggestionsCard
-                mode="terminal"
-                count={kbSuggestions.length}
-                summary={SUMMARY}
-                onPrev={() => dispatch({ type: 'prev' })}
-                onNext={() => dispatch({ type: 'next' })}
-              />
-              {/* Decision chips below — mirrors Interactive story so the
-                user can undo any decision from terminal (when not yet
-                published). When already published from a previous review,
-                we still render the chips so the user can see the
-                historical decisions, but the undo handler is a no-op
-                because the underlying suggestion is `published`. */}
-              {kbSuggestions.map((s) => {
-                const decision = effectiveDecisions[s.id];
-                if (!decision) return null;
-                return (
-                  <AIGapSuggestionCard
-                    key={s.id}
-                    suggestion={s}
-                    state={decision}
-                    onUndo={
-                      isAlreadyPublished
-                        ? undefined
-                        : (id) => dispatch({ type: 'undo', id })
-                    }
-                  />
-                );
-              })}
-            </>
-          )}
-        </aside>
+        <AIGapRail
+          articleRef={articleRef}
+          summary={summaryNode}
+          items={railItems}
+        />
       </div>
 
       <SourcesSideSheet

--- a/packages/kb-ui/src/components/content/AIGapRail.tsx
+++ b/packages/kb-ui/src/components/content/AIGapRail.tsx
@@ -1,0 +1,403 @@
+// AIGapRail — Y-paired absolute-positioned rail for the AI Gaps review
+// flow.
+//
+// Replaces the legacy `flex flex-col gap-4` stack with a tall column in
+// which:
+//   - The `summary` slot is sticky at the top of the rail.
+//   - Each `items[i].node` (paired suggestion card) is absolutely
+//     positioned and vertically anchored to its matching DOM anchor in
+//     `articleRef`, identified by `data-suggestion-id`.
+//   - A top-to-bottom collision walk ensures cards don't overlap; the
+//     `minGap` between cards is enforced by pinning each card's top to
+//     `max(targetTop, prevBottom + minGap)`.
+//   - When a card is offset from its anchor's true Y by more than
+//     `connectorTolerance` px (default 24), a 1px dotted vertical
+//     connector renders on the card's left edge back toward the anchor.
+//     Below tolerance the connector is suppressed — the visual rule is
+//     "show it only when the pairing isn't obvious".
+//   - `transition: top 200ms ease-out` on each card so future reflows
+//     (chunk 4 activation, chunk 5 accept/reject) animate smoothly.
+//
+// Coordinate-space translation: anchors live in the article body
+// container; cards live in this rail. Both containers are siblings in a
+// flex row, so we translate `articleAnchorOffsetTop` → rail-space top by
+// adding `(articleRect.top - railRect.top)` measured via
+// `getBoundingClientRect()` relative to the viewport. This handles every
+// case where the two columns don't start at the same Y (e.g. when the
+// article body has a wrapping header above it).
+//
+// The rail itself is NOT sticky — chunk 3 explicitly moves stickiness
+// from the rail container to the summary card inside the rail.
+import * as React from 'react';
+import { cn } from '../../utils/cn';
+import { useAnchorPositions } from '../../hooks/useAnchorPositions';
+
+/* ─────────────────────────────────────────────────────────────
+ * Types
+ * ───────────────────────────────────────────────────────────── */
+
+export type AIGapRailItem = {
+  /** Stable id matching the `data-suggestion-id` on the article anchor. */
+  id: string;
+  /** The card to render at the paired Y position. */
+  node: React.ReactNode;
+};
+
+export type AIGapRailProps = {
+  /**
+   * Reference to the article body container — the element whose subtree
+   * contains the `data-suggestion-id` anchors. Used both as the
+   * measurement container for `useAnchorPositions` AND as the
+   * coordinate-space origin for translating anchor offsetTops into
+   * rail-space tops.
+   */
+  articleRef: React.RefObject<HTMLElement | null>;
+  /**
+   * Sticky element rendered at the top of the rail. Typically the
+   * `<AISuggestionsCard>` summary card. The rail wraps it in a `sticky
+   * top-4` container so it stays visible while the user scrolls.
+   */
+  summary: React.ReactNode;
+  /**
+   * Paired suggestion cards. Order is preserved for the collision walk
+   * (top-to-bottom). Each item's `id` MUST match the `data-suggestion-id`
+   * on its anchor in the article — items whose anchors aren't found are
+   * rendered at a fallback position (stacked at the bottom of the rail).
+   */
+  items: AIGapRailItem[];
+  /** Minimum gap (px) between cards during collision walk. Default 12. */
+  minGap?: number;
+  /**
+   * Maximum offset (px) between a card's pinned top and its anchor's true
+   * Y before a dotted connector renders. Default 24.
+   */
+  connectorTolerance?: number;
+  className?: string;
+};
+
+/* ─────────────────────────────────────────────────────────────
+ * Helpers
+ * ───────────────────────────────────────────────────────────── */
+
+const DEFAULT_MIN_GAP = 12;
+const DEFAULT_CONNECTOR_TOLERANCE = 24;
+/**
+ * Fallback card height (px) used in the collision walk when a card
+ * hasn't been measured yet (first paint). Picked to match the active
+ * `AIGapSuggestionCard` height in Figma — close enough that the rail's
+ * `min-height` computation is roughly correct on first frame.
+ */
+const FALLBACK_CARD_HEIGHT = 184;
+
+type CardLayout = {
+  id: string;
+  /** Anchor's true Y in rail-space (the target top). */
+  target: number;
+  /** Pinned top after the collision walk. */
+  top: number;
+  /** Whether to show the dotted connector (|top - target| > tolerance). */
+  showConnector: boolean;
+  /**
+   * Signed Y delta = `top - target`. Positive → card pushed DOWN from its
+   * anchor (connector extends UP from card top toward the anchor). Negative
+   * → card pulled UP above its anchor (connector extends DOWN from card
+   * bottom toward the anchor). Zero → no offset, no connector.
+   */
+  delta: number;
+};
+
+/* ─────────────────────────────────────────────────────────────
+ * Component
+ * ───────────────────────────────────────────────────────────── */
+
+export function AIGapRail({
+  articleRef,
+  summary,
+  items,
+  minGap = DEFAULT_MIN_GAP,
+  connectorTolerance = DEFAULT_CONNECTOR_TOLERANCE,
+  className,
+}: AIGapRailProps) {
+  const railRef = React.useRef<HTMLDivElement>(null);
+  // Per-card refs so we can measure rendered heights for the collision
+  // walk. Keyed by item.id so re-ordering doesn't blow up the map.
+  const cardRefsRef = React.useRef<Map<string, HTMLDivElement | null>>(
+    new Map(),
+  );
+  // Cached measured heights so consumers can read them in render.
+  const [cardHeights, setCardHeights] = React.useState<Record<string, number>>(
+    () => ({}),
+  );
+  // Translation offset between article container and rail container, in
+  // viewport coordinates. Recomputed on resize / layout.
+  const [coordOffset, setCoordOffset] = React.useState(0);
+
+  /* ── Anchor offsets in article-container space ─────────────── */
+  const ids = React.useMemo(() => items.map((i) => i.id), [items]);
+  const anchorPositions = useAnchorPositions({
+    containerRef: articleRef,
+    ids,
+  });
+
+  /* ── Measure card heights ──────────────────────────────────── */
+  // ResizeObserver on each rendered card. Heights drive the collision
+  // walk's `prevBottom`. Coalesced into a single state update per frame
+  // via rAF so React doesn't re-render twice per resize.
+  React.useEffect(() => {
+    const rail = railRef.current;
+    if (!rail) return;
+    let rafId: number | null = null;
+    let cancelled = false;
+    const pending: Record<string, number> = {};
+
+    const flush = () => {
+      rafId = null;
+      if (cancelled) return;
+      setCardHeights((prev) => {
+        let changed = false;
+        const next: Record<string, number> = { ...prev };
+        for (const [id, h] of Object.entries(pending)) {
+          if (next[id] !== h) {
+            next[id] = h;
+            changed = true;
+          }
+        }
+        // Drop heights for ids no longer in the items list.
+        const activeIds = new Set(ids);
+        for (const k of Object.keys(next)) {
+          if (!activeIds.has(k)) {
+            delete next[k];
+            changed = true;
+          }
+        }
+        for (const k of Object.keys(pending)) delete pending[k];
+        return changed ? next : prev;
+      });
+    };
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const el = entry.target as HTMLElement;
+        const id = el.getAttribute('data-rail-card-id');
+        if (!id) continue;
+        pending[id] = entry.contentRect.height;
+      }
+      if (rafId === null) rafId = requestAnimationFrame(flush);
+    });
+
+    for (const item of items) {
+      const el = cardRefsRef.current.get(item.id);
+      if (el) observer.observe(el);
+    }
+
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+      if (rafId !== null) cancelAnimationFrame(rafId);
+    };
+  }, [items, ids]);
+
+  /* ── Article ↔ rail coordinate-space translation ───────────── */
+  React.useEffect(() => {
+    const measureOffset = () => {
+      const rail = railRef.current;
+      const article = articleRef.current;
+      if (!rail || !article) return;
+      // `getBoundingClientRect().top` is viewport-relative. The
+      // difference is article-space-top → rail-space-top.
+      const offset =
+        article.getBoundingClientRect().top -
+        rail.getBoundingClientRect().top;
+      setCoordOffset((prev) => (prev === offset ? prev : offset));
+    };
+    measureOffset();
+    // Re-measure on resize and on layout-affecting subtree mutations
+    // (the article body's height changes when suggestions are
+    // accepted/dismissed and ArticleBody re-flows).
+    const onResize = () => measureOffset();
+    window.addEventListener('resize', onResize);
+    let mo: MutationObserver | null = null;
+    const article = articleRef.current;
+    if (article) {
+      mo = new MutationObserver(measureOffset);
+      mo.observe(article, { subtree: true, childList: true, characterData: true });
+    }
+    return () => {
+      window.removeEventListener('resize', onResize);
+      if (mo) mo.disconnect();
+    };
+  }, [articleRef]);
+
+  /* ── Collision walk — pin each card top to max(target, prev+gap) ── */
+  const layouts: CardLayout[] = React.useMemo(() => {
+    const out: CardLayout[] = [];
+    let prevBottom = 0;
+    for (const item of items) {
+      const rawAnchor = anchorPositions[item.id];
+      // Skip the connector + use a fallback top when the anchor isn't
+      // measured yet — keeps first paint legible (cards stack near the
+      // top instead of jumping when measurements land).
+      const hasAnchor = typeof rawAnchor === 'number';
+      const target = hasAnchor ? rawAnchor + coordOffset : prevBottom;
+      const top = Math.max(target, prevBottom);
+      const height = cardHeights[item.id] ?? FALLBACK_CARD_HEIGHT;
+      const delta = top - target;
+      const showConnector = hasAnchor && Math.abs(delta) > connectorTolerance;
+      out.push({ id: item.id, target, top, showConnector, delta });
+      prevBottom = top + height + minGap;
+    }
+    return out;
+  }, [items, anchorPositions, coordOffset, cardHeights, minGap, connectorTolerance]);
+
+  /* ── Rail min-height: tallest card-bottom across the walk ──── */
+  const minHeight = React.useMemo(() => {
+    let bottom = 0;
+    for (const l of layouts) {
+      const height = cardHeights[l.id] ?? FALLBACK_CARD_HEIGHT;
+      bottom = Math.max(bottom, l.top + height);
+    }
+    return bottom;
+  }, [layouts, cardHeights]);
+
+  /* ── First-paint opacity: hide cards until anchors are measured ─ */
+  // If at least one anchor is measured we consider the layout ready.
+  // (All-or-nothing on the first frame to avoid a partial reveal.)
+  const ready = items.length === 0 || Object.keys(anchorPositions).length > 0;
+
+  return (
+    <aside
+      ref={railRef}
+      data-kb-component="ai-gap-rail"
+      data-kb-part="ai-gaps-rail"
+      className={cn(
+        // Cards inside are absolutely positioned, so the rail must be
+        // `relative` and have an explicit min-height. The sticky child
+        // (summary) sits inside, so we can't use a `flex` layout that
+        // would otherwise control intrinsic height.
+        'relative w-[380px] shrink-0',
+        className,
+      )}
+      style={{ minHeight: minHeight ? `${minHeight}px` : undefined }}
+    >
+      {/* Sticky summary slot — replaces the rail-level stickiness. */}
+      <div
+        data-kb-part="ai-gap-rail-summary"
+        className="sticky top-4 z-[1]"
+      >
+        {summary}
+      </div>
+
+      {items.map((item) => {
+        const layout = layouts.find((l) => l.id === item.id);
+        if (!layout) return null;
+        return (
+          <RailCard
+            key={item.id}
+            id={item.id}
+            top={layout.top}
+            ready={ready}
+            showConnector={layout.showConnector}
+            delta={layout.delta}
+            registerRef={(el) => {
+              if (el) cardRefsRef.current.set(item.id, el);
+              else cardRefsRef.current.delete(item.id);
+            }}
+          >
+            {item.node}
+          </RailCard>
+        );
+      })}
+    </aside>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * RailCard — single absolute-positioned card slot.
+ *
+ * Owns the `position: absolute`, the `top` transition, the optional
+ * dotted connector chrome, and the first-paint opacity-0 → opacity-1
+ * fade once positions are known. The card content itself stays
+ * untouched — we don't restyle `AIGapSuggestionCard`.
+ * ───────────────────────────────────────────────────────────── */
+
+type RailCardProps = {
+  id: string;
+  top: number;
+  ready: boolean;
+  showConnector: boolean;
+  /** Signed offset from anchor (top - target). Drives connector direction. */
+  delta: number;
+  registerRef: (el: HTMLDivElement | null) => void;
+  children: React.ReactNode;
+};
+
+function RailCard({
+  id,
+  top,
+  ready,
+  showConnector,
+  delta,
+  registerRef,
+  children,
+}: RailCardProps) {
+  // Track previous `top` so we can flip `will-change: top` on only
+  // while a transition is in flight. After the transition end we drop
+  // `will-change` so it doesn't sit on the layer indefinitely.
+  const prevTopRef = React.useRef(top);
+  const [willChange, setWillChange] = React.useState(false);
+  React.useEffect(() => {
+    if (prevTopRef.current !== top) {
+      prevTopRef.current = top;
+      setWillChange(true);
+    }
+  }, [top]);
+  const onTransitionEnd = React.useCallback(
+    (e: React.TransitionEvent<HTMLDivElement>) => {
+      if (e.propertyName === 'top') setWillChange(false);
+    },
+    [],
+  );
+
+  return (
+    <div
+      ref={registerRef}
+      data-rail-card-id={id}
+      data-kb-part="ai-gap-rail-card"
+      data-rail-connector={showConnector ? 'true' : 'false'}
+      onTransitionEnd={onTransitionEnd}
+      className={cn(
+        // Absolute position so multiple cards can coexist in a tall
+        // rail without flexbox squashing them together.
+        'absolute left-0 right-0',
+        // 200ms ease-out per the chunk 3 spec — chunk 4/5 reflows
+        // (activation / accept / reject) inherit this animation.
+        'transition-[top,opacity] duration-200 ease-out',
+        ready ? 'opacity-100' : 'opacity-0',
+      )}
+      style={{
+        top: `${top}px`,
+        willChange: willChange ? 'top' : undefined,
+      }}
+    >
+      {showConnector && (
+        <span
+          aria-hidden="true"
+          data-kb-part="ai-gap-rail-connector"
+          // 1px dotted vertical line on the card's left edge, extending
+          // back toward the anchor. When `delta > 0` (card pushed DOWN
+          // from anchor) the line runs UP from the card top a distance
+          // of `delta` px. When `delta < 0` (card pulled UP above anchor)
+          // the line runs DOWN from card bottom by `|delta|` px. Token
+          // color `border-border` per the chunk 3 spec.
+          className="pointer-events-none absolute -left-3 border-l border-dotted border-border"
+          style={
+            delta > 0
+              ? { top: `-${delta}px`, height: `${delta}px` }
+              : { bottom: `${delta}px`, height: `${-delta}px` }
+          }
+        />
+      )}
+      {children}
+    </div>
+  );
+}

--- a/packages/kb-ui/src/components/content/ArticleBody.tsx
+++ b/packages/kb-ui/src/components/content/ArticleBody.tsx
@@ -274,48 +274,60 @@ function S3Region({
 
 /* ─────────────────────────────────────────────────────────────
  * Component
+ *
+ * `forwardRef` so consumers (e.g. the AI Gaps rail) can pass a ref to
+ * the rendered `<article>` and measure the subtree's anchor offsets
+ * relative to it. The ref is intentionally typed `HTMLElement` (not
+ * `HTMLDivElement`) to match the `<article>` landmark.
  * ───────────────────────────────────────────────────────────── */
 
-export function ArticleBody({
-  decisions,
-  regions,
-  suggestionIds,
-  className,
-}: ArticleBodyProps) {
-  return (
-    <article
-      data-kb-component="article-body"
-      data-kb-s1={decisions.s1}
-      data-kb-s2={decisions.s2}
-      data-kb-s3={decisions.s3}
-      className={cn(
-        'w-full max-w-[720px] rounded-[12px] border border-card-border bg-white',
-        'shadow-[0_1px_2px_rgba(15,23,42,0.04)]',
-        'p-8',
-        className,
-      )}
-    >
-      {regions.header}
-      {regions.beforeS1}
-      <S1Region
-        decision={decisions.s1}
-        content={regions.s1}
-        suggestionId={suggestionIds?.s1}
-      />
-      {regions.betweenS1AndS2}
-      <S2Region
-        decision={decisions.s2}
-        before={regions.s2.before}
-        after={regions.s2.after}
-        suggestionId={suggestionIds?.s2}
-      />
-      {regions.betweenS2AndS3}
-      <S3Region
-        decision={decisions.s3}
-        content={regions.s3}
-        suggestionId={suggestionIds?.s3}
-      />
-      {regions.afterS3}
-    </article>
-  );
-}
+export const ArticleBody = React.forwardRef<HTMLElement, ArticleBodyProps>(
+  function ArticleBody(
+    { decisions, regions, suggestionIds, className },
+    ref,
+  ) {
+    return (
+      <article
+        ref={ref}
+        data-kb-component="article-body"
+        data-kb-s1={decisions.s1}
+        data-kb-s2={decisions.s2}
+        data-kb-s3={decisions.s3}
+        className={cn(
+          // `relative` makes the article a positioned ancestor so anchor
+          // descendants (SuggestionBlock with `data-suggestion-id`) have
+          // `offsetParent === article`. This is what `useAnchorPositions`
+          // walks; without it the walk goes off-chain to `<body>` and
+          // anchor offsets come back empty (the rail then falls back to
+          // its stacked layout).
+          'relative w-full max-w-[720px] rounded-[12px] border border-card-border bg-white',
+          'shadow-[0_1px_2px_rgba(15,23,42,0.04)]',
+          'p-8',
+          className,
+        )}
+      >
+        {regions.header}
+        {regions.beforeS1}
+        <S1Region
+          decision={decisions.s1}
+          content={regions.s1}
+          suggestionId={suggestionIds?.s1}
+        />
+        {regions.betweenS1AndS2}
+        <S2Region
+          decision={decisions.s2}
+          before={regions.s2.before}
+          after={regions.s2.after}
+          suggestionId={suggestionIds?.s2}
+        />
+        {regions.betweenS2AndS3}
+        <S3Region
+          decision={decisions.s3}
+          content={regions.s3}
+          suggestionId={suggestionIds?.s3}
+        />
+        {regions.afterS3}
+      </article>
+    );
+  },
+);

--- a/packages/kb-ui/src/components/content/index.ts
+++ b/packages/kb-ui/src/components/content/index.ts
@@ -60,6 +60,8 @@ export type {
   ArticleBodySuggestionIds,
   ArticleSuggestionDecision,
 } from './ArticleBody';
+export { AIGapRail } from './AIGapRail';
+export type { AIGapRailProps, AIGapRailItem } from './AIGapRail';
 export type {
   AISuggestion,
   AISuggestionType,

--- a/packages/kb-ui/src/pages/KBAIGapsExperience.stories.tsx
+++ b/packages/kb-ui/src/pages/KBAIGapsExperience.stories.tsx
@@ -10,6 +10,8 @@ import type {
   ArticleBodyRegions,
   ArticleSuggestionDecision,
 } from '../components/content/ArticleBody';
+import { AIGapRail } from '../components/content/AIGapRail';
+import type { AIGapRailItem } from '../components/content/AIGapRail';
 import { AISuggestionsCard } from '../components/content/AISuggestionsCard';
 import { AIGapSuggestionCard } from '../components/content/AIGapSuggestionCard';
 import { SuggestionHighlight } from '../components/content/SuggestionBlock';
@@ -870,6 +872,81 @@ function InteractiveRender({ enableKeyboard }: { enableKeyboard: boolean }) {
     state.mode,
   );
 
+  // Article ref + suggestion-ids map for the chunk 3 paired-layout rail.
+  // The three suggestion ids (s1/s2/s3) map 1:1 to ArticleBody slots in
+  // this story since `interactiveSuggestions` is ordered s1, s2, s3.
+  const articleRef = React.useRef<HTMLElement>(null);
+  const articleSuggestionIds = React.useMemo(
+    () => ({ s1: 's1', s2: 's2', s3: 's3' }),
+    [],
+  );
+
+  /* ─ Rail composition (chunk 3) ──────────────────────────────
+   * Summary card sticky at the top of the rail in every mode. Paired
+   * suggestion cards render in `idle` from page load, swapping to
+   * `active` for the focused suggestion during `reviewing` and to
+   * decision chips once accepted/dismissed. The legacy invisible-non-
+   * active branch is gone — every suggestion always renders a paired
+   * card in the rail, anchored to its highlight.
+   * ───────────────────────────────────────────────────────────── */
+  const summaryNode = (
+    <>
+      <ArticleSettingsPanel compact defaultCollapsed value={dummySettings} />
+      {state.mode === 'pre-review' && (
+        <AISuggestionsCard
+          mode="pre-review"
+          count={interactiveSuggestions.length}
+          summary={SUMMARY}
+          onReview={() => dispatch({ type: 'review' })}
+          onPrev={() => dispatch({ type: 'prev' })}
+          onNext={() => dispatch({ type: 'next' })}
+        />
+      )}
+      {state.mode === 'terminal' && (
+        <AISuggestionsCard
+          mode="terminal"
+          count={interactiveSuggestions.length}
+          summary={SUMMARY}
+          onPrev={() => dispatch({ type: 'prev' })}
+          onNext={() => dispatch({ type: 'next' })}
+        />
+      )}
+    </>
+  );
+
+  const railItems: AIGapRailItem[] = interactiveSuggestions.map((s) => {
+    const decision = state.decisions[s.id];
+    if (decision) {
+      return {
+        id: s.id,
+        node: (
+          <AIGapSuggestionCard
+            suggestion={s}
+            state={decision}
+            onUndo={(id) => dispatch({ type: 'undo', id })}
+          />
+        ),
+      };
+    }
+    if (state.mode === 'reviewing' && s.id === activeSuggestion?.id) {
+      return {
+        id: s.id,
+        node: (
+          <AIGapSuggestionCard
+            suggestion={s}
+            state="active"
+            onPrev={() => dispatch({ type: 'prev' })}
+            onNext={() => dispatch({ type: 'next' })}
+            onOpenSources={(id) => dispatch({ type: 'openSources', id })}
+            onAccept={(id) => dispatch({ type: 'accept', id })}
+            onReject={(id) => dispatch({ type: 'reject', id })}
+          />
+        ),
+      };
+    }
+    return { id: s.id, node: <AIGapSuggestionCard suggestion={s} state="idle" /> };
+  });
+
   return (
     <div className="h-screen w-full">
       <AppShell
@@ -900,101 +977,17 @@ function InteractiveRender({ enableKeyboard }: { enableKeyboard: boolean }) {
           className="flex flex-row justify-between items-start gap-6"
         >
           <ArticleBody
+            ref={articleRef}
             decisions={articleDecisions}
             regions={passwordResetRegions}
+            suggestionIds={articleSuggestionIds}
             className="max-w-[720px] w-full"
           />
-          <aside
-            data-kb-part="ai-gaps-rail"
-            /*
-             * `sticky top-4` keeps the rail in view as the article scrolls
-             * inside <main>. Round 2's static frames didn't need this since
-             * state was fixed per story; in the interactive flow the user
-             * auto-scrolls between suggestions and the rail must follow.
-             */
-            className="w-[380px] shrink-0 flex flex-col gap-4 sticky top-4"
-          >
-            <ArticleSettingsPanel compact defaultCollapsed value={dummySettings} />
-
-            {state.mode === 'pre-review' && (
-              <AISuggestionsCard
-                mode="pre-review"
-                count={interactiveSuggestions.length}
-                summary={SUMMARY}
-                onReview={() => dispatch({ type: 'review' })}
-                onPrev={() => dispatch({ type: 'prev' })}
-                onNext={() => dispatch({ type: 'next' })}
-              />
-            )}
-
-            {state.mode === 'reviewing' &&
-              interactiveSuggestions.map((s) => {
-                const decision = state.decisions[s.id];
-                if (decision) {
-                  // Reviewed suggestions persist as chips in the rail so
-                  // the user can undo at any time — matches flow-doc
-                  // frames 5/7/8.
-                  return (
-                    <AIGapSuggestionCard
-                      key={s.id}
-                      suggestion={s}
-                      state={decision}
-                      onUndo={(id) => dispatch({ type: 'undo', id })}
-                    />
-                  );
-                }
-                if (s.id === activeSuggestion?.id) {
-                  return (
-                    <AIGapSuggestionCard
-                      key={s.id}
-                      suggestion={s}
-                      state="active"
-                      onPrev={() => dispatch({ type: 'prev' })}
-                      onNext={() => dispatch({ type: 'next' })}
-                      onOpenSources={(id) =>
-                        dispatch({ type: 'openSources', id })
-                      }
-                      onAccept={(id) => dispatch({ type: 'accept', id })}
-                      onReject={(id) => dispatch({ type: 'reject', id })}
-                    />
-                  );
-                }
-                // Un-decided, non-active suggestions are invisible in the
-                // rail during `reviewing` — matches frames 3/5/7/8.
-                return null;
-              })}
-
-            {state.mode === 'terminal' && (
-              <>
-                <AISuggestionsCard
-                  mode="terminal"
-                  count={interactiveSuggestions.length}
-                  summary={SUMMARY}
-                  onPrev={() => dispatch({ type: 'prev' })}
-                  onNext={() => dispatch({ type: 'next' })}
-                />
-                {/*
-                 * Show every decision chip below the terminal card so the
-                 * user can still undo any individual decision. Figma hides
-                 * these in frame 10, but the dispatch explicitly calls out
-                 * that undo must remain available from the terminal screen
-                 * so the user can re-open a dismissed or accepted item.
-                 */}
-                {interactiveSuggestions.map((s) => {
-                  const decision = state.decisions[s.id];
-                  if (!decision) return null;
-                  return (
-                    <AIGapSuggestionCard
-                      key={s.id}
-                      suggestion={s}
-                      state={decision}
-                      onUndo={(id) => dispatch({ type: 'undo', id })}
-                    />
-                  );
-                })}
-              </>
-            )}
-          </aside>
+          <AIGapRail
+            articleRef={articleRef}
+            summary={summaryNode}
+            items={railItems}
+          />
         </div>
       </AppShell>
 


### PR DESCRIPTION
## Summary
- Adds `AIGapRail` primitive: sticky summary slot at top, absolute-positioned paired cards anchored to `[data-suggestion-id]` highlights via `useAnchorPositions` + a top-to-bottom collision walk (12px min gap).
- 1px dotted left-edge connector renders only when a card's pinned Y deviates from its anchor by >24px (signed delta so the line points back toward the anchor in both directions).
- `ArticleBody` now `forwardRef`s + is `position: relative` so the `offsetParent` walk lands on the article container.
- Demo `ReviewPage` + Storybook `KBAIGapsExperience` Interactive drop the legacy visibility gate — all three paired cards render in `state="idle"` from page load. Stickiness moves from the rail container to the summary slot.

## Test plan
- [x] `npx tsc -p packages/kb-ui --noEmit` + `npx tsc -p apps/demo --noEmit` — clean
- [x] `npm run --workspace=packages/kb-ui build` — clean
- [x] `npm run --workspace=packages/kb-ui build-storybook` — clean
- [x] Visual: demo `/ai-optimise/how-to-reset-your-password/review` — summary card sticky, 3 paired idle cards anchored to s1/s2/s3 highlights; scrolling keeps the pairing; dotted connector visible on s3 (delta=115px)
- [x] Visual: Storybook `Patterns / AI Optimisation / AI Gaps` (`frame: interactive`) — same layout
- [x] Click "Review Suggestions" → s1 flips to `active`, s2/s3 stay `idle`, reducer flow preserved