### PR TITLE
feat(kb-ui): AI gaps counter + position + terminal polish (chunk 5)

### DIFF
--- a/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
+++ b/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
@@ -288,7 +288,16 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
     ? deriveHistoricalDecisions(storeSuggestions)
     : aiState.decisions;
 
-  const activeSuggestion = kbSuggestions[aiState.activeIndex];
+  // `aiState.activeIndex` can be -1 (chunk 5 sentinel for "no active
+  // card" after strict-forward auto-advance runs off the end of the
+  // list). `Array[-1]` is `undefined` so downstream `?.id` checks no-op.
+  const activeSuggestion =
+    aiState.activeIndex >= 0 ? kbSuggestions[aiState.activeIndex] : undefined;
+
+  // Chunk 5 — remaining unresolved count drives the compact reviewing
+  // summary's count pill.
+  const resolvedCount = Object.keys(effectiveDecisions).length;
+  const remaining = kbSuggestions.length - resolvedCount;
 
   /* ── Scroll side effects (chunk 4 — rAF smooth scroll) ───
    *
@@ -339,7 +348,6 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
         return;
       }
       const activeId = activeSuggestion?.id;
-      if (!activeId) return;
       switch (e.key) {
         case 'j':
         case 'ArrowDown':
@@ -353,10 +361,15 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
           break;
         case 'y':
         case 'Enter':
+          // Chunk 5 — `activeIndex = -1` (no active card) means accept
+          // is a no-op. The user must navigate or click to focus a card
+          // before deciding.
+          if (!activeId) return;
           e.preventDefault();
           dispatch({ type: 'accept', id: activeId });
           break;
         case 'n':
+          if (!activeId) return;
           e.preventDefault();
           dispatch({ type: 'reject', id: activeId });
           break;
@@ -443,7 +456,7 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
       {effectiveMode === 'reviewing' && (
         <AISuggestionsCard
           mode="reviewing"
-          count={kbSuggestions.length}
+          count={remaining}
           summary={SUMMARY}
         />
       )}
@@ -460,7 +473,7 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
   );
 
   const railItems = React.useMemo<AIGapRailItem[]>(() => {
-    return kbSuggestions.map((s) => {
+    return kbSuggestions.map((s, i) => {
       const decision = effectiveDecisions[s.id];
       if (decision) {
         return {
@@ -494,6 +507,10 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
               onReject={(id) => dispatch({ type: 'reject', id })}
               canGoPrev={canGoPrev}
               canGoNext={canGoNext}
+              // Chunk 5 — 1-based position in the ORIGINAL list so the
+              // user always sees "I'm on N of M" regardless of which
+              // earlier cards have been resolved.
+              position={{ index: i + 1, total: kbSuggestions.length }}
             />
           ),
         };

--- a/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
+++ b/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
@@ -60,6 +60,19 @@ export type AIGapSuggestionCardProps = {
   meta?: React.ReactNode;
   decisionLabels?: { accepted: string; dismissed: string };
   typeRegistry?: Record<string, SuggestionTypeMeta>;
+  /**
+   * Chunk 5 — optional `X / Y` position indicator rendered on the
+   * `active` card next to the type chip. `index` is 1-based (the
+   * user-facing position of this card in the ORIGINAL suggestion
+   * list, NOT the unresolved-only subset). `total` is the full count.
+   * Suppressed on `idle` / `accepted` / `dismissed` states.
+   *
+   * Figma has no explicit spec for this indicator at chunk 5 lock;
+   * the inline rendering uses `text-12 font-medium text-text-muted`
+   * to read as a quiet secondary label that doesn't compete with
+   * the type chip's color treatment. Flagged in the PR description.
+   */
+  position?: { index: number; total: number };
 };
 
 /* ─────────────────────────────────────────────────────────────
@@ -223,6 +236,7 @@ export function AIGapSuggestionCard({
   meta,
   decisionLabels,
   typeRegistry,
+  position,
 }: AIGapSuggestionCardProps) {
   const resolvedRegistry = typeRegistry ?? DEFAULT_GAP_TYPES;
   if (state === 'accepted' || state === 'dismissed') {
@@ -319,7 +333,22 @@ export function AIGapSuggestionCard({
       data-kb-component="ai-gap-suggestion-card"
       data-kb-state={state}
       data-kb-type={suggestion.type}
-      header={<TypeChip type={suggestion.type} registry={resolvedRegistry} />}
+      header={
+        state === 'active' && position ? (
+          <div className="flex w-full items-center justify-between gap-2">
+            <TypeChip type={suggestion.type} registry={resolvedRegistry} />
+            <span
+              data-kb-part="ai-gap-position"
+              aria-label={`Suggestion ${position.index} of ${position.total}`}
+              className="text-[12px] font-medium leading-[18px] text-text-muted tabular-nums"
+            >
+              {position.index} / {position.total}
+            </span>
+          </div>
+        ) : (
+          <TypeChip type={suggestion.type} registry={resolvedRegistry} />
+        )
+      }
       body={
         <>
           {meta}

--- a/packages/kb-ui/src/components/content/AISuggestionsCard.tsx
+++ b/packages/kb-ui/src/components/content/AISuggestionsCard.tsx
@@ -24,6 +24,13 @@ export type AISuggestionsCardProps = {
    * `terminal`    — "Suggestions" + count badge + disabled `✓ Reviewed All` pill.
    */
   mode: AISuggestionsCardMode;
