### PR TITLE
fix(kb-ui): align AI Gaps rail header chrome + per-article summary

### DIFF
--- a/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
+++ b/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
@@ -217,7 +217,10 @@ function deriveHistoricalDecisions(
  * Component
  * ───────────────────────────────────────────────────────────── */
 
-const SUMMARY =
+// Generic fallback when an article has no per-article `aiGapsSummary`
+// seeded. Every AI-targeted article should set its own context-specific
+// copy — this only fires for unseeded articles routed into this page.
+const FALLBACK_SUMMARY =
   "Hiver's AI flagged improvements based on recent customer conversations. Review each suggestion below.";
 
 export default function ReviewPage() {
@@ -431,8 +434,10 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
     'next',
   );
 
+  const summary = article.aiGapsSummary ?? FALLBACK_SUMMARY;
+
   const summaryNode = (
-    <>
+    <div className="flex flex-col gap-5">
       <ArticleSettingsPanel
         compact
         defaultCollapsed
@@ -442,7 +447,7 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
         <AISuggestionsCard
           mode="pre-review"
           count={kbSuggestions.length}
-          summary={SUMMARY}
+          summary={summary}
           onReview={() => {
             const firstId = kbSuggestions[0]?.id;
             if (firstId) {
@@ -457,19 +462,19 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
         <AISuggestionsCard
           mode="reviewing"
           count={remaining}
-          summary={SUMMARY}
+          summary={summary}
         />
       )}
       {effectiveMode === 'terminal' && (
         <AISuggestionsCard
           mode="terminal"
           count={kbSuggestions.length}
-          summary={SUMMARY}
+          summary={summary}
           onPrev={() => dispatch({ type: 'prev' })}
           onNext={() => dispatch({ type: 'next' })}
         />
       )}
-    </>
+    </div>
   );
 
   const railItems = React.useMemo<AIGapRailItem[]>(() => {

--- a/apps/demo/src/store/fixtures/articles.ts
+++ b/apps/demo/src/store/fixtures/articles.ts
@@ -178,6 +178,8 @@ export const articles: Article[] = [
       visibility: 'public',
       reviewerIds: ['user-aanya', 'user-devika'],
     },
+    aiGapsSummary:
+      'Refining the article with updated instruction set, updating link and by removing legacy instructions',
   },
   {
     id: 'art-restricting-an-inbox-to-specific-agents',
@@ -290,6 +292,8 @@ export const articles: Article[] = [
       visibility: 'public',
       reviewerIds: ['user-aanya'],
     },
+    aiGapsSummary:
+      'Adding accessibility best-practices guidance, renaming the color picker to theme selector and removing legacy iframe embed instructions',
   },
   {
     id: 'art-connecting-whatsapp-business-to-hiver',
@@ -378,6 +382,8 @@ export const articles: Article[] = [
       visibility: 'public',
       reviewerIds: ['user-mira', 'user-tarun'],
     },
+    aiGapsSummary:
+      'Adding timezone guidance for rule schedules, clarifying the ambiguous Recent trigger and removing the deprecated sender-domain toggle',
   },
   {
     id: 'art-defining-first-response-targets',

--- a/apps/demo/src/store/types.ts
+++ b/apps/demo/src/store/types.ts
@@ -78,6 +78,15 @@ export type Article = {
    */
   bodyHTML: string;
   settings: ArticleSettings;
+  /**
+   * Optional per-article context-specific summary surfaced in the AI
+   * Gaps rail header. Briefly describes the actual suggestions on this
+   * article (e.g. "Refining the article with updated instruction set,
+   * updating link and by removing legacy instructions"). When absent,
+   * the rail falls back to a generic blurb. Only seeded on the 3
+   * AI-targeted articles.
+   */
+  aiGapsSummary?: string;
 };
 
 export type AISuggestionType = 'addition' | 'replace' | 'removal';

--- a/packages/kb-ui/src/components/content/AISuggestionsCard.tsx
+++ b/packages/kb-ui/src/components/content/AISuggestionsCard.tsx
@@ -4,6 +4,7 @@
 import * as React from 'react';
 import { Check } from '@untitledui/icons';
 import { cn } from '../../utils/cn';
+import { tokens } from '../../tokens';
 import { AiIcon } from '../brand/AiIcon';
 import { Button } from '../primitives/Button';
 import { AICard } from './AICard';
@@ -106,14 +107,15 @@ export function AISuggestionsCard({
         mode="active"
         className={cn(
           'px-4 py-3',
+          // Match the Settings card's border colour so all rail-header
+          // cards read as one family. `border-surface-muted` overrides
+          // `AICard`'s default `border-card-border` via twMerge.
+          'border-surface-muted',
           // Chunk 5 — when the rail's `sticky` wrapper pins this compact
           // header at the top, scrolled cards behind it can overlap the
           // bottom edge. AICard already provides an opaque white bg and a
-          // 1px slate border; add a subtle drop shadow so the overlap
-          // reads as "tucked under" rather than visually broken. Same
-          // tone as Figma `Shadows/md` used on the AI suggestion card
-          // chrome (low-opacity 2-step shadow), but only applied here so
-          // pre-review and terminal stay unchanged.
+          // 1px slate border; keep the softer chunk-5 shadow here so the
+          // overlap reads as "tucked under" rather than visually broken.
           'shadow-[0px_2px_4px_-2px_rgba(0,0,0,0.06),0px_4px_6px_-1px_rgba(0,0,0,0.05)]',
           className,
         )}
@@ -136,7 +138,16 @@ export function AISuggestionsCard({
     <AICard
       mode="active"
       footerGap={16}
-      className={className}
+      // Match the Settings card's border colour (`border-surface-muted`)
+      // so the two rail-header cards read as the same family.
+      // `border-surface-muted` overrides `AICard`'s default
+      // `border-card-border` via twMerge. Shadow uses `tokens.shadow.md`
+      // — the same two-step shadow Settings already applies — so the
+      // pair has matching elevation. Inline style guarantees the shadow
+      // can't be stripped by twMerge collapsing arbitrary `shadow-[...]`
+      // classes against any caller-provided override.
+      className={cn('border-surface-muted', className)}
+      style={{ boxShadow: tokens.shadow.md }}
       data-kb-component="ai-suggestions-card"
       data-kb-mode={mode}
       header={

--- a/packages/kb-ui/src/pages/KBAIGapsExperience.stories.tsx
+++ b/packages/kb-ui/src/pages/KBAIGapsExperience.stories.tsx
@@ -913,7 +913,7 @@ function InteractiveRender({ enableKeyboard }: { enableKeyboard: boolean }) {
    * and sets the active index.
    * ───────────────────────────────────────────────────────────── */
   const summaryNode = (
-    <>
+    <div className="flex flex-col gap-5">
       <ArticleSettingsPanel compact defaultCollapsed value={dummySettings} />
       {state.mode === 'pre-review' && (
         <AISuggestionsCard
@@ -950,7 +950,7 @@ function InteractiveRender({ enableKeyboard }: { enableKeyboard: boolean }) {
           onNext={() => dispatch({ type: 'next' })}
         />
       )}
-    </>
+    </div>
   );
 
   const railItems: AIGapRailItem[] = interactiveSuggestions.map((s, i) => {


### PR DESCRIPTION
- Per-article `aiGapsSummary` field on `Article`; seeded on all 3 AI-targeted articles. Password-reset uses the literal Figma copy; auto-reply and chat-widget get tight summaries in the same shape.
- ReviewPage and KBAIGapsExperience Interactive story wrap their summary slot in a flex column with `gap-5` so Settings and AI Suggestions no longer touch.
- AISuggestionsCard pre-review/terminal now ship `tokens.shadow.md` + `border-surface-muted` to match Settings exactly. Reviewing mode swaps to `border-surface-muted` while keeping its existing tucked-under shadow.
- Verified clean: `tsc -p packages/kb-ui --noEmit`, `tsc -p apps/demo --noEmit`, kb-ui `build`, `build-storybook`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)