### PR TITLE
fix(kb-ui): collapsed chips stay visible after accept/reject, active-only highlights

### DIFF
--- a/packages/kb-ui/src/components/content/AIGapRail.tsx
+++ b/packages/kb-ui/src/components/content/AIGapRail.tsx
@@ -301,9 +301,20 @@ export function AIGapRail({
   }, [layouts, cardHeights]);
 
   /* ── First-paint opacity: hide cards until anchors are measured ─ */
-  // If at least one anchor is measured we consider the layout ready.
-  // (All-or-nothing on the first frame to avoid a partial reveal.)
-  const ready = items.length === 0 || Object.keys(anchorPositions).length > 0;
+  // Strictly a FIRST-FRAME flicker gate. We latch `ready` to `true` on the
+  // first effect tick — never flip it back to `false` afterwards. Anchors
+  // legitimately disappear when their suggestions are accepted/dismissed (S1
+  // accepted → PlainSentences; S3 accepted → null; etc.), and previously the
+  // gate's `Object.keys(anchorPositions).length > 0` check would flip back
+  // to `false` in those terminal states and hide every collapsed-chip card
+  // with opacity 0. The collision walk already handles missing anchors via
+  // the `prevBottom` fallback, so cards still position correctly when only
+  // some / none of their anchors are mounted.
+  const [ready, setReady] = React.useState(false);
+  React.useEffect(() => {
+    if (ready) return;
+    setReady(true);
+  }, [ready]);
 
   return (
     <aside

--- a/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
+++ b/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
@@ -99,15 +99,20 @@ function TypeChip({
   registry: Record<string, SuggestionTypeMeta>;
 }) {
   const meta = registry[type];
+  // Figma 74:10470 / 81:16974 / 81:16996 — TypeChip label is 14/20 medium
+  // across active, idle, and collapsed states. Earlier 12/18 sizing was a
+  // mis-pulled token from an older Figma revision.
+  const labelClass =
+    'text-[14px] font-medium leading-[20px] whitespace-nowrap';
   if (!meta) {
     return (
       <span
         data-kb-part="ai-gap-type-chip"
         data-kb-type={type}
-        className="inline-flex items-center gap-1"
+        className="inline-flex items-center gap-[6px]"
         style={{ color: tokens.color.textDisabled }}
       >
-        <span className="text-[12px] font-medium leading-[18px]">{type}</span>
+        <span className={labelClass}>{type}</span>
       </span>
     );
   }
@@ -116,11 +121,11 @@ function TypeChip({
     <span
       data-kb-part="ai-gap-type-chip"
       data-kb-type={type}
-      className="inline-flex items-center gap-1"
+      className="inline-flex items-center gap-[6px]"
       style={{ color }}
     >
-      <Icon className="h-[14px] w-[14px]" />
-      <span className="text-[12px] font-medium leading-[18px]">{label}</span>
+      <Icon className="h-[14px] w-[14px] shrink-0" />
+      <span className={labelClass}>{label}</span>
     </span>
   );
 }
@@ -244,17 +249,29 @@ export function AIGapSuggestionCard({
       state === 'accepted'
         ? (decisionLabels?.accepted ?? 'ACCEPTED')
         : (decisionLabels?.dismissed ?? 'DISMISSED');
+    // Figma 74:10581 (dismissed-replace) / 74:10491 (accepted-addition) —
+    // both 452×76 with: bg=canvas (#f5f5f5), border=card-border, padding
+    // px-[22px] py-[24px], 12px radius. Inner row gap 6px. Label is
+    // 13/19 medium #64748b (text-muted) — NO letter-spacing. Divider is
+    // ~30px tall, 1px wide, slate-blue/faint.
     return (
       <AICard
         mode="collapsed"
-        className={className}
+        className={cn(
+          // Override AICard's collapsed defaults: canvas bg + Figma padding.
+          'bg-canvas px-[22px] py-[24px]',
+          className,
+        )}
         data-kb-component="ai-gap-suggestion-card"
         data-kb-state={state}
         data-kb-type={suggestion.type}
       >
         <TypeChip type={suggestion.type} registry={resolvedRegistry} />
-        <span aria-hidden className="mx-3 h-4 w-px shrink-0 bg-card-divider" />
-        <span className="text-[12px] font-medium leading-[18px] text-text-meta tracking-wide">
+        <span
+          aria-hidden
+          className="mx-3 h-[28px] w-px shrink-0 bg-card-divider"
+        />
+        <span className="text-[13px] font-medium leading-[19px] text-text-muted">
           {decisionLabel}
         </span>
         <button
@@ -262,9 +279,9 @@ export function AIGapSuggestionCard({
           onClick={() => onUndo?.(suggestion.id)}
           aria-label={`Undo ${state} for ${suggestion.title}`}
           className={cn(
-            'ml-auto inline-flex size-6 items-center justify-center rounded-[4px]',
-            'text-text-muted transition-colors',
-            'hover:bg-surface-muted hover:text-text-primary',
+            'ml-auto inline-flex size-7 items-center justify-center rounded-full',
+            'text-text-primary transition-colors',
+            'hover:bg-surface-muted',
             'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
           )}
         >
@@ -329,10 +346,12 @@ export function AIGapSuggestionCard({
     <AICard
       mode="active"
       className={cn(
-        isIdle &&
-          // Override AICard defaults: grey BG + faint border + shadow +
-          // Figma-exact padding. twMerge resolves the conflicts.
-          'bg-canvas border-border shadow-lg px-[22px] py-[24px]',
+        // Figma 74:10466 (active) / 2829:9484 (idle) — both share padding
+        // (px-22 py-24), 12px radius, faint border (#f1f5f9), and Shadows/lg.
+        // Override AICard's `p-4` default → Figma padding.
+        'border-border shadow-lg px-[22px] py-[24px]',
+        // Idle differs from active only by bg (canvas grey vs white).
+        isIdle ? 'bg-canvas' : 'bg-white',
         // Click-to-activate surface for idle cards. Pointer cursor + soft
         // hover lift indicate clickability without breaking the recessed
         // visual treatment.
@@ -373,11 +392,10 @@ export function AIGapSuggestionCard({
           {meta}
           <h3
             data-kb-part="ai-gap-title"
-            className={cn(
-              'mt-2 text-[14px] font-medium leading-[20px]',
-              // Idle title steps down to slateTextBody per Figma 2829:9484.
-              isIdle ? 'text-text-secondary' : 'text-text-primary',
-            )}
+            // Figma 74:10476 — title is 14/20 medium #334155 (slateTextBody)
+            // for both active and idle. Earlier active used text-primary
+            // (#0f172a) which was darker than the Figma spec.
+            className="mt-2 text-[14px] font-medium leading-[20px] text-text-secondary"
           >
             {suggestion.title}
           </h3>
@@ -389,8 +407,10 @@ export function AIGapSuggestionCard({
           </p>
         </>
       }
-      showFooterDivider={!isIdle}
-      footerGap={isIdle ? 20 : 12}
+      // Figma 74:10466 / 2829:9484 — NO horizontal divider between body and
+      // footer in either active or idle. Card uses a 20px gap instead.
+      showFooterDivider={false}
+      footerGap={20}
       footer={
         actions !== undefined ? (
           actions

--- a/packages/kb-ui/src/components/content/ArticleBody.tsx
+++ b/packages/kb-ui/src/components/content/ArticleBody.tsx
@@ -6,18 +6,34 @@
 // Read-mode article body used by the AI Gaps review experience.
 //
 // The component owns the **decision-to-render** logic for the three
-// suggestion regions (s1 addition, s2 replace, s3 removal):
+// suggestion regions (s1 addition, s2 replace, s3 removal). The rule is
+// **only `active` renders the colored highlight wash**. Every other state
+// (inactive, accepted, dismissed) renders plain article text so the reader
+// can scan the article naturally — the rail's collapsed chip is the sole
+// indicator of a decided suggestion.
 //
-//   - `inactive` / `active` → the region content is wrapped in a
-//     `SuggestionBlock` of the matching variant. Per-sentence highlights
-//     are applied (each `sentences[]` entry gets its own green/red block
-//     with a 4px gap between blocks — matches Figma 137:4022 / 137:4132).
-//   - `accepted` (s1 addition)  → region rendered as plain body text.
-//   - `accepted` (s2 replace)   → only the `after` half rendered, plain.
-//   - `accepted` (s3 removal)   → region hidden.
-//   - `dismissed` (s1 addition) → region hidden (addition never applied).
-//   - `dismissed` (s2 replace)  → `before` half rendered, plain (revert).
-//   - `dismissed` (s3 removal)  → region rendered as plain body text.
+//   - s1 addition
+//       inactive → plain (preview the proposed addition, no wash)
+//       active   → green wash via SuggestionBlock
+//       accepted → plain (addition kept)
+//       dismissed → hidden (addition reverted, article reverts to baseline)
+//   - s2 replace
+//       inactive → plain `before` (current article state)
+//       active   → red(before) + green(after) wash via SuggestionBlock
+//       accepted → plain `after` (replacement applied)
+//       dismissed → plain `before` (revert)
+//   - s3 removal
+//       inactive → plain (text still in article, no wash)
+//       active   → red strike wash via SuggestionBlock
+//       accepted → hidden (text removed)
+//       dismissed → plain (text kept)
+//
+// Every slot ALWAYS emits an invisible `data-suggestion-id` anchor (even
+// when the slot's content is hidden, e.g. dismissed addition / accepted
+// removal). The anchor lets the AIGapRail's `useAnchorPositions` lookup
+// keep pairing the rail card to a stable article-Y for the lifetime of the
+// review — without it, the rail card would jump to its fallback (stacked
+// under summary) the moment its suggestion was decided.
 //
 // **The article copy itself lives in the consumer.** ArticleBody no longer
 // hardcodes any specific article — it accepts a `regions` object whose
@@ -179,7 +195,43 @@ function PlainSentences({ sentences }: { sentences: SuggestionSentence[] }) {
 }
 
 /* ─────────────────────────────────────────────────────────────
- * Per-suggestion renderers — encode the accept/dismiss semantics
+ * Anchor stub — invisible `data-suggestion-id` carrier rendered when a
+ * slot's content is hidden (s1 dismissed, s3 accepted). Has zero visual
+ * footprint but preserves the article-Y the rail uses for pairing the
+ * collapsed chip card to its anchor's original position.
+ *
+ * Doubles as a legacy `id="s1|s2|s3"` scroll target so the chunk-4
+ * rAF smooth-scroll still has something to scroll to.
+ * ───────────────────────────────────────────────────────────── */
+
+function AnchorStub({
+  id,
+  suggestionId,
+}: {
+  id: string;
+  suggestionId?: string;
+}) {
+  return (
+    <span
+      id={id}
+      data-kb-part="suggestion-anchor-stub"
+      {...(suggestionId ? { 'data-suggestion-id': suggestionId } : {})}
+      // `block` + zero height so it shows up in `offsetTop` measurements
+      // (inline `span`s without `block` can have funky offset behaviour
+      // depending on the layout context) without affecting the flow.
+      className="block h-0 w-full"
+      aria-hidden="true"
+    />
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Per-suggestion renderers — encode the accept/dismiss semantics.
+ *
+ * Only `active` renders the SuggestionBlock wash. All other states
+ * render plain article text. Every variant emits a stable
+ * `data-suggestion-id` anchor — either via the SuggestionBlock itself
+ * (active) or via an invisible `AnchorStub` wrapper (plain / hidden).
  * ───────────────────────────────────────────────────────────── */
 
 function S1Region({
@@ -191,23 +243,31 @@ function S1Region({
   content: SuggestionSentence[];
   suggestionId?: string;
 }) {
-  if (decision === 'accepted') {
-    // Addition accepted → content kept as plain body text.
-    return <PlainSentences sentences={content} />;
+  if (decision === 'active') {
+    // Active addition → per-sentence green highlight block. SuggestionBlock
+    // already emits `id="s1"` + `data-suggestion-id`, so no stub needed.
+    return (
+      <SuggestionBlock
+        type="addition"
+        id="s1"
+        suggestionId={suggestionId}
+        className="mb-4"
+        sentences={content}
+      />
+    );
   }
   if (decision === 'dismissed') {
-    // Addition dismissed → content never added.
-    return null;
+    // Addition dismissed → content never added; emit a stub so the rail
+    // still has an article-Y to pair the collapsed dismissed chip to.
+    return <AnchorStub id="s1" suggestionId={suggestionId} />;
   }
-  // inactive | active → per-sentence highlight block.
+  // inactive | accepted → plain body text + stub anchor (the PlainSentences
+  // emit no `data-suggestion-id` so we wrap with a stub).
   return (
-    <SuggestionBlock
-      type="addition"
-      id="s1"
-      suggestionId={suggestionId}
-      className="mb-4"
-      sentences={content}
-    />
+    <>
+      <AnchorStub id="s1" suggestionId={suggestionId} />
+      <PlainSentences sentences={content} />
+    </>
   );
 }
 
@@ -222,24 +282,28 @@ function S2Region({
   after: SuggestionSentence[];
   suggestionId?: string;
 }) {
-  if (decision === 'accepted') {
-    // Replace accepted → new content remains as plain text.
-    return <PlainSentences sentences={after} />;
+  if (decision === 'active') {
+    // Active replace → per-sentence red (old) + green (new) stacked pair.
+    return (
+      <SuggestionBlock
+        type="replace"
+        id="s2"
+        suggestionId={suggestionId}
+        className="mb-4"
+        oldSentences={before}
+        newSentences={after}
+      />
+    );
   }
-  if (decision === 'dismissed') {
-    // Replace dismissed → old content remains.
-    return <PlainSentences sentences={before} />;
-  }
-  // inactive | active → per-sentence red (old) + green (new) stacked pair.
+  // inactive → plain `before` (current state of the article).
+  // accepted → plain `after` (replacement applied).
+  // dismissed → plain `before` (revert).
+  const sentences = decision === 'accepted' ? after : before;
   return (
-    <SuggestionBlock
-      type="replace"
-      id="s2"
-      suggestionId={suggestionId}
-      className="mb-4"
-      oldSentences={before}
-      newSentences={after}
-    />
+    <>
+      <AnchorStub id="s2" suggestionId={suggestionId} />
+      <PlainSentences sentences={sentences} />
+    </>
   );
 }
 
@@ -252,23 +316,28 @@ function S3Region({
   content: SuggestionSentence[];
   suggestionId?: string;
 }) {
+  if (decision === 'active') {
+    // Active removal → per-sentence red wash over the existing content.
+    return (
+      <SuggestionBlock
+        type="removal"
+        id="s3"
+        suggestionId={suggestionId}
+        className="mb-4"
+        sentences={content}
+      />
+    );
+  }
   if (decision === 'accepted') {
-    // Removal accepted → content deleted.
-    return null;
+    // Removal accepted → content deleted; emit a stub for the chip pairing.
+    return <AnchorStub id="s3" suggestionId={suggestionId} />;
   }
-  if (decision === 'dismissed') {
-    // Removal dismissed → existing content stays as plain body.
-    return <PlainSentences sentences={content} />;
-  }
-  // inactive | active → per-sentence red wash over the existing content.
+  // inactive | dismissed → plain body text + stub anchor.
   return (
-    <SuggestionBlock
-      type="removal"
-      id="s3"
-      suggestionId={suggestionId}
-      className="mb-4"
-      sentences={content}
-    />
+    <>
+      <AnchorStub id="s3" suggestionId={suggestionId} />
+      <PlainSentences sentences={content} />
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary

- **Fix 1 — Vanishing cards in terminal state**: `AIGapRail`'s opacity-gate (`Object.keys(anchorPositions).length > 0`) flipped back to `false` once all suggestions were decided, because accepted/dismissed slots no longer rendered a `SuggestionBlock` with a `data-suggestion-id` anchor — hiding every collapsed chip with `opacity: 0`. Latch `ready=true` after the first effect; never flip back. Also: `ArticleBody` now always emits a `data-suggestion-id` anchor stub for every slot (even when content is hidden), so the rail's collision walk can keep pairing chips to their original article-Y.
- **Fix 2 — Active-only highlights**: Only the active suggestion's region renders the colored wash. `inactive` / `accepted` / `dismissed` render plain article text. The article reads as its current state; the rail's collapsed chip is the sole indicator of a decision. Updated `S1Region` / `S2Region` / `S3Region` accordingly — payload-applying logic (added text appears, removed text disappears) is unchanged.
- **Pixel-perfect audit of all 4 AIGapSuggestionCard variants against Figma** (74:10466 active / 74:10491 accepted / 74:10581 dismissed / 2829:9484 idle). Fixed: collapsed chip `bg-white → bg-canvas`, `px-3 py-2 → px-[22px] py-[24px]`, label `12/18 tracking-wide → 13/19 no tracking`, divider `h-4 → h-[28px]`, undo `rounded-[4px] → rounded-full size-7`. Active card: shared padding + shadow with idle (only bg differs), removed body↔footer divider, title color `text-primary → text-secondary`. TypeChip `12/18 → 14/20` medium across all states.

## Test plan

- [x] `tsc kb-ui --noEmit` clean
- [x] `tsc demo --noEmit` clean
- [x] `npm run --workspace=packages/kb-ui build` clean
- [x] `npm run --workspace=packages/kb-ui build-storybook` clean
- [x] `npm run --workspace=apps/demo build` clean
- [x] Playwright walk on `/ai-optimise/how-to-reset-your-password/review`:
  - Load → 3 idle cards visible, no highlights in article body, summary in pre-review
  - Click first idle card → first becomes active, addition wash appears, others stay idle
  - Click second idle card → first reverts to idle (wash disappears), second active (replace wash appears)
  - Accept second → second becomes accepted chip (h=78), third auto-activates (removal wash appears)
  - Reject third → third becomes dismissed chip; terminal state; **all 3 chips visible, opacity 1.0** (no vanishing)
  - Undo second chip → flips back to active, replace wash reappears
- [x] Storybook variants (Review/Content/AIGapSuggestionCard) — Active Addition / Replace / Removal + Accepted Addition + Dismissed Replace render 1:1 with Figma reference