+  /**
+   * Number to display in the count badge / CTA text. Semantics differ
+   * by mode (consumer-decided, not derived here):
+   *   - `pre-review` → total suggestions (kickoff CTA "Review Suggestions (N)")
+   *   - `reviewing`  → REMAINING unresolved (`total - accepted - dismissed`)
+   *   - `terminal`   → total suggestions (the "I reviewed N" summary)
+   */
   count: number;
   summary: string;
   onReview?: () => void;
@@ -97,7 +104,19 @@ export function AISuggestionsCard({
     return (
       <AICard
         mode="active"
-        className={cn('px-4 py-3', className)}
+        className={cn(
+          'px-4 py-3',
+          // Chunk 5 — when the rail's `sticky` wrapper pins this compact
+          // header at the top, scrolled cards behind it can overlap the
+          // bottom edge. AICard already provides an opaque white bg and a
+          // 1px slate border; add a subtle drop shadow so the overlap
+          // reads as "tucked under" rather than visually broken. Same
+          // tone as Figma `Shadows/md` used on the AI suggestion card
+          // chrome (low-opacity 2-step shadow), but only applied here so
+          // pre-review and terminal stay unchanged.
+          'shadow-[0px_2px_4px_-2px_rgba(0,0,0,0.06),0px_4px_6px_-1px_rgba(0,0,0,0.05)]',
+          className,
+        )}
         data-kb-component="ai-suggestions-card"
         data-kb-mode={mode}
         header={

--- a/packages/kb-ui/src/hooks/useAIGapsReducer.ts
+++ b/packages/kb-ui/src/hooks/useAIGapsReducer.ts
@@ -65,28 +65,6 @@ export const initialAIGapsState: AIGapsState = {
  * ───────────────────────────────────────────────────────────── */
 
 /**
- * Find the next un-decided suggestion starting AFTER `startIndex`, wrapping
- * to the beginning if necessary. Returns -1 if every suggestion has a
- * decision. A "decision" is any entry in `decisions` — accepted or dismissed.
- *
- * The wrap behaviour matches Grammarly-style review flows: accepting the
- * last suggestion while an earlier one is still un-decided jumps back to
- * that earlier one (so the user doesn't need to manually rewind).
- */
-function findNextUndecided(
-  suggestions: AISuggestion[],
-  decisions: Record<string, AISuggestionDecision>,
-  startIndex: number,
-): number {
-  const n = suggestions.length;
-  for (let step = 1; step <= n; step += 1) {
-    const idx = (startIndex + step) % n;
-    if (decisions[suggestions[idx].id] === undefined) return idx;
-  }
-  return -1;
-}
-
-/**
  * Find the previous un-decided suggestion starting BEFORE `startIndex`.
  * Chunk 4 — used by the `prev` action to skip resolved cards when walking
  * the rail backwards. Returns -1 if none exist (every other card is
@@ -207,12 +185,29 @@ export function aiGapsReducer(
       const nextDecisions = { ...state.decisions, [action.id]: decision };
       const allReviewed = isAllReviewed(suggestions, nextDecisions);
       if (allReviewed) {
-        return { ...state, decisions: nextDecisions, mode: 'terminal' };
+        // Drop the active card on entry to terminal so the rail's
+        // `s.id === activeSuggestion?.id` check never lights up a resolved
+        // card after the last decision.
+        return {
+          ...state,
+          decisions: nextDecisions,
+          mode: 'terminal',
+          activeIndex: -1,
+        };
       }
-      // Advance to the next un-decided suggestion. Start search from the
-      // current active index so accepting the currently-visible one jumps
-      // to the next logical target (which may wrap).
-      const nextIdx = findNextUndecided(
+      // Chunk 5 — strict directional auto-advance. Look FORWARD only;
+      // do NOT wrap to earlier unresolved cards. If no unresolved
+      // suggestion exists after the current one, drop the active card
+      // (activeIndex = -1) — the user is signalling "I'm done with the
+      // forward walk" and any remaining earlier-resolved-then-undone
+      // cards can be re-activated by an explicit click.
+      //
+      // The sentinel `activeIndex = -1` reads as "no active card" in
+      // consumers: rail composition checks `s.id === activeSuggestion?.id`
+      // which is always false when `suggestions[-1]` is undefined, so
+      // every paired card falls back to idle. ArticleBody decisions
+      // mirror this — the `i === activeIndex` check never matches.
+      const nextIdx = findNextUndecidedNoWrap(
         suggestions,
         nextDecisions,
         state.activeIndex,
@@ -221,9 +216,7 @@ export function aiGapsReducer(
         ...state,
         mode: 'reviewing',
         decisions: nextDecisions,
-        // If every suggestion is reviewed the branch above returns early;
-        // otherwise `findNextUndecided` can't return -1 here.
-        activeIndex: nextIdx === -1 ? state.activeIndex : nextIdx,
+        activeIndex: nextIdx,
       };
     }
 
@@ -245,12 +238,17 @@ export function aiGapsReducer(
       const n = suggestions.length;
       if (n === 0) return state;
       // Chunk 4 — skip resolved cards. If currently no card is active
-      // (pre-review or terminal) jump to the LAST un-decided card so
+      // (pre-review, terminal, OR `activeIndex = -1` from chunk 5's
+      // strict-forward auto-advance) jump to the LAST un-decided card so
       // pressing Up out of pre-review still produces a sensible target.
-      if (state.mode !== 'reviewing') {
-        const first = findFirstUndecided(suggestions, state.decisions);
-        if (first === -1) return state;
-        return { ...state, mode: 'reviewing', activeIndex: first };
+      if (state.mode !== 'reviewing' || state.activeIndex < 0) {
+        // Walk from the end back to find the last undecided.
+        for (let i = suggestions.length - 1; i >= 0; i -= 1) {
+          if (state.decisions[suggestions[i].id] === undefined) {
+            return { ...state, mode: 'reviewing', activeIndex: i };
+          }
+        }
+        return state;
       }
       const prevIdx = findPrevUndecidedNoWrap(
         suggestions,
@@ -267,10 +265,11 @@ export function aiGapsReducer(
     case 'next': {
       const n = suggestions.length;
       if (n === 0) return state;
-      // Chunk 4 — same logic as `prev`, mirrored. From pre-review/terminal,
+      // Chunk 4 — same logic as `prev`, mirrored. From pre-review/terminal
+      // (or `activeIndex = -1` after chunk 5's strict-forward auto-advance),
       // jump to the FIRST un-decided card so a fresh page can activate
       // via a simple `next` dispatch.
-      if (state.mode !== 'reviewing') {
+      if (state.mode !== 'reviewing' || state.activeIndex < 0) {
         const first = findFirstUndecided(suggestions, state.decisions);
         if (first === -1) return state;
         return { ...state, mode: 'reviewing', activeIndex: first };

--- a/packages/kb-ui/src/pages/KBAIGapsExperience.stories.tsx
+++ b/packages/kb-ui/src/pages/KBAIGapsExperience.stories.tsx
@@ -758,7 +758,19 @@ function StaticFrameRender({
 function InteractiveRender({ enableKeyboard }: { enableKeyboard: boolean }) {
   const { state, dispatch, publishEnabled, canGoPrev, canGoNext } =
     useAIGapsReducer(interactiveSuggestions);
-  const activeSuggestion = interactiveSuggestions[state.activeIndex];
+  // `state.activeIndex` can be -1 (chunk 5 sentinel for "no active card"
+  // after strict-forward auto-advance runs off the end of the list).
+  // `Array[-1]` is safely `undefined` so downstream `?.id` checks no-op.
+  const activeSuggestion =
+    state.activeIndex >= 0
+      ? interactiveSuggestions[state.activeIndex]
+      : undefined;
+
+  // Chunk 5 — remaining unresolved count drives the compact reviewing
+  // summary's count pill. `pre-review` / `terminal` keep showing the
+  // total (kickoff CTA + post-review summary respectively).
+  const resolvedCount = Object.keys(state.decisions).length;
+  const remaining = interactiveSuggestions.length - resolvedCount;
 
   /* ─────────────────────────────────────────────────────────
    * Scroll side effects (chunk 4 — replaces scrollIntoView)
@@ -842,7 +854,6 @@ function InteractiveRender({ enableKeyboard }: { enableKeyboard: boolean }) {
       }
       if (state.mode !== 'reviewing') return;
       const activeId = activeSuggestion?.id;
-      if (!activeId) return;
       switch (e.key) {
         case 'j':
         case 'ArrowDown':
@@ -856,10 +867,15 @@ function InteractiveRender({ enableKeyboard }: { enableKeyboard: boolean }) {
           break;
         case 'y':
         case 'Enter':
+          // Accept/reject require an active card (chunk 5: activeIndex
+          // can be -1 with no card focused — the user must navigate or
+          // click before deciding).
+          if (!activeId) return;
           e.preventDefault();
           dispatch({ type: 'accept', id: activeId });
           break;
         case 'n':
+          if (!activeId) return;
           e.preventDefault();
           dispatch({ type: 'reject', id: activeId });
           break;
@@ -921,7 +937,7 @@ function InteractiveRender({ enableKeyboard }: { enableKeyboard: boolean }) {
       {state.mode === 'reviewing' && (
         <AISuggestionsCard
           mode="reviewing"
-          count={interactiveSuggestions.length}
+          count={remaining}
           summary={SUMMARY}
         />
       )}
@@ -937,7 +953,7 @@ function InteractiveRender({ enableKeyboard }: { enableKeyboard: boolean }) {
     </>
   );
 
-  const railItems: AIGapRailItem[] = interactiveSuggestions.map((s) => {
+  const railItems: AIGapRailItem[] = interactiveSuggestions.map((s, i) => {
     const decision = state.decisions[s.id];
     if (decision) {
       return {
@@ -965,6 +981,10 @@ function InteractiveRender({ enableKeyboard }: { enableKeyboard: boolean }) {
             onReject={(id) => dispatch({ type: 'reject', id })}
             canGoPrev={canGoPrev}
             canGoNext={canGoNext}
+            // Chunk 5 — 1-based position in the ORIGINAL list. Users
+            // need "I'm on 2 of 3" regardless of how many cards have
+            // already been resolved.
+            position={{ index: i + 1, total: interactiveSuggestions.length }}
           />
         ),
       };


### PR DESCRIPTION
Final chunk of the AI Gaps interaction refactor (chunks 1-4: #83 #84 #85 #86).

- **Counter** — reviewing summary's count pill now shows REMAINING unresolved (`total - accepted - dismissed`). Pre-review CTA and terminal pill keep showing total.
- **Position indicator** — active card renders a quiet `X / Y` next to the type chip. X is 1-based in the original list so users know "I'm on 2 of 3" regardless of which earlier cards are resolved. Figma has no spec for this — used `text-12 font-medium text-text-muted` and flagged in the code comment.
- **Strict directional auto-advance** — `accept` / `reject` look forward only; when no unresolved card remains after the current one, `activeIndex = -1` (sentinel for "no active card"). Terminal entry also clears `activeIndex`. Reducer API remains backwards-compatible.
- **Terminal transitions** — undo from terminal automatically drops back to reviewing (compact) mode with the un-done card active and the count pill repopulated. Re-accepting flips back to terminal.
- **Sticky-overlap polish** — compact reviewing summary gains a low-opacity bottom drop-shadow so when scrolled cards pass behind it, the overlap reads as tucked under rather than broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)