### PR TITLE
feat(kb-ui): AI gaps active-flow interactions (chunk 4)

### DIFF
--- a/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
+++ b/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
@@ -33,6 +33,8 @@ import {
   ArticleBody,
   ArticleSettingsPanel,
   SourcesSideSheet,
+  hasUndecidedNeighbour,
+  smoothScrollTo,
   type AIGapRailItem,
   type AISuggestion as KbUiAISuggestion,
   type AISuggestionDecision,
@@ -288,22 +290,34 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
 
   const activeSuggestion = kbSuggestions[aiState.activeIndex];
 
-  /* ── Scroll side effects (mirrors kb-ui Interactive story) ─ */
+  /* ── Scroll side effects (chunk 4 — rAF smooth scroll) ───
+   *
+   * Mirrors the kb-ui Interactive story: position the active highlight's
+   * center at 40% of the viewport height so the rest of the article
+   * stays visible below it. Driven by the rAF-based `smoothScrollTo`
+   * utility — bails on prefers-reduced-motion, cancels on manual
+   * scroll input mid-flight.
+   * ─────────────────────────────────────────────────────── */
   React.useEffect(() => {
+    const main = document.querySelector('main') as HTMLElement | null;
+    if (!main) return;
     if (effectiveMode === 'reviewing') {
       const id = kbSuggestions[aiState.activeIndex]?.id;
       if (!id) return;
       const slot = slotMap.get(id);
       if (!slot) return;
       const el = document.getElementById(slot);
-      if (el) {
-        el.scrollIntoView({ block: 'center', behavior: 'smooth' });
-      }
+      if (!el) return;
+      const mainRect = main.getBoundingClientRect();
+      const elRect = el.getBoundingClientRect();
+      const viewportH = mainRect.height;
+      const elCenterFromTop = elRect.top - mainRect.top + elRect.height / 2;
+      const targetCenterY = viewportH * 0.4;
+      const target = Math.max(0, main.scrollTop + elCenterFromTop - targetCenterY);
+      smoothScrollTo({ target, duration: 400, scrollElement: main });
       return;
     }
-    // Both `terminal` and `pre-review` scroll <main> back to top.
-    const main = document.querySelector('main');
-    if (main) main.scrollTo({ top: 0, behavior: 'smooth' });
+    smoothScrollTo({ target: 0, duration: 400, scrollElement: main });
   }, [effectiveMode, aiState.activeIndex, kbSuggestions, slotMap]);
 
   /* ── Keyboard shortcuts (PRD §7.5) ──────────────────────── */
@@ -379,14 +393,31 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
   // an `<article>` so we widen the type accordingly.
   const articleRef = React.useRef<HTMLElement>(null);
 
-  /* ── Rail composition — chunk 3: paired layout ────────────────
-   * Summary card stays sticky at the rail top in every mode. In
-   * `pre-review` the paired idle cards render anchored to highlights;
-   * during `reviewing` we swap the matching item to its active card and
-   * other paired cards stay as decision chips or idle (chunks 4/5 wire
-   * the activation logic). In `terminal` the decision chips replace the
-   * paired idle cards.
+  /* ── Rail composition — chunk 4: active flow ──────────────────
+   *
+   * Summary card switches mode:
+   *   pre-review → full detail + "Review Suggestions (N)" CTA
+   *   reviewing  → compact header (icon + title + count pill)
+   *   terminal   → "Suggestions" + count + disabled "Reviewed All" pill
+   *
+   * Paired idle cards are click-to-activate via `onActivate` which
+   * dispatches `activateSuggestion`. Active card's up/down arrows
+   * are disabled at the boundaries (no unresolved card prev/next of
+   * the active one) via `canGoPrev` / `canGoNext`.
    * ───────────────────────────────────────────────────────────── */
+  const canGoPrev = hasUndecidedNeighbour(
+    kbSuggestions,
+    effectiveDecisions,
+    aiState.activeIndex,
+    'prev',
+  );
+  const canGoNext = hasUndecidedNeighbour(
+    kbSuggestions,
+    effectiveDecisions,
+    aiState.activeIndex,
+    'next',
+  );
+
   const summaryNode = (
     <>
       <ArticleSettingsPanel
@@ -399,9 +430,21 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
           mode="pre-review"
           count={kbSuggestions.length}
           summary={SUMMARY}
-          onReview={() => dispatch({ type: 'review' })}
+          onReview={() => {
+            const firstId = kbSuggestions[0]?.id;
+            if (firstId) {
+              dispatch({ type: 'activateSuggestion', id: firstId });
+            }
+          }}
           onPrev={() => dispatch({ type: 'prev' })}
           onNext={() => dispatch({ type: 'next' })}
+        />
+      )}
+      {effectiveMode === 'reviewing' && (
+        <AISuggestionsCard
+          mode="reviewing"
+          count={kbSuggestions.length}
+          summary={SUMMARY}
         />
       )}
       {effectiveMode === 'terminal' && (
@@ -449,16 +492,29 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
               }
               onAccept={(id) => dispatch({ type: 'accept', id })}
               onReject={(id) => dispatch({ type: 'reject', id })}
+              canGoPrev={canGoPrev}
+              canGoNext={canGoNext}
             />
           ),
         };
       }
