### PR TITLE
feat(demo): per-article bodies for AI Gaps Review

### DIFF
--- a/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
+++ b/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
@@ -55,6 +55,10 @@ import { routes } from '../../lib/routes';
 import { passwordResetRegions } from './passwordResetRegions';
 import { autoReplyRegions } from './autoReplyRegions';
 import { chatWidgetRegions } from './chatWidgetRegions';
+import type {
+  AISuggestion as StoreAISuggestion,
+  ConversationSource as StoreConversationSource,
+} from '../../store/types';
 
 /* ─────────────────────────────────────────────────────────────
  * Per-article regions lookup — each AI-targeted article ships its
@@ -68,10 +72,6 @@ const regionsByArticleId: Record<string, ArticleBodyRegions> = {
   'art-setting-up-auto-reply-rules': autoReplyRegions,
   'art-customizing-the-chat-widget': chatWidgetRegions,
 };
-import type {
-  AISuggestion as StoreAISuggestion,
-  ConversationSource as StoreConversationSource,
-} from '../../store/types';
 
 /* ─────────────────────────────────────────────────────────────
  * Adapters — store types → kb-ui types

--- a/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
+++ b/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
@@ -10,14 +10,13 @@
 //     persistence) rather than via React.useReducer.
 //   - Suggestions are sourced from the store's `suggestions` slice and
 //     mapped position-wise onto `ArticleBody`'s s1/s2/s3 slots.
-//     `ArticleBody` now accepts a `regions` prop carrying the article
-//     markup, and the demo passes `passwordResetRegions` (defined in
-//     `./passwordResetRegions.tsx`) for all three AI-targeted articles
-//     in v1, since the mock store doesn't yet model per-article body
-//     HTML. The visual highlight chrome and slot positions are correct
-//     per article, but the surrounding copy is the password-reset
-//     article for every AI review session. Modelling per-article body
-//     HTML in the mock store is left for a future demo iteration.
+//     `ArticleBody` accepts a `regions` prop carrying the article markup;
+//     each of the three AI-targeted articles has its own regions module
+//     (`./passwordResetRegions.tsx`, `./autoReplyRegions.tsx`,
+//     `./chatWidgetRegions.tsx`) so the rendered body content matches
+//     the suggestion payloads naturally. The mock store still doesn't
+//     model per-article body HTML — these regions modules are the
+//     demo's local source of truth for article copy.
 //   - PRD §9.5 terminal-state-after-publish branch: when an article was
 //     previously published from this flow, all suggestions have status
 //     `'published'` so we render the terminal state with chips reflecting
@@ -39,6 +38,7 @@ import {
   type AISuggestion as KbUiAISuggestion,
   type AISuggestionDecision,
   type ArticleBodyDecisions,
+  type ArticleBodyRegions,
   type ArticleSuggestionDecision,
   type ArticleSettings as KbUiArticleSettings,
   type ConversationSource as KbUiConversationSource,
@@ -53,6 +53,21 @@ import {
 import { useAIGapsForArticle } from '../../hooks/useAIGapsForArticle';
 import { routes } from '../../lib/routes';
 import { passwordResetRegions } from './passwordResetRegions';
+import { autoReplyRegions } from './autoReplyRegions';
+import { chatWidgetRegions } from './chatWidgetRegions';
+
+/* ─────────────────────────────────────────────────────────────
+ * Per-article regions lookup — each AI-targeted article ships its
+ * own body markup that threads the relevant suggestion payloads.
+ * Fallback to password-reset for any unseeded article id so the
+ * route can't crash on a stray slug.
+ * ───────────────────────────────────────────────────────────── */
+
+const regionsByArticleId: Record<string, ArticleBodyRegions> = {
+  'art-how-to-reset-your-password': passwordResetRegions,
+  'art-setting-up-auto-reply-rules': autoReplyRegions,
+  'art-customizing-the-chat-widget': chatWidgetRegions,
+};
 import type {
   AISuggestion as StoreAISuggestion,
   ConversationSource as StoreConversationSource,
@@ -574,7 +589,7 @@ function ReviewExperience({ articleId }: ReviewExperienceProps) {
         <ArticleBody
           ref={articleRef}
           decisions={articleDecisions}
-          regions={passwordResetRegions}
+          regions={regionsByArticleId[articleId] ?? passwordResetRegions}
           suggestionIds={articleSuggestionIds}
           className="max-w-[720px] w-full"
         />

--- a/apps/demo/src/routes/ai-optimise/autoReplyRegions.tsx
+++ b/apps/demo/src/routes/ai-optimise/autoReplyRegions.tsx
@@ -1,0 +1,190 @@
+// Auto-reply rules article markup for the AI Gaps Review experience.
+//
+// Mirrors `./passwordResetRegions.tsx`'s shape — the demo cannot import
+// private story symbols, so we replicate the typography helpers locally
+// per the existing convention. Each AI-targeted article ships its own
+// regions module so the article body content threads its specific
+// suggestion payloads naturally.
+//
+// Suggestion payload alignment (`apps/demo/src/store/fixtures/suggestions.ts`):
+//   - s1 (addition)  ↔ sug-autoreply-1.payload.newHTML  — timezone tip
+//   - s2 (replace)   ↔ sug-autoreply-2.payload.{oldHTML,newHTML}  — Recent trigger
+//   - s3 (removal)   ↔ sug-autoreply-3.payload.oldHTML  — domain toggle
+//
+// Slot order rendered by `ArticleBody`:
+//   header → beforeS1 → s1 region → betweenS1AndS2 → s2 region
+//          → betweenS2AndS3 → s3 region → afterS3
+
+import * as React from 'react';
+import {
+  SuggestionHighlight,
+  type ArticleBodyRegions,
+} from '@test-kb-ui/kb-ui';
+
+/* ─────────────────────────────────────────────────────────────
+ * Typography helpers — duplicated locally to match
+ * `passwordResetRegions.tsx` 1:1. Values pulled from Figma
+ * `9aGp5t9fH1d0PXi4LMhOdb#74:10788`.
+ * ───────────────────────────────────────────────────────────── */
+
+function H1({ children }: { children: React.ReactNode }) {
+  return (
+    <h1 className="mb-2 text-[24px] font-semibold leading-[32px] text-text-primary">
+      {children}
+    </h1>
+  );
+}
+
+function Subtitle({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mb-6 text-[14px] font-normal leading-[20px] text-text-muted">
+      {children}
+    </p>
+  );
+}
+
+function H2({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="mt-6 mb-3 text-[20px] font-semibold leading-[28px] text-text-primary">
+      {children}
+    </h2>
+  );
+}
+
+function P({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mb-4 text-[16px] font-normal leading-[24px] text-text-secondary">
+      {children}
+    </p>
+  );
+}
+
+function Strong({ children }: { children: React.ReactNode }) {
+  return (
+    <strong className="font-semibold text-text-primary">{children}</strong>
+  );
+}
+
+export const autoReplyRegions: ArticleBodyRegions = {
+  header: (
+    <>
+      <H1>Setting Up Auto-Reply Rules</H1>
+      <Subtitle>Last updated 3 weeks ago</Subtitle>
+    </>
+  ),
+  beforeS1: (
+    <>
+      <P>
+        Auto-reply rules let you respond to incoming conversations
+        automatically — useful for out-of-office coverage, after-hours
+        acknowledgments, or routing simple FAQs to canned responses. Each
+        rule has a <Strong>trigger</Strong> (the condition that fires it)
+        and a <Strong>schedule</Strong> (the time window when it&rsquo;s
+        active).
+      </P>
+      <H2>Setting the Schedule</H2>
+      <P>
+        Define when the rule is allowed to fire. Most teams use{' '}
+        <Strong>Business hours</Strong> to limit the rule to working days;{' '}
+        <Strong>Always</Strong> runs the rule 24/7 including weekends. The
+        schedule editor previews the next 7 days so you can sanity-check
+        the window before saving.
+      </P>
+    </>
+  ),
+  /* Addition — timezone tip. Single highlighted block; inline <Strong>
+   * picks up the bold "Timezone tip:" lead from the suggestion payload. */
+  s1: [
+    <span
+      key="s1-tz"
+      className="block text-[16px] leading-[24px] text-text-primary"
+    >
+      <SuggestionHighlight>
+        <Strong>Timezone tip:</Strong> rule schedules always run in the
+        workspace&rsquo;s primary timezone, not the agent&rsquo;s local
+        timezone. If your team spans timezones, double-check the schedule
+        preview against the inbox&rsquo;s expected coverage hours before
+        saving the rule.
+      </SuggestionHighlight>
+    </span>,
+  ],
+  betweenS1AndS2: (
+    <>
+      <H2>Picking the Trigger</H2>
+      <P>
+        The trigger fires the rule. Hiver supports several conditions,
+        from new conversation to time-windowed matches, and you can
+        combine multiple triggers with AND/OR logic.
+      </P>
+    </>
+  ),
+  /* Replace — Recent trigger clarification. Each half is one JSX entry
+   * so inline <em> emphasis renders correctly inside the highlight. */
+  s2: {
+    before: [
+      <span
+        key="s2-before"
+        className="text-[16px] leading-[24px] text-text-primary"
+      >
+        <SuggestionHighlight>
+          The most common trigger is <em>New conversation</em> — fires
+          once per conversation, the moment it arrives. The{' '}
+          <em>Recent</em> trigger is ambiguous on its own; we recommend
+          pairing it with an explicit time window to avoid accidentally
+          re-firing on every message in an old thread.
+        </SuggestionHighlight>
+      </span>,
+    ],
+    after: [
+      <span
+        key="s2-after"
+        className="text-[16px] leading-[24px] text-text-primary"
+      >
+        <SuggestionHighlight>
+          The most common trigger is <em>New conversation</em> — fires
+          once per conversation, the moment it arrives. The{' '}
+          <em>Within the last 24 hours</em> trigger (formerly labelled
+          &ldquo;Recent&rdquo;) fires for any conversation whose last
+          inbound message arrived in the past 24 hours, which is precise
+          enough to use without an extra time window.
+        </SuggestionHighlight>
+      </span>,
+    ],
+  },
+  betweenS2AndS3: (
+    <>
+      <H2>Filtering by Sender</H2>
+      <P>
+        Filters narrow which conversations a rule applies to — by sender
+        email, sender domain, conversation tag, or subject keyword.
+        Combine filters into a <em>filter group</em> to express complex
+        AND/OR conditions.
+      </P>
+    </>
+  ),
+  /* Removal — legacy domain toggle. H2 + body each render as their own
+   * highlighted entry so the heading keeps its typography. */
+  s3: [
+    <span
+      key="s3-h2"
+      className="block text-[20px] font-semibold leading-[28px] text-text-primary"
+    >
+      <SuggestionHighlight>
+        Match by sender domain only
+      </SuggestionHighlight>
+    </span>,
+    'The legacy “Match by sender domain only” toggle flattens any conversation from a given domain into a single rule path. Most teams have moved to the more flexible “Filter group” UI, which lets you combine domain matching with tags, subject filters, and timing. This toggle is preserved for backward compatibility but new rules should not use it.',
+  ],
+  afterS3: (
+    <>
+      <H2>Saving and Activating</H2>
+      <P>
+        Once the schedule, trigger, and filters are configured, click{' '}
+        <Strong>Save</Strong> at the top right. The rule activates
+        immediately for new incoming conversations matching its criteria.
+        You can pause a rule at any time from the rule list — paused rules
+        stay configured but stop firing.
+      </P>
+    </>
+  ),
+};

--- a/apps/demo/src/routes/ai-optimise/chatWidgetRegions.tsx
+++ b/apps/demo/src/routes/ai-optimise/chatWidgetRegions.tsx
@@ -1,0 +1,220 @@
+// Chat widget article markup for the AI Gaps Review experience.
+//
+// Mirrors `./passwordResetRegions.tsx`'s shape — the demo cannot import
+// private story symbols, so we replicate the typography helpers locally
+// per the existing convention.
+//
+// Suggestion payload alignment (`apps/demo/src/store/fixtures/suggestions.ts`):
+//   - s1 (addition)  ↔ sug-chatwidget-1.payload.newHTML  — a11y subsection
+//   - s2 (replace)   ↔ sug-chatwidget-2.payload.{oldHTML,newHTML}  — color picker → theme selector
+//   - s3 (removal)   ↔ sug-chatwidget-3.payload.oldHTML  — iframe embed
+//
+// Slot order rendered by `ArticleBody`:
+//   header → beforeS1 → s1 region → betweenS1AndS2 → s2 region
+//          → betweenS2AndS3 → s3 region → afterS3
+
+import * as React from 'react';
+import {
+  SuggestionHighlight,
+  type ArticleBodyRegions,
+} from '@test-kb-ui/kb-ui';
+
+/* ─────────────────────────────────────────────────────────────
+ * Typography helpers — duplicated locally to match
+ * `passwordResetRegions.tsx` 1:1.
+ * ───────────────────────────────────────────────────────────── */
+
+function H1({ children }: { children: React.ReactNode }) {
+  return (
+    <h1 className="mb-2 text-[24px] font-semibold leading-[32px] text-text-primary">
+      {children}
+    </h1>
+  );
+}
+
+function Subtitle({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mb-6 text-[14px] font-normal leading-[20px] text-text-muted">
+      {children}
+    </p>
+  );
+}
+
+function H2({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="mt-6 mb-3 text-[20px] font-semibold leading-[28px] text-text-primary">
+      {children}
+    </h2>
+  );
+}
+
+function P({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mb-4 text-[16px] font-normal leading-[24px] text-text-secondary">
+      {children}
+    </p>
+  );
+}
+
+function Strong({ children }: { children: React.ReactNode }) {
+  return (
+    <strong className="font-semibold text-text-primary">{children}</strong>
+  );
+}
+
+export const chatWidgetRegions: ArticleBodyRegions = {
+  header: (
+    <>
+      <H1>Customizing the Chat Widget</H1>
+      <Subtitle>Last updated 1 month ago</Subtitle>
+    </>
+  ),
+  beforeS1: (
+    <>
+      <P>
+        The Hiver chat widget appears on your customer-facing pages and
+        lets visitors start conversations with your support team. You can
+        customize its colors, position, behavior, and embed method to
+        match your brand and product.
+      </P>
+      <H2>Choosing Colors and Themes</H2>
+      <P>
+        Open <Strong>Widget → Appearance</Strong> to access the theme
+        settings. Hiver ships with three preset themes (Default, Dark,
+        High contrast) you can use as starting points, or build a custom
+        theme from scratch.
+      </P>
+    </>
+  ),
+  /* Addition — accessibility subsection. H2 + intro + bullet list each
+   * render as their own highlighted entry so the heading keeps its
+   * typography and the list keeps its disc bullets + indentation. */
+  s1: [
+    <span
+      key="s1-h2"
+      className="block text-[20px] font-semibold leading-[28px] text-text-primary"
+    >
+      <SuggestionHighlight>
+        Accessibility best practices
+      </SuggestionHighlight>
+    </span>,
+    'The default theme already meets WCAG 2.1 AA contrast for body text and controls. When customising colours, keep contrast above 4.5:1 between launcher text and launcher background — the colour picker shows a live contrast warning when you fall below this. Other accessibility-affecting settings:',
+    <span
+      key="s1-list-1"
+      className="block text-[16px] leading-[24px] text-text-primary"
+    >
+      <SuggestionHighlight>
+        <span className="flex items-start">
+          <span className="shrink-0 pr-2">•</span>
+          <span>
+            Always provide a non-emoji welcome banner — screen readers
+            treat emoji-only banners as decorative.
+          </span>
+        </span>
+      </SuggestionHighlight>
+    </span>,
+    <span
+      key="s1-list-2"
+      className="block text-[16px] leading-[24px] text-text-primary"
+    >
+      <SuggestionHighlight>
+        <span className="flex items-start">
+          <span className="shrink-0 pr-2">•</span>
+          <span>
+            Keep the launcher position bottom-right unless your site&rsquo;s
+            navigation conflicts — most users now expect that spot.
+          </span>
+        </span>
+      </SuggestionHighlight>
+    </span>,
+    <span
+      key="s1-list-3"
+      className="block text-[16px] leading-[24px] text-text-primary"
+    >
+      <SuggestionHighlight>
+        <span className="flex items-start">
+          <span className="shrink-0 pr-2">•</span>
+          <span>
+            Enable keyboard-shortcut hints in{' '}
+            <Strong>Widget → Behaviour</Strong> for power users on
+            assistive tech.
+          </span>
+        </span>
+      </SuggestionHighlight>
+    </span>,
+  ],
+  betweenS1AndS2: (
+    <>
+      <H2>Setting the Brand Color</H2>
+      <P>
+        Customizing the colour is usually the first step when matching
+        the widget to your brand. The widget propagates the brand colour
+        to the launcher, the header bar, and outgoing message bubbles.
+      </P>
+    </>
+  ),
+  /* Replace — Color picker → Theme selector. Inline <Strong> picks up
+   * the bolded component names from the suggestion payload. */
+  s2: {
+    before: [
+      <span
+        key="s2-before"
+        className="text-[16px] leading-[24px] text-text-primary"
+      >
+        <SuggestionHighlight>
+          Use the <Strong>Color picker</Strong> to set the launcher and
+          header background. The text colour auto-adjusts for contrast —
+          the widget stays legible whether you pick a deep navy or a pale
+          cream as the base.
+        </SuggestionHighlight>
+      </span>,
+    ],
+    after: [
+      <span
+        key="s2-after"
+        className="text-[16px] leading-[24px] text-text-primary"
+      >
+        <SuggestionHighlight>
+          Use the <Strong>Theme selector</Strong> (now WCAG-validated) to
+          set the launcher and header background. Hiver shows a live
+          contrast badge as you pick — anything below WCAG 2.1 AA earns a
+          warning so you can correct before the widget ships.
+        </SuggestionHighlight>
+      </span>,
+    ],
+  },
+  betweenS2AndS3: (
+    <>
+      <H2>Installing the Widget</H2>
+      <P>
+        Once your theme is finalised, install the widget on your site.
+        The recommended method is a <code>&lt;script&gt;</code> tag in
+        your page&rsquo;s <code>&lt;head&gt;</code> — it loads
+        asynchronously, supports realtime features, and updates
+        automatically when you change widget settings.
+      </P>
+    </>
+  ),
+  /* Removal — legacy iframe embed. H2 + body each render as their own
+   * highlighted entry so the heading keeps its typography. */
+  s3: [
+    <span
+      key="s3-h2"
+      className="block text-[20px] font-semibold leading-[28px] text-text-primary"
+    >
+      <SuggestionHighlight>Embedding via iframe</SuggestionHighlight>
+    </span>,
+    'For pages where you can’t drop a script tag (legacy CMS, sandboxed environments) you can embed the widget as an iframe. Get the iframe URL from Widget → Install → iframe. Note that iframe embed disables some features — agent typing indicators, file drag-drop, and screen-share invitations all rely on the parent-page script.',
+  ],
+  afterS3: (
+    <>
+      <H2>Testing on Staging</H2>
+      <P>
+        Before promoting widget changes to production, test in a staging
+        environment. Hiver lets you toggle the staging variant from{' '}
+        <Strong>Widget → Environments</Strong> — staging traffic stays
+        isolated from production analytics and customer histories.
+      </P>
+    </>
+  ),
+};


### PR DESCRIPTION
## Summary
- Each of the 3 AI-targeted articles now renders its own body content instead of all three sharing `passwordResetRegions`.
- New `autoReplyRegions.tsx` + `chatWidgetRegions.tsx` thread the existing `sug-autoreply-*` / `sug-chatwidget-*` payload copy into the s1/s2/s3 slots — green addition / red+green replace / red removal each land on the right region.
- `ReviewPage` now dispatches via a per-article-id lookup; falls back to password-reset for unseeded ids.
- Password-reset article body unchanged.

## Test plan
- [x] `npm run --workspace=packages/kb-ui typecheck`
- [x] `npm run --workspace=apps/demo typecheck`
- [x] `npm run --workspace=packages/kb-ui build`
- [x] `npm run --workspace=packages/kb-ui build-storybook`
- [x] `npm run --workspace=apps/demo build`
- [x] Playwright @ 1880px — all 3 articles render distinct copy; s1/s2/s3 highlights land on the matching paragraph in each.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>