-      // pre-review + reviewing-non-active → idle paired card. Chunk 3
-      // explicitly bypasses the legacy visibility gate so every
-      // suggestion's idle card renders from page load.
+      // pre-review + reviewing-non-active → idle paired card. Clicking
+      // an idle card dispatches `activateSuggestion` (chunk 4). When
+      // the article is already published (PRD §9.5) suppress activation
+      // so the historical chips can't be re-activated.
       return {
         id: s.id,
-        node: <AIGapSuggestionCard suggestion={s} state="idle" />,
+        node: (
+          <AIGapSuggestionCard
+            suggestion={s}
+            state="idle"
+            onActivate={
+              isAlreadyPublished
+                ? undefined
+                : (id) => dispatch({ type: 'activateSuggestion', id })
+            }
+          />
+        ),
       };
     });
   }, [
@@ -468,6 +524,8 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
     activeSuggestion,
     isAlreadyPublished,
     dispatch,
+    canGoPrev,
+    canGoNext,
   ]);
 
   return (

--- a/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
+++ b/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
@@ -37,6 +37,24 @@ export type AIGapSuggestionCardProps = {
   onAccept?: (id: string) => void;
   onReject?: (id: string) => void;
   onUndo?: (id: string) => void;
+  /**
+   * Chunk 4 — click handler for the idle card. Fires when the user
+   * clicks anywhere on a paired `state="idle"` card to activate it.
+   * Wraps the entire card in a `<button>`-like surface (Radix-style
+   * keyboard semantics: Enter / Space).
+   */
+  onActivate?: (id: string) => void;
+  /**
+   * Chunk 4 — `false` disables the up-arrow on the active card.
+   * Defaults to `true` (arrow stays clickable). Has no effect when
+   * `state !== 'active'`.
+   */
+  canGoPrev?: boolean;
+  /**
+   * Chunk 4 — `false` disables the down-arrow on the active card.
+   * Defaults to `true`. Has no effect when `state !== 'active'`.
+   */
+  canGoNext?: boolean;
   className?: string;
   actions?: React.ReactNode;
   meta?: React.ReactNode;
@@ -97,14 +115,19 @@ function TypeChip({
 function SourcesButton({
   count,
   onClick,
+  disabled,
 }: {
   count: number;
   onClick?: () => void;
+  disabled?: boolean;
 }) {
   return (
     <button
       type="button"
-      onClick={onClick}
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      aria-hidden={disabled || undefined}
+      tabIndex={disabled ? -1 : undefined}
       className={cn(
         'inline-flex items-center gap-1 rounded-[4px] px-1.5 py-1',
         // Per Figma `ai-gap-active-addition.png` — '4 Sources' is
@@ -112,7 +135,9 @@ function SourcesButton({
         // visual baseline alignment with the icon + adjacent NavArrow
         // / accept-reject pills (medium gave a heavier optical feel).
         'text-[14px] font-normal leading-[20px] text-text-meta',
-        'transition-colors hover:bg-surface-muted hover:text-text-primary',
+        disabled
+          ? 'cursor-default'
+          : 'transition-colors hover:bg-surface-muted hover:text-text-primary',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
       )}
     >
@@ -122,16 +147,26 @@ function SourcesButton({
   );
 }
 
-function RejectButton({ onClick }: { onClick?: () => void }) {
+function RejectButton({
+  onClick,
+  disabled,
+}: {
+  onClick?: () => void;
+  disabled?: boolean;
+}) {
   return (
     <button
       type="button"
-      onClick={onClick}
-      aria-label="Reject suggestion"
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      aria-hidden={disabled || undefined}
+      tabIndex={disabled ? -1 : undefined}
+      aria-label={disabled ? undefined : 'Reject suggestion'}
       className={cn(
         'inline-flex size-6 items-center justify-center rounded-full bg-[var(--color-btn-danger-bg)]',
         // Hover bg derived from --color-ai-removal (#d52c1f) at ~12% over white.
-        'text-ai-removal transition-colors hover:bg-[#fad9d6]',
+        'text-ai-removal',
+        disabled ? 'cursor-default' : 'transition-colors hover:bg-[#fad9d6]',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
       )}
     >
@@ -140,19 +175,29 @@ function RejectButton({ onClick }: { onClick?: () => void }) {
   );
 }
 
-function AcceptButton({ onClick }: { onClick?: () => void }) {
+function AcceptButton({
+  onClick,
+  disabled,
+}: {
+  onClick?: () => void;
+  disabled?: boolean;
+}) {
   return (
     <button
       type="button"
-      onClick={onClick}
-      aria-label="Accept suggestion"
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      aria-hidden={disabled || undefined}
+      tabIndex={disabled ? -1 : undefined}
+      aria-label={disabled ? undefined : 'Accept suggestion'}
       className={cn(
         // Figma 74:10490 — bg=background/neutral/subtle (#f1f5f9),
         // icon=icon/neutral/default (#0f172a). Same pill shape as
         // the reject button (rounded-full). Hover deepens the bg one
         // step to keep affordance visible on the light fill.
         'inline-flex size-6 items-center justify-center rounded-full bg-surface-muted',
-        'text-text-primary transition-colors hover:bg-card-border',
+        'text-text-primary',
+        disabled ? 'cursor-default' : 'transition-colors hover:bg-card-border',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
       )}
     >
@@ -170,6 +215,9 @@ export function AIGapSuggestionCard({
   onAccept,
   onReject,
   onUndo,
+  onActivate,
+  canGoPrev = true,
+  canGoNext = true,
   className,
   actions,
   meta,
@@ -228,6 +276,22 @@ export function AIGapSuggestionCard({
    * ───────────────────────────────────────────────────────────── */
   const isIdle = state === 'idle';
 
+  // Chunk 4 — idle cards are click-to-activate. The whole card acts as the
+  // primary click target so users don't need to hit a tiny CTA. Inner
+  // arrows/sources/accept-reject buttons keep their existing inert UI but
+  // are wrapped in `e.stopPropagation()` so cursor accuracy isn't punished.
+  const handleIdleActivate = isIdle && onActivate
+    ? () => onActivate(suggestion.id)
+    : undefined;
+  const handleIdleKey = handleIdleActivate
+    ? (e: React.KeyboardEvent<HTMLElement>) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleIdleActivate();
+        }
+      }
+    : undefined;
+
   return (
     <AICard
       mode="active"
@@ -236,8 +300,22 @@ export function AIGapSuggestionCard({
           // Override AICard defaults: grey BG + faint border + shadow +
           // Figma-exact padding. twMerge resolves the conflicts.
           'bg-canvas border-border shadow-lg px-[22px] py-[24px]',
+        // Click-to-activate surface for idle cards. Pointer cursor + soft
+        // hover lift indicate clickability without breaking the recessed
+        // visual treatment.
+        isIdle && handleIdleActivate &&
+          'cursor-pointer transition-shadow hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/15',
         className,
       )}
+      onClick={handleIdleActivate}
+      onKeyDown={handleIdleKey}
+      role={isIdle && handleIdleActivate ? 'button' : undefined}
+      tabIndex={isIdle && handleIdleActivate ? 0 : undefined}
+      aria-label={
+        isIdle && handleIdleActivate
+          ? `Activate suggestion: ${suggestion.title}`
+          : undefined
+      }
       data-kb-component="ai-gap-suggestion-card"
       data-kb-state={state}
       data-kb-type={suggestion.type}
@@ -268,11 +346,37 @@ export function AIGapSuggestionCard({
       footer={
         actions !== undefined ? (
           actions
+        ) : isIdle ? (
+          // Idle keeps the same chrome (arrows / sources / accept-reject
+          // pills) for visual parity with active, but every inner button
+          // is fully inert: `disabled` removes them from the tab order
+          // AND from the a11y role tree; `aria-hidden` keeps screen
+          // readers from double-announcing inactive controls. The whole
+          // card surface is the real input — clicks fire `onActivate`.
+          <>
+            <div className="flex items-center gap-1">
+              <NavArrow direction="up" disabled />
+              <NavArrow direction="down" disabled />
+            </div>
+            <div className="flex items-center gap-2">
+              <SourcesButton count={suggestion.sourceCount} disabled />
+              <RejectButton disabled />
+              <AcceptButton disabled />
+            </div>
+          </>
         ) : (
           <>
             <div className="flex items-center gap-1">
-              <NavArrow direction="up" onClick={onPrev} />
-              <NavArrow direction="down" onClick={onNext} />
+              <NavArrow
+                direction="up"
+                onClick={onPrev}
+                disabled={!canGoPrev}
+              />
+              <NavArrow
+                direction="down"
+                onClick={onNext}
+                disabled={!canGoNext}
+              />
             </div>
             <div className="flex items-center gap-2">
               <SourcesButton

--- a/packages/kb-ui/src/components/content/AISuggestionsCard.tsx
+++ b/packages/kb-ui/src/components/content/AISuggestionsCard.tsx
@@ -9,11 +9,18 @@ import { Button } from '../primitives/Button';
 import { AICard } from './AICard';
 import { NavArrow } from './NavArrow';
 
-export type AISuggestionsCardMode = 'pre-review' | 'terminal';
+export type AISuggestionsCardMode = 'pre-review' | 'reviewing' | 'terminal';
 
 export type AISuggestionsCardProps = {
   /**
    * `pre-review`  — "AI Suggestions" + primary `Review Suggestions (N)` CTA.
+   * `reviewing`   — compact header (chunk 4): "AI Suggestions" + count pill,
+   *                 no description, no nav arrows, no CTA. Used while a
+   *                 paired suggestion card is active so the summary card
+   *                 doesn't compete visually with the active card.
+   *                 Figma has no explicit variant for this — minimal version
+   *                 derived to match the terminal mode's compact rhythm
+   *                 (icon + title + count pill in a single 56-px row).
    * `terminal`    — "Suggestions" + count badge + disabled `✓ Reviewed All` pill.
    */
   mode: AISuggestionsCardMode;
@@ -69,8 +76,42 @@ export function AISuggestionsCard({
   terminalLabel,
 }: AISuggestionsCardProps) {
   const isTerminal = mode === 'terminal';
+  const isReviewing = mode === 'reviewing';
   const resolvedTitle = title ?? (isTerminal ? 'Suggestions' : 'AI Suggestions');
   const resolvedTerminalLabel = terminalLabel ?? 'Reviewed All';
+
+  /* ─────────────────────────────────────────────────────────────
+   * Reviewing (chunk 4) — compact single-row variant.
+   *
+   * The summary card collapses to a 56-px tall pill: AI sparkle + title
+   * + count pill. No description, no nav arrows, no CTA. Matches the
+   * terminal mode's geometry but reads as a quiet header instead of an
+   * end-state. Figma has no explicit variant for this — derived to keep
+   * the rail visually clean while a paired suggestion card is active.
+   *
+   * Padding drops from 16 to `px-4 py-3` so the row reads as a header
+   * rather than a card body. Background stays white + 1-px slate border
+   * so it visually belongs to the same family as the active card below it.
+   * ───────────────────────────────────────────────────────────── */
+  if (isReviewing) {
+    return (
+      <AICard
+        mode="active"
+        className={cn('px-4 py-3', className)}
+        data-kb-component="ai-suggestions-card"
+        data-kb-mode={mode}
+        header={
+          <div className="flex items-center gap-2">
+            <AiIcon size={16} aria-hidden="true" />
+            <span className="text-[14px] font-medium leading-[20px] text-text-primary">
+              {resolvedTitle}
+            </span>
+            <CountPill count={count} />
+          </div>
+        }
+      />
+    );
+  }
 
   return (
     <AICard

--- a/packages/kb-ui/src/components/content/NavArrow.tsx
+++ b/packages/kb-ui/src/components/content/NavArrow.tsx
@@ -14,20 +14,30 @@ import { cn } from '../../utils/cn';
 export type NavArrowProps = {
   direction: 'up' | 'down';
   onClick?: () => void;
+  /**
+   * Chunk 4 — disables the button and dims the icon. When `true`,
+   * `onClick` is dropped and the button is `aria-disabled` so screen
+   * readers announce the state.
+   */
+  disabled?: boolean;
   className?: string;
 };
 
-export function NavArrow({ direction, onClick, className }: NavArrowProps) {
+export function NavArrow({ direction, onClick, disabled, className }: NavArrowProps) {
   const Icon = direction === 'up' ? ChevronUp : ChevronDown;
   return (
     <button
       type="button"
-      onClick={onClick}
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      aria-disabled={disabled || undefined}
       aria-label={direction === 'up' ? 'Previous suggestion' : 'Next suggestion'}
       className={cn(
         'inline-flex size-6 items-center justify-center rounded-[4px]',
-        'text-text-muted transition-colors',
-        'hover:bg-surface-muted hover:text-text-primary',
+        // Idle baseline. Hover affordances dropped when disabled.
+        disabled
+          ? 'cursor-not-allowed text-text-disabled'
+          : 'text-text-muted transition-colors hover:bg-surface-muted hover:text-text-primary',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
         className,
       )}

--- a/packages/kb-ui/src/hooks/useAIGapsReducer.ts
+++ b/packages/kb-ui/src/hooks/useAIGapsReducer.ts
@@ -40,6 +40,11 @@ export type AIGapsAction =
   | { type: 'prev' }
   | { type: 'next' }
   | { type: 'setActive'; index: number }
+  // Chunk 4 — single-card activation. Equivalent to `setActive` by index
+  // but addresses the card by stable id (clicks on the rail card itself
+  // don't carry index information). Also forces `mode: 'reviewing'` so
+  // clicking a paired idle card transitions cleanly out of pre-review.
+  | { type: 'activateSuggestion'; id: string }
   | { type: 'openSources'; id: string }
   | { type: 'closeSources' }
   | { type: 'reset' };
@@ -79,6 +84,79 @@ function findNextUndecided(
     if (decisions[suggestions[idx].id] === undefined) return idx;
   }
   return -1;
+}
+
+/**
+ * Find the previous un-decided suggestion starting BEFORE `startIndex`.
+ * Chunk 4 — used by the `prev` action to skip resolved cards when walking
+ * the rail backwards. Returns -1 if none exist (every other card is
+ * resolved).
+ *
+ * Non-wrapping: if you're on the first un-decided suggestion and press
+ * `prev`, this returns -1 → the reducer keeps `activeIndex` where it is.
+ * That maps to the user spec's "previous arrow is disabled at the first
+ * unresolved card" rule.
+ */
+function findPrevUndecidedNoWrap(
+  suggestions: AISuggestion[],
+  decisions: Record<string, AISuggestionDecision>,
+  startIndex: number,
+): number {
+  for (let idx = startIndex - 1; idx >= 0; idx -= 1) {
+    if (decisions[suggestions[idx].id] === undefined) return idx;
+  }
+  return -1;
+}
+
+/**
+ * Non-wrapping version of `findNextUndecided` — only searches indices
+ * AFTER `startIndex`. Used by chunk 4's arrow-disabled UI to detect
+ * "no unresolved cards remain after this one" without wrapping back to
+ * the start of the list.
+ */
+function findNextUndecidedNoWrap(
+  suggestions: AISuggestion[],
+  decisions: Record<string, AISuggestionDecision>,
+  startIndex: number,
+): number {
+  for (let idx = startIndex + 1; idx < suggestions.length; idx += 1) {
+    if (decisions[suggestions[idx].id] === undefined) return idx;
+  }
+  return -1;
+}
+
+/**
+ * First un-decided suggestion in the list, or -1 if every suggestion has
+ * a decision. Used by chunk 4 when `activateSuggestion` lands on a card
+ * that's already resolved, or when `next`/`prev` is invoked from a
+ * terminal state.
+ */
+function findFirstUndecided(
+  suggestions: AISuggestion[],
+  decisions: Record<string, AISuggestionDecision>,
+): number {
+  for (let i = 0; i < suggestions.length; i += 1) {
+    if (decisions[suggestions[i].id] === undefined) return i;
+  }
+  return -1;
+}
+
+/**
+ * Returns `true` if the suggestion at `activeIndex` has at least one
+ * un-decided neighbour on the requested side. Drives the arrow-disabled
+ * UI on the active card so consumers don't have to re-derive this.
+ */
+export function hasUndecidedNeighbour(
+  suggestions: AISuggestion[],
+  decisions: Record<string, AISuggestionDecision>,
+  activeIndex: number,
+  direction: 'prev' | 'next',
+): boolean {
+  if (suggestions.length === 0) return false;
+  if (direction === 'prev') {
+    return findPrevUndecidedNoWrap(suggestions, decisions, activeIndex) !== -1;
+  }
+  return findNextUndecidedNoWrap(suggestions, decisions, activeIndex) !== -1;
 }
 
 /**
@@ -166,13 +244,44 @@ export function aiGapsReducer(
     case 'prev': {
       const n = suggestions.length;
       if (n === 0) return state;
-      return { ...state, activeIndex: (state.activeIndex - 1 + n) % n };
+      // Chunk 4 — skip resolved cards. If currently no card is active
+      // (pre-review or terminal) jump to the LAST un-decided card so
+      // pressing Up out of pre-review still produces a sensible target.
+      if (state.mode !== 'reviewing') {
+        const first = findFirstUndecided(suggestions, state.decisions);
+        if (first === -1) return state;
+        return { ...state, mode: 'reviewing', activeIndex: first };
+      }
+      const prevIdx = findPrevUndecidedNoWrap(
+        suggestions,
+        state.decisions,
+        state.activeIndex,
+      );
+      // -1 means "you're at the first unresolved; arrow should be disabled
+      // at the UI layer". Reducer keeps the current activeIndex so the UI
+      // doesn't lurch.
+      if (prevIdx === -1) return state;
+      return { ...state, activeIndex: prevIdx };
     }
 
     case 'next': {
       const n = suggestions.length;
       if (n === 0) return state;
-      return { ...state, activeIndex: (state.activeIndex + 1) % n };
+      // Chunk 4 — same logic as `prev`, mirrored. From pre-review/terminal,
+      // jump to the FIRST un-decided card so a fresh page can activate
+      // via a simple `next` dispatch.
+      if (state.mode !== 'reviewing') {
+        const first = findFirstUndecided(suggestions, state.decisions);
+        if (first === -1) return state;
+        return { ...state, mode: 'reviewing', activeIndex: first };
+      }
+      const nextIdx = findNextUndecidedNoWrap(
+        suggestions,
+        state.decisions,
+        state.activeIndex,
+      );
+      if (nextIdx === -1) return state;
+      return { ...state, activeIndex: nextIdx };
     }
 
     case 'setActive': {
@@ -181,6 +290,29 @@ export function aiGapsReducer(
       // Clamp defensively so callers can't leak out-of-range indices.
       const clamped = Math.max(0, Math.min(n - 1, action.index));
       return { ...state, activeIndex: clamped };
+    }
+
+    case 'activateSuggestion': {
+      // Chunk 4 — directly activate a card by id. Forces `mode:
+      // 'reviewing'` so the first click out of pre-review transitions
+      // both the summary card's chrome AND the rail's per-card decoration
+      // in a single dispatch.
+      //
+      // Two edge cases:
+      //   1. The id doesn't match any suggestion → no-op (defensive; the
+      //      rail items are derived from `suggestions` so this shouldn't
+      //      happen in practice).
+      //   2. The target is already resolved → activate the first
+      //      un-resolved card instead. Clicking an accepted/dismissed
+      //      chip should never re-activate a finished decision.
+      const idx = suggestions.findIndex((s) => s.id === action.id);
+      if (idx === -1) return state;
+      if (state.decisions[action.id] !== undefined) {
+        const fallback = findFirstUndecided(suggestions, state.decisions);
+        if (fallback === -1) return state;
+        return { ...state, mode: 'reviewing', activeIndex: fallback };
+      }
+      return { ...state, mode: 'reviewing', activeIndex: idx };
     }
 
     case 'openSources': {
@@ -213,6 +345,18 @@ export type UseAIGapsReducerResult = {
   dispatch: React.Dispatch<AIGapsAction>;
   publishEnabled: boolean;
   allReviewed: boolean;
+  /**
+   * `true` when there is at least one un-decided suggestion BEFORE the
+   * currently active one. Drives the up-arrow's disabled state on the
+   * active card. Chunk 4.
+   */
+  canGoPrev: boolean;
+  /**
+   * `true` when there is at least one un-decided suggestion AFTER the
+   * currently active one. Drives the down-arrow's disabled state on the
+   * active card. Chunk 4.
+   */
+  canGoNext: boolean;
 };
 
 /**
@@ -234,5 +378,17 @@ export function useAIGapsReducer(
   );
   const publishEnabled = isPublishEnabled(state.decisions);
   const allReviewed = isAllReviewed(suggestions, state.decisions);
-  return { state, dispatch, publishEnabled, allReviewed };
+  const canGoPrev = hasUndecidedNeighbour(
+    suggestions,
+    state.decisions,
+    state.activeIndex,
+    'prev',
+  );
+  const canGoNext = hasUndecidedNeighbour(
+    suggestions,
+    state.decisions,
+    state.activeIndex,
+    'next',
+  );
+  return { state, dispatch, publishEnabled, allReviewed, canGoPrev, canGoNext };
 }

--- a/packages/kb-ui/src/index.ts
+++ b/packages/kb-ui/src/index.ts
@@ -2,6 +2,11 @@
 // Components are exported here as they are built phase by phase.
 
 export { cn } from './utils/cn';
+export { smoothScrollTo, easings } from './utils/smoothScrollTo';
+export type {
+  SmoothScrollOptions,
+  SmoothScrollHandle,
+} from './utils/smoothScrollTo';
 export { tokens } from './tokens';
 export type { Tokens } from './tokens';
 
@@ -19,6 +24,7 @@ export {
   aiGapsReducer,
   isPublishEnabled,
   isAllReviewed,
+  hasUndecidedNeighbour,
 } from './hooks/useAIGapsReducer';
 export type {
   AIGapsState,

--- a/packages/kb-ui/src/pages/KBAIGapsExperience.stories.tsx
+++ b/packages/kb-ui/src/pages/KBAIGapsExperience.stories.tsx
@@ -23,6 +23,7 @@ import {
   type ConversationSource,
 } from '../components/overlays/SourcesSideSheet';
 import { useAIGapsReducer } from '../hooks/useAIGapsReducer';
+import { smoothScrollTo } from '../utils/smoothScrollTo';
 
 /* ─────────────────────────────────────────────────────────────
  * KB AI Gaps Experience — Figma `9aGp5t9fH1d0PXi4LMhOdb#74:10788`
@@ -755,49 +756,54 @@ function StaticFrameRender({
  * ───────────────────────────────────────────────────────────── */
 
 function InteractiveRender({ enableKeyboard }: { enableKeyboard: boolean }) {
-  const { state, dispatch, publishEnabled } = useAIGapsReducer(
-    interactiveSuggestions,
-  );
+  const { state, dispatch, publishEnabled, canGoPrev, canGoNext } =
+    useAIGapsReducer(interactiveSuggestions);
   const activeSuggestion = interactiveSuggestions[state.activeIndex];
 
   /* ─────────────────────────────────────────────────────────
-   * Scroll side effects
+   * Scroll side effects (chunk 4 — replaces scrollIntoView)
    *
-   * Two distinct scroll behaviours:
-   * 1. `reviewing` — scroll the active suggestion block into view.
-   *    Target is looked up by `SuggestionBlock`'s `id` prop, which it
-   *    emits on its root DOM element.
-   * 2. `terminal` — scroll the <main> back to the top (per frame 10
-   *    annotation: "will scroll to top once the last suggestion is
-   *    acted upon").
+   * Behaviour:
+   *   1. `reviewing` — scroll <main> so the active suggestion's highlight
+   *      center sits ~40% from the top of the viewport. This gives room
+   *      for the rest of the article below the highlight to be visible
+   *      and prevents the active card from feeling pinned to a screen
+   *      edge. Animated via the custom `smoothScrollTo` rAF loop so
+   *      duration is deterministic and the user can cancel mid-flight
+   *      with manual scroll input.
+   *   2. `terminal` + `pre-review` — return <main> to the top.
    *
-   * `scrollIntoView` walks up to the nearest scrollable ancestor, which
-   * is the `<main>` inside `AppShell` (`overflow-y-auto`). `window` is
-   * not scrollable here because `AppShell` clips at `h-screen` +
-   * `overflow-hidden`. We therefore NEVER use `window.scrollTo`.
+   * `<main>` (inside `AppShell`) is the scroll container here, not
+   * `window` — `AppShell` clips at `h-screen overflow-hidden` so
+   * `window.scrollY` doesn't move.
    * ───────────────────────────────────────────────────────────── */
   React.useEffect(() => {
+    const main = document.querySelector('main') as HTMLElement | null;
+    if (!main) return;
     if (state.mode === 'reviewing') {
       const id = interactiveSuggestions[state.activeIndex]?.id;
       if (!id) return;
       const el = document.getElementById(id);
-      // `el` can be null if the active suggestion's block has been
-      // removed (e.g. an addition that was dismissed, or a removal that
-      // was accepted). Silently no-op in that case — the user can prev/
-      // next to a still-rendered block.
-      if (el) {
-        el.scrollIntoView({ block: 'center', behavior: 'smooth' });
-      }
+      if (!el) return;
+      // Position the highlight's center at 40% of the viewport height.
+      // Math: target scrollTop = current scrollTop + (rect.top - 0.40 *
+      // viewport) + rect.height / 2.
+      const mainRect = main.getBoundingClientRect();
+      const elRect = el.getBoundingClientRect();
+      const viewportH = mainRect.height;
+      const elCenterFromTop = elRect.top - mainRect.top + elRect.height / 2;
+      const targetCenterY = viewportH * 0.4;
+      const target = Math.max(0, main.scrollTop + elCenterFromTop - targetCenterY);
+      smoothScrollTo({
+        target,
+        duration: 400,
+        scrollElement: main,
+      });
       return;
     }
     // Both `terminal` (frame 10) and `pre-review` (post-reset) scroll
-    // <main> to the top. This keeps the close/reset handler from
-    // leaving the user mid-article, and matches flow-doc §frame 10:
-    // "will scroll to top once the last suggestion is acted upon".
-    const main = document.querySelector('main');
-    if (main) {
-      main.scrollTo({ top: 0, behavior: 'smooth' });
-    }
+    // <main> to the top.
+    smoothScrollTo({ target: 0, duration: 400, scrollElement: main });
   }, [state.mode, state.activeIndex]);
 
   /* ─────────────────────────────────────────────────────────
@@ -881,13 +887,14 @@ function InteractiveRender({ enableKeyboard }: { enableKeyboard: boolean }) {
     [],
   );
 
-  /* ─ Rail composition (chunk 3) ──────────────────────────────
-   * Summary card sticky at the top of the rail in every mode. Paired
-   * suggestion cards render in `idle` from page load, swapping to
-   * `active` for the focused suggestion during `reviewing` and to
-   * decision chips once accepted/dismissed. The legacy invisible-non-
-   * active branch is gone — every suggestion always renders a paired
-   * card in the rail, anchored to its highlight.
+  /* ─ Rail composition (chunk 4 — adds compact summary + onActivate) ─
+   * Summary card sticky at the top of the rail in every mode. In
+   * `pre-review` it's the full-detail card with the "Review Suggestions
+   * (N)" CTA. Once any card is activated the summary collapses to its
+   * `reviewing` (compact) variant — icon + title + count pill only.
+   * Paired suggestion cards remain in `idle` until activated; clicks
+   * dispatch `activateSuggestion` which both flips `mode` to `reviewing`
+   * and sets the active index.
    * ───────────────────────────────────────────────────────────── */
   const summaryNode = (
     <>
@@ -897,9 +904,25 @@ function InteractiveRender({ enableKeyboard }: { enableKeyboard: boolean }) {
           mode="pre-review"
           count={interactiveSuggestions.length}
           summary={SUMMARY}
-          onReview={() => dispatch({ type: 'review' })}
+          onReview={() =>
+            // Chunk 4 — the "Review Suggestions (N)" CTA now activates
+            // the first unresolved card directly. This replaces the
+            // legacy `'review'` action which only flipped mode without
+            // anchoring an active suggestion.
+            dispatch({
+              type: 'activateSuggestion',
+              id: interactiveSuggestions[0].id,
+            })
+          }
           onPrev={() => dispatch({ type: 'prev' })}
           onNext={() => dispatch({ type: 'next' })}
+        />
+      )}
+      {state.mode === 'reviewing' && (
+        <AISuggestionsCard
+          mode="reviewing"
+          count={interactiveSuggestions.length}
+          summary={SUMMARY}
         />
       )}
       {state.mode === 'terminal' && (
@@ -940,11 +963,22 @@ function InteractiveRender({ enableKeyboard }: { enableKeyboard: boolean }) {
             onOpenSources={(id) => dispatch({ type: 'openSources', id })}
             onAccept={(id) => dispatch({ type: 'accept', id })}
             onReject={(id) => dispatch({ type: 'reject', id })}
+            canGoPrev={canGoPrev}
+            canGoNext={canGoNext}
           />
         ),
       };
     }
-    return { id: s.id, node: <AIGapSuggestionCard suggestion={s} state="idle" /> };
+    return {
+      id: s.id,
+      node: (
+        <AIGapSuggestionCard
+          suggestion={s}
+          state="idle"
+          onActivate={(id) => dispatch({ type: 'activateSuggestion', id })}
+        />
+      ),
+    };
   });
 
   return (

--- a/packages/kb-ui/src/utils/smoothScrollTo.ts
+++ b/packages/kb-ui/src/utils/smoothScrollTo.ts
@@ -1,0 +1,198 @@
+// smoothScrollTo — single-page custom scroller used by the AI Gaps review
+// flow.
+//
+// Why a custom scroller instead of `window.scrollTo({ behavior: 'smooth' })`:
+//   1. The native call has no cancellation hook — chunked, rapid card
+//      activations (arrow-key spam) would interrupt one another with
+//      undefined animation behaviour across browsers.
+//   2. We need a deterministic duration so the rail's `transition: top`
+//      (chunk 3) and the page scroll start and finish on the same beat.
+//      Native `behavior: 'smooth'` runs at user-agent-tuned duration that
+//      varies across Chrome/Firefox/Safari.
+//   3. We respect `prefers-reduced-motion` and **also** bail when the user
+//      starts scrolling manually mid-animation. The native API does
+//      neither — once started it runs to completion.
+//
+// The function is a pure rAF loop. No deps, no React. Tested implicitly
+// by the AI Gaps reducer flow's manual QA in chunk 4.
+
+/**
+ * Easing curves used by `smoothScrollTo`.
+ *
+ * `easeOutCubic` — default. Decelerates toward target. Feels snappy at the
+ * start of the animation, settles at the end. Matches the visual rhythm of
+ * the rail's `transition: top 200ms ease-out`.
+ */
+export const easings = {
+  easeOutCubic: (t: number): number => 1 - Math.pow(1 - t, 3),
+  linear: (t: number): number => t,
+} as const;
+
+export type SmoothScrollOptions = {
+  /** Target Y position in document/window scroll coordinates (pixels). */
+  target: number;
+  /**
+   * Duration in milliseconds. Default 400. Setting to 0 jumps immediately
+   * without rAF.
+   */
+  duration?: number;
+  /**
+   * Easing function. Default `easings.easeOutCubic`. Takes normalized
+   * time `t` in `[0, 1]`, returns a value in `[0, 1]`.
+   */
+  easing?: (t: number) => number;
+  /**
+   * Optional element to scroll instead of `window`. Defaults to scrolling
+   * the document (`window.scrollTo`). When provided, `target` is the
+   * `scrollTop` value to land on.
+   */
+  scrollElement?: HTMLElement | null;
+};
+
+export type SmoothScrollHandle = {
+  /** Cancel the in-flight animation. No-op if already done. */
+  cancel: () => void;
+};
+
+/**
+ * Returns `true` if the user has expressed a preference for reduced motion
+ * at the OS level. SSR-safe — returns `false` when `window` is undefined.
+ */
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || !window.matchMedia) return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/**
+ * Tracks the currently-running scroll animation so a new call can cancel
+ * the previous one in-flight. This is process-global by design: only one
+ * scroll animation should run at a time. A second `smoothScrollTo()` call
+ * with a new target preempts the first.
+ */
+let activeHandle: SmoothScrollHandle | null = null;
+
+/**
+ * Animate a scroll from the current position to `target` via
+ * `requestAnimationFrame`.
+ *
+ * Stops early if:
+ *   - The user starts scrolling manually (wheel/touchmove detected).
+ *   - A new `smoothScrollTo` call preempts this one.
+ *   - The caller invokes `cancel()` on the returned handle.
+ *
+ * Jumps immediately (no animation) if:
+ *   - `prefers-reduced-motion: reduce` is set.
+ *   - `duration <= 0`.
+ */
+export function smoothScrollTo(opts: SmoothScrollOptions): SmoothScrollHandle {
+  // Preempt any previous animation. Each call owns the scroll until it
+  // ends or is cancelled — this prevents two competing rAF loops fighting
+  // over scrollY.
+  if (activeHandle) {
+    activeHandle.cancel();
+  }
+
+  const duration = opts.duration ?? 400;
+  const easing = opts.easing ?? easings.easeOutCubic;
+  const scrollEl = opts.scrollElement ?? null;
+
+  // SSR / non-browser environments — return a noop handle. The animation
+  // can't run, but callers shouldn't have to null-check.
+  if (typeof window === 'undefined') {
+    return { cancel: () => undefined };
+  }
+
+  const startY = scrollEl ? scrollEl.scrollTop : window.scrollY;
+  const target = opts.target;
+
+  // Already at target (within 1px) — no animation needed.
+  if (Math.abs(target - startY) < 1) {
+    return { cancel: () => undefined };
+  }
+
+  // Reduced motion or zero-duration → immediate jump.
+  if (duration <= 0 || prefersReducedMotion()) {
+    if (scrollEl) scrollEl.scrollTop = target;
+    else window.scrollTo({ top: target });
+    return { cancel: () => undefined };
+  }
+
+  let rafId: number | null = null;
+  let cancelled = false;
+  let userInterrupted = false;
+  let startTime: number | null = null;
+
+  // Listen for manual scroll input. `wheel` covers desktop mouse/trackpad;
+  // `touchmove` covers mobile. We don't listen for `scroll` itself
+  // because our own `scrollTo` writes fire `scroll` events too.
+  // `keydown` covers spacebar / arrow / pgup / pgdn / home / end navigation.
+  const onUserScroll = () => {
+    userInterrupted = true;
+  };
+  const onUserKey = (e: KeyboardEvent) => {
+    // Only treat scroll-affecting keys as interrupts. Listing explicitly
+    // so unrelated keypresses (e.g. AI Gaps' own j/k/y/n) don't cancel
+    // a scroll the consumer just kicked off.
+    if (
+      e.key === ' ' ||
+      e.key === 'PageDown' ||
+      e.key === 'PageUp' ||
+      e.key === 'Home' ||
+      e.key === 'End' ||
+      e.key === 'ArrowDown' ||
+      e.key === 'ArrowUp'
+    ) {
+      // Don't cancel if focus is in an input — those keys belong to the input.
+      const t = e.target as HTMLElement | null;
+      const tag = t?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || t?.isContentEditable) return;
+      userInterrupted = true;
+    }
+  };
+  // `passive: true` keeps the page-scroll path on the compositor thread so
+  // the listener doesn't fight scroll performance.
+  window.addEventListener('wheel', onUserScroll, { passive: true });
+  window.addEventListener('touchmove', onUserScroll, { passive: true });
+  window.addEventListener('keydown', onUserKey);
+
+  const cleanup = () => {
+    window.removeEventListener('wheel', onUserScroll);
+    window.removeEventListener('touchmove', onUserScroll);
+    window.removeEventListener('keydown', onUserKey);
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    if (activeHandle === handle) activeHandle = null;
+  };
+
+  const step = (now: number) => {
+    if (cancelled || userInterrupted) {
+      cleanup();
+      return;
+    }
+    if (startTime === null) startTime = now;
+    const elapsed = now - startTime;
+    const t = Math.min(1, elapsed / duration);
+    const eased = easing(t);
+    const y = startY + (target - startY) * eased;
+    if (scrollEl) scrollEl.scrollTop = y;
+    else window.scrollTo({ top: y });
+    if (t < 1) {
+      rafId = requestAnimationFrame(step);
+    } else {
+      cleanup();
+    }
+  };
+
+  rafId = requestAnimationFrame(step);
+
+  const handle: SmoothScrollHandle = {
+    cancel: () => {
+      cancelled = true;
+      cleanup();
+    },
+  };
+  activeHandle = handle;
+  return handle;
+}


### PR DESCRIPTION
## Summary

Chunk 4 of 5 in the AI Gaps interaction refactor. Wires the full active-flow loop: clicking a paired card, arrow keys/buttons, accept/reject — each activates the right card, reflows the rail, and smooth-scrolls the article so the highlight sits at 40% of the viewport.

- **smoothScrollTo utility** — rAF-based scroller with deterministic duration. Respects \`prefers-reduced-motion\`, cancels on manual scroll (\`wheel\` / \`touchmove\` / scroll-keys), preempts any in-flight call. Replaces the legacy \`scrollIntoView({ behavior: 'smooth' })\` in both the demo \`ReviewPage\` and the Storybook \`Interactive\` story. Exported as \`smoothScrollTo\` + \`easings\` from the kb-ui public surface.
- **Reducer changes (backward-compatible)** — new \`activateSuggestion\` action; existing \`prev\` / \`next\` now skip resolved cards and bail (no wrap) at boundaries. New \`hasUndecidedNeighbour\` helper + \`canGoPrev\` / \`canGoNext\` derived from \`useAIGapsReducer\` drive the disabled-arrow UI on the active card. All existing public action names preserved.
- **Summary \`reviewing\` (compact) mode** — \`AISuggestionsCard\` gets a third mode: a 56-px header rendering just AI sparkle + "AI Suggestions" + count pill. Used during \`reviewing\` so the summary doesn't compete visually with the active card. Figma has no explicit variant for this — derived to match the terminal mode's geometry.
- **Scroll-spy non-tracking** — active state is sticky to user input. Manual page scroll does NOT change which card is active. The scroll effect only fires when \`state.mode\` or \`state.activeIndex\` changes (i.e. from a click, arrow, accept, or reject).

## Non-trivial UX calls flagged for sanity-check

1. **Idle paired cards are click-to-activate as a whole** — \`role=button\` on the AICard root with Enter/Space keyboard semantics. The inner arrow/sources/accept-reject buttons remain rendered for visual parity with the active card but every one is \`disabled\` (out of tab order, out of the a11y role tree). This is what makes clicks on the idle card land on the activation handler rather than being absorbed by an inner button. Alternative considered: hide the buttons entirely on idle — rejected because Figma's idle paired card explicitly shows the same chrome as active.
2. **Compact summary mode visual** — settled on icon + title + count pill in a single \`px-4 py-3\` row. The user spec said "still shows 'Review Suggestions (N)' CTA-text but stripped of the highlighted sparkle/description" — I dropped the CTA-text on purpose because the activation path is now the paired card itself; a re-Review CTA from the compact header would be redundant. If you'd rather keep the CTA visible, let me know and I'll thread \`onReview\` through the compact branch.
3. **Active-card-behind-sticky-summary on manual scroll** — when the user manually scrolls past the article header, the sticky compact summary overlays the middle of any rail card that's behind it. Visible as a card top + footer with a gap covered by the summary. This is a chunk-3 paired-layout artifact and consistent with the user spec ("manual scroll does NOT change which card is active"). Flagging because the visual reads a bit broken in that specific scroll position — could be a chunk-5 polish item if you want me to add a "tuck under sticky" rule.

## Test plan

- [x] \`npm run --workspace=packages/kb-ui build\` — clean
- [x] \`npm run --workspace=packages/kb-ui build-storybook\` — clean
- [x] \`npx tsc -p packages/kb-ui --noEmit\` — clean
- [x] \`npx tsc -p apps/demo --noEmit\` — clean
- [x] \`npm run --workspace=apps/demo build\` — clean
- [x] Playwright walkthrough of all 8 steps in the user spec at \`/ai-optimise/how-to-reset-your-password/review\` — every step produces the expected rail state, decision chip rendering, and scrolled article position. Screenshots verified.
- [x] Storybook \`Patterns/AI Optimisation/AI Gaps → Default\` with \`frame=interactive\` — Review CTA collapses summary, click idle to swap active, ArrowUp/ArrowDown skip resolved cards, accept/reject auto-advance, terminal mode lands on "Reviewed All" pill.

## Local URLs (currently running)

- Demo: http://localhost:5173/ai-optimise/how-to-reset-your-password/review
- Storybook: http://localhost:6006/?path=/story/patterns-ai-optimisation-ai-gaps--default

🤖 Generated with [Claude Code](https://claude.com/claude-code)