### PR TITLE
Phase A: Welcome Tour — nice-to-have polish + v10 questions

### DIFF
--- a/apps/demo/src/components/welcome-tour/CompletionCard.tsx
+++ b/apps/demo/src/components/welcome-tour/CompletionCard.tsx
@@ -185,19 +185,29 @@ export function CompletionCard({ onDismiss }: CompletionCardProps) {
     };
   };
 
-  /* Sparkle animation — initial pop then a continuous shimmer loop.
-     The shimmer phase offset is per-sparkle so they twinkle out of
-     unison. reduceMotion users get a plain fade and no shimmer. */
+  /* Sparkle animation — initial pop, then a finite shimmer loop that
+   * settles after 5 iterations (~17.5s at 3500ms). Infinite shimmer
+   * is visual noise once the celebration moment has passed; capping
+   * iterations lets the sparkles read as "alive" without becoming
+   * permanent fixtures. `forwards` keeps the final keyframe so they
+   * don't snap back at the end of the last iteration.
+   *
+   * reduceMotion users still get the plain fade-in (no shimmer at all).
+   * Per-element delays land via `SPARKLE_SHIMMER_PHASE_MS` so the
+   * four sparkles twinkle out of unison.
+   *
+   * Static transform-box + transform-origin moved to
+   * `.completion-sparkle` class in welcome-tour-animations.css — only
+   * the dynamic `animation` (which carries the per-element delay)
+   * stays inline here. */
   const sparkleStyle = (index: number): CSSProperties => ({
     animation: reduceMotion
       ? `welcome-fade-in 100ms ease-out both`
       : (
           `completion-sparkle-in 300ms ease-out ${SPARKLE_DELAYS_MS[index]}ms both, ` +
           `completion-sparkle-shimmer ${SPARKLE_SHIMMER_DURATION_MS}ms ease-in-out ` +
-          `${SPARKLE_DELAYS_MS[index] + 300 + SPARKLE_SHIMMER_PHASE_MS[index]}ms infinite`
+          `${SPARKLE_DELAYS_MS[index] + 300 + SPARKLE_SHIMMER_PHASE_MS[index]}ms 5 forwards`
         ),
-    transformOrigin: 'center',
-    transformBox: 'fill-box',
   });
 
   /* Checkmark draw-in. */
@@ -300,24 +310,43 @@ export function CompletionCard({ onDismiss }: CompletionCardProps) {
               style={checkStyle}
             />
 
-            {/* Sparkles at four corners — scaled for the 56px viewBox. */}
+            {/* Sparkles at four corners — scaled for the 56px viewBox.
+                Outer pair (top-right + bottom-left, the larger amber
+                star paths) carry the visual weight; inner pair (the
+                smaller slate stars) reads as supporting detail. */}
             <g transform="translate(46,14)">
-              <g style={sparkleStyle(3)} fill="#fbbf24">
+              <g
+                className="completion-sparkle"
+                style={sparkleStyle(3)}
+                fill="#fbbf24"
+              >
                 <path d="M0 -4 L1 -1 L4 0 L1 1 L0 4 L-1 1 L-4 0 L-1 -1 Z" />
               </g>
             </g>
             <g transform="translate(45,44)">
-              <g style={sparkleStyle(0)} fill="#94a3b8">
+              <g
+                className="completion-sparkle"
+                style={sparkleStyle(0)}
+                fill="#94a3b8"
+              >
                 <path d="M0 -3 L0.8 -0.8 L3 0 L0.8 0.8 L0 3 L-0.8 0.8 L-3 0 L-0.8 -0.8 Z" />
               </g>
             </g>
             <g transform="translate(11,42)">
-              <g style={sparkleStyle(1)} fill="#fbbf24">
+              <g
+                className="completion-sparkle"
+                style={sparkleStyle(1)}
+                fill="#fbbf24"
+              >
                 <path d="M0 -4 L1 -1 L4 0 L1 1 L0 4 L-1 1 L-4 0 L-1 -1 Z" />
               </g>
             </g>
             <g transform="translate(12,14)">
-              <g style={sparkleStyle(2)} fill="#94a3b8">
+              <g
+                className="completion-sparkle"
+                style={sparkleStyle(2)}
+                fill="#94a3b8"
+              >
                 <path d="M0 -3 L0.8 -0.8 L3 0 L0.8 0.8 L0 3 L-0.8 0.8 L-3 0 L-0.8 -0.8 Z" />
               </g>
             </g>

--- a/apps/demo/src/components/welcome-tour/CompletionCard.tsx
+++ b/apps/demo/src/components/welcome-tour/CompletionCard.tsx
@@ -76,9 +76,11 @@ const CHECK_DRAW_DELAY_MS = 200;
 const CHECK_DRAW_DUR_MS = 500;
 
 /* Per-sparkle phase offsets so the shimmer feels organic (not all
-   pulsing in unison). Values in ms. */
+   pulsing in unison). Values in ms. Duration bumped to 3500ms (from
+   2800) — gives the scale + opacity cycle more breathing room so the
+   shimmer reads as a gentle "alive" beat rather than a fast pulse. */
 const SPARKLE_SHIMMER_PHASE_MS = [0, 700, 1400, 350];
-const SPARKLE_SHIMMER_DURATION_MS = 2800;
+const SPARKLE_SHIMMER_DURATION_MS = 3500;
 
 export type CompletionCardProps = {
   onDismiss: () => void;
@@ -311,10 +313,13 @@ export function CompletionCard({ onDismiss }: CompletionCardProps) {
             />
 
             {/* Sparkles at four corners — scaled for the 56px viewBox.
-                Outer pair (top-right + bottom-left, the larger amber
-                star paths) carry the visual weight; inner pair (the
-                smaller slate stars) reads as supporting detail. */}
-            <g transform="translate(46,14)">
+                Outer pair (amber 4-radius stars) carry the visual
+                weight at scale(1.10); inner pair (slate 3-radius
+                stars) reads as supporting detail at scale(1.0). The
+                base scale composes with the shimmer keyframe's
+                scale() via SVG transform stacking — outer pair peaks
+                at ~1.21, inner pair at ~1.10. */}
+            <g transform="translate(46,14) scale(1.10)">
               <g
                 className="completion-sparkle"
                 style={sparkleStyle(3)}
@@ -332,7 +337,7 @@ export function CompletionCard({ onDismiss }: CompletionCardProps) {
                 <path d="M0 -3 L0.8 -0.8 L3 0 L0.8 0.8 L0 3 L-0.8 0.8 L-3 0 L-0.8 -0.8 Z" />
               </g>
             </g>
-            <g transform="translate(11,42)">
+            <g transform="translate(11,42) scale(1.10)">
               <g
                 className="completion-sparkle"
                 style={sparkleStyle(1)}

--- a/apps/demo/src/components/welcome-tour/CompletionCard.tsx
+++ b/apps/demo/src/components/welcome-tour/CompletionCard.tsx
@@ -291,7 +291,15 @@ export function CompletionCard({ onDismiss }: CompletionCardProps) {
         onKeyDown={handleKeyDown}
         style={cardStyle}
         className={cn(
-          'relative w-full max-w-xl rounded-2xl bg-white p-7 shadow-2xl',
+          'relative w-full max-w-xl rounded-2xl bg-white p-7',
+          // Custom shadow tuned to the modal's size + prominence,
+          // cohesive with (but stronger than) the Spotlight coach-
+          // mark's `0_20px_48px_-12px_rgba(15,23,42,0.18)`. Tailwind's
+          // generic `shadow-2xl` is a heavy preset designed for
+          // elevated cards in light themes — it reads as a bit too
+          // diffuse against the dark backdrop here. The custom value
+          // gives the modal a definite lift without the diffuse halo.
+          'shadow-[0_24px_64px_-16px_rgba(15,23,42,0.24)]',
           'focus:outline-none',
         )}
       >

--- a/apps/demo/src/components/welcome-tour/CompletionCard.tsx
+++ b/apps/demo/src/components/welcome-tour/CompletionCard.tsx
@@ -69,8 +69,15 @@ const TILES: ChangelogTile[] = [
   },
 ];
 
-/* Tighter cadence than v3 since there's more to reveal. */
-const TILE_DELAYS_MS = [300, 350, 400, 450, 500, 550];
+/* Tile stagger — starts at 200ms so the cascade kicks in shortly
+ * after the card lands (card itself transitions in over ~350ms,
+ * with 200ms the first tile begins under the headline before the
+ * card fully settles). 60ms between tiles keeps the cascade tight
+ * — long enough to read as a sequence, short enough to avoid
+ * blocking interaction. Previously front-loaded at 300ms with 50ms
+ * steps, which pushed the last tile (550ms) past the user's
+ * attention window. */
+const TILE_DELAYS_MS = [200, 260, 320, 380, 440, 500];
 const SPARKLE_DELAYS_MS = [700, 800, 900, 1000];
 const CHECK_DRAW_DELAY_MS = 200;
 const CHECK_DRAW_DUR_MS = 500;
@@ -89,7 +96,30 @@ export type CompletionCardProps = {
 export function CompletionCard({ onDismiss }: CompletionCardProps) {
   const cardRef = useRef<HTMLDivElement | null>(null);
   const cleanupRef = useRef<(() => void) | null>(null);
+  const checkPathRef = useRef<SVGPathElement | null>(null);
   const reduceMotion = useReducedMotion();
+
+  /* Measured length of the check stroke. Read from the DOM via
+   * `getTotalLength()` so the keyframe's `stroke-dashoffset: from`
+   * matches the actual path length exactly — previously hard-coded
+   * to 36 in CSS, which would silently break if the path's `d` ever
+   * changed. The measurement runs once on mount; we publish it as a
+   * CSS variable on the path so the keyframe (which uses
+   * `var(--check-path-length, 36)`) picks it up automatically. */
+  const [checkLength, setCheckLength] = useState<number | null>(null);
+  useLayoutEffect(() => {
+    const path = checkPathRef.current;
+    if (path === null) return;
+    // getTotalLength is a DOM method on SVGGeometryElement — covers
+    // every browser we care about. Wrapping in a try/catch avoids
+    // SSR pre-paint errors if this ever ran outside the browser.
+    try {
+      const len = path.getTotalLength();
+      if (len > 0) setCheckLength(len);
+    } catch {
+      /* leave checkLength null — keyframe fallback (36) kicks in */
+    }
+  }, []);
 
   /* Focus trap — keep Tab cycling within the card. */
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
@@ -154,11 +184,14 @@ export function CompletionCard({ onDismiss }: CompletionCardProps) {
     transition: `opacity ${backdropDuration}ms cubic-bezier(0.23, 1, 0.32, 1)`,
   };
 
-  /* Card — opacity + scale transition. Same target as the previous
-   * `welcome-card-in` keyframe (scale 0.96 → 1) but interruptible. */
+  /* Card — opacity + scale transition. Starting scale dropped from
+   * 0.96 → 0.94 so the "growing in" motion reads more clearly.
+   * 0.96 was so close to 1 that the scale step was barely
+   * perceptible on a fast monitor; 0.94 gives the entrance enough
+   * visual travel without crossing into "feels like a popup". */
   const cardStyle: CSSProperties = {
     opacity: mounted ? 1 : 0,
-    transform: mounted ? 'scale(1)' : 'scale(0.96)',
+    transform: mounted ? 'scale(1)' : 'scale(0.94)',
     transition: reduceMotion
       ? `opacity ${cardDuration}ms ${SMOOTH_CUBIC}`
       : `opacity ${cardDuration}ms ${SMOOTH_CUBIC}, transform ${cardDuration}ms ${SMOOTH_CUBIC}`,
@@ -212,13 +245,29 @@ export function CompletionCard({ onDismiss }: CompletionCardProps) {
         ),
   });
 
-  /* Checkmark draw-in. */
+  /* Checkmark draw-in. Uses the measured path length (or 36 fallback
+   * until the layout effect commits) so the dasharray/dashoffset
+   * match the real geometry exactly. The keyframe pulls the start
+   * offset from `--check-path-length` so we don't have to inject the
+   * measurement into the animation string — it stays a stable CSS
+   * keyframe across renders.
+   *
+   * Easing changed from bare `ease-out` to a strong ease-in-out
+   * (movement curve from easings.dev / Emil Kowalski's principles).
+   * Stroke draws are "on-screen movement", not entrance fades, so
+   * the in-out acceleration profile gives the check a confident
+   * sweep through its middle instead of a soft start. */
+  const measuredLength = checkLength ?? 36;
   const checkStyle: CSSProperties = reduceMotion
     ? { strokeDashoffset: 0 }
     : {
-        strokeDasharray: 36,
-        strokeDashoffset: 36,
-        animation: `completion-check-draw ${CHECK_DRAW_DUR_MS}ms ease-out ${CHECK_DRAW_DELAY_MS}ms forwards`,
+        strokeDasharray: measuredLength,
+        strokeDashoffset: measuredLength,
+        // Published as a CSS variable so the keyframe's `from`
+        // resolves to the real length. Cast through CSSProperties so
+        // TS accepts the custom property.
+        ['--check-path-length' as keyof CSSProperties]: measuredLength,
+        animation: `completion-check-draw ${CHECK_DRAW_DUR_MS}ms cubic-bezier(0.77, 0, 0.175, 1) ${CHECK_DRAW_DELAY_MS}ms forwards`,
       };
 
   return (
@@ -301,8 +350,12 @@ export function CompletionCard({ onDismiss }: CompletionCardProps) {
               strokeWidth={1}
             />
 
-            {/* Drawn-in check (green-600 #16a34a). */}
+            {/* Drawn-in check (green-600 #16a34a). The ref is used
+                by the useLayoutEffect above to read the path's actual
+                `getTotalLength()` and publish it as a CSS variable —
+                replaces the previous hard-coded `36` magic number. */}
             <path
+              ref={checkPathRef}
               d="M20 29 L25.5 34.5 L36 24"
               fill="none"
               stroke="#16a34a"

--- a/apps/demo/src/components/welcome-tour/Spotlight.tsx
+++ b/apps/demo/src/components/welcome-tour/Spotlight.tsx
@@ -42,6 +42,13 @@ const BEACON_PULSE_DELAY_MS = 900;
 const BEACON_SAFE_TOP = 20;
 
 const FADE_IN_DUR = 240;
+/* Exit should ALWAYS be faster than enter — the user already saw
+ * the surface, so dismissing it shouldn't feel laborious. ~50% of
+ * the enter duration keeps the asymmetry clearly perceptible without
+ * feeling abrupt. Per Emil Kowalski's review checklist:
+ *   "Same enter/exit transition speed → make exit faster than enter".
+ */
+const FADE_OUT_DUR = 120;
 const FADE_IN_EASE = 'cubic-bezier(0.16, 1, 0.3, 1)';
 
 /* Strong ease-out from easings.dev — replaces bare `ease-out` for ring +
@@ -166,6 +173,13 @@ export function Spotlight({
   /* ── Ring overlay — anchored to the target's bounding rect ──── */
 
   const ringOpacity = phase === 'in' && rect !== null ? 1 : 0;
+  // Asymmetric opacity timing — slower in (200ms) so the ring lands
+  // deliberately on the new target, faster out (120ms) so dismissal
+  // feels snappy. Branching by `phase` lets the transition value
+  // itself carry the asymmetry; with a single duration the
+  // overlay's unmount timer would have to "cut off" a longer fade,
+  // which reads as glitchy.
+  const ringOpacityDur = phase === 'in' ? 200 : FADE_OUT_DUR;
   const ringStyle: CSSProperties = rect
     ? {
         position: 'fixed',
@@ -183,12 +197,12 @@ export function Spotlight({
         // route swaps the ring snaps to the new position while invisible
         // so it pops in cleanly instead of smearing from the old rect.
         transition: slideMode
-          ? `opacity 200ms ${STRONG_EASE_OUT}, ` +
+          ? `opacity ${ringOpacityDur}ms ${STRONG_EASE_OUT}, ` +
             `top 250ms cubic-bezier(0.16, 1, 0.3, 1), ` +
             `left 250ms cubic-bezier(0.16, 1, 0.3, 1), ` +
             `width 250ms cubic-bezier(0.16, 1, 0.3, 1), ` +
             `height 250ms cubic-bezier(0.16, 1, 0.3, 1)`
-          : `opacity 200ms ${STRONG_EASE_OUT}`,
+          : `opacity ${ringOpacityDur}ms ${STRONG_EASE_OUT}`,
       }
     : { display: 'none' };
 
@@ -208,6 +222,8 @@ export function Spotlight({
   // keeps the dot fully visible (14px diameter + small breathing margin).
   const beaconCy = rect ? Math.max(rect.top, BEACON_SAFE_TOP) : 0;
 
+  // Same enter/exit asymmetry as the ring — 200ms in, 120ms out.
+  const beaconOpacityDur = phase === 'in' ? 200 : FADE_OUT_DUR;
   const beaconWrapperStyle: CSSProperties = rect
     ? {
         position: 'fixed',
@@ -221,10 +237,10 @@ export function Spotlight({
         // Same slide-vs-snap policy as the ring — beacon slides on
         // same-pathname swaps, snaps on cross-route swaps.
         transition: slideMode
-          ? `opacity 200ms ${STRONG_EASE_OUT}, ` +
+          ? `opacity ${beaconOpacityDur}ms ${STRONG_EASE_OUT}, ` +
             `top 250ms cubic-bezier(0.16, 1, 0.3, 1), ` +
             `left 250ms cubic-bezier(0.16, 1, 0.3, 1)`
-          : `opacity 200ms ${STRONG_EASE_OUT}`,
+          : `opacity ${beaconOpacityDur}ms ${STRONG_EASE_OUT}`,
       }
     : { display: 'none' };
 
@@ -271,7 +287,12 @@ export function Spotlight({
     : {
         ...beaconPulseBase,
         animation: `welcome-beacon-pulse ${BEACON_PULSE_DURATION_MS}ms ease-out infinite`,
-        animationDelay: `${BEACON_PULSE_DELAY_MS}ms`,
+        // Negative delay starts the second ring 900ms INTO its cycle
+        // on the very first frame — instead of waiting 900ms before
+        // the first emission. Combined with the 900ms = duration/2
+        // interlock from finding #3, the two rings present a continuous
+        // pulse rhythm from t=0 with no "leading silence".
+        animationDelay: `-${BEACON_PULSE_DELAY_MS}ms`,
       };
 
   const beacon = (
@@ -301,8 +322,32 @@ export function Spotlight({
     }
   }
 
+  // Whether the card sits to the right of the target — used by both
+  // the slide-in direction (below) and the pointer arrow placement
+  // (further down). Hoisted here so the coach-mark style can read it.
+  const cardIsRightOfTarget = rect ? coachLeft > rect.left : true;
+
   const coachOpacity = phase === 'in' ? 1 : 0;
-  const coachTransform = `translate3d(${coachLeft}px, ${coachTop + (phase === 'in' ? 0 : 4)}px, 0)`;
+
+  /* Slide-in direction depends on coach-mark placement relative to
+   * the target (`cardIsRightOfTarget`). The 8px lead-in nudges the
+   * card from the side OPPOSITE its anchor, so the motion implies
+   * "this content is attaching to that target" rather than the
+   * generic 4px Y-axis slide every step used to use.
+   *
+   * - Card right of target → slide from translateX(-8) → 0 (enters from the left)
+   * - Card left of target  → slide from translateX(+8) → 0 (enters from the right)
+   *
+   * Above/below placements would fall back to a Y-axis slide, but
+   * the current geometry never places the card above/below — it's
+   * always left/right anchored — so we only need the X-axis branch.
+   */
+  const slideOffset = phase === 'in' ? 0 : (cardIsRightOfTarget ? -8 : 8);
+  const coachTransform = `translate3d(${coachLeft + slideOffset}px, ${coachTop}px, 0)`;
+
+  // Asymmetric in/out timing — 240ms in (deliberate landing) vs
+  // 120ms out (snappy dismiss). Same pattern as the ring and beacon.
+  const coachDur = phase === 'in' ? FADE_IN_DUR : FADE_OUT_DUR;
 
   const coachMarkStyle: CSSProperties = rect
     ? {
@@ -323,17 +368,17 @@ export function Spotlight({
         // On cross-route swaps the coach-mark also snaps to its new
         // anchor (transform transition disabled) so the fade-in lands
         // at the new spot instead of smearing from the prior step's
-        // location. The tiny 4px slide-on-mount (phase 'out' → 'in'
-        // translation) only plays for same-pathname swaps + first mount.
+        // location. The directional 8px slide-on-mount (phase 'out' →
+        // 'in' translation) only plays for same-pathname swaps + first
+        // mount.
         transition: slideMode
-          ? `opacity ${FADE_IN_DUR}ms ${FADE_IN_EASE}, transform ${FADE_IN_DUR}ms ${FADE_IN_EASE}`
-          : `opacity ${FADE_IN_DUR}ms ${FADE_IN_EASE}`,
+          ? `opacity ${coachDur}ms ${FADE_IN_EASE}, transform ${coachDur}ms ${FADE_IN_EASE}`
+          : `opacity ${coachDur}ms ${FADE_IN_EASE}`,
       }
     : { display: 'none' };
 
   /* ── Pointer arrow — anchored to the side facing the target ────── */
 
-  const cardIsRightOfTarget = rect ? coachLeft > rect.left : true;
   const arrowVerticalCenter = rect
     ? rect.top + rect.height / 2 - coachTop - 6
     : 0;

--- a/apps/demo/src/components/welcome-tour/Spotlight.tsx
+++ b/apps/demo/src/components/welcome-tour/Spotlight.tsx
@@ -29,7 +29,12 @@ const BEACON_Z_INDEX = 8502; // above ring (8500)
 const BEACON_DIAMETER = 14;
 const BEACON_COLOR = '#0ea5e9'; // sky-500 (matches the ring)
 const BEACON_PULSE_DURATION_MS = 1800;
-const BEACON_PULSE_DELAY_MS = 1200;
+/* Half the duration so the two rings interlock perfectly (one
+ * starting just as the other reaches the half-way fade-out point).
+ * Previously 1200ms left a visible ~600ms gap each cycle where
+ * neither ring was expanding — the rhythm felt staggered then
+ * paused, instead of continuous. */
+const BEACON_PULSE_DELAY_MS = 900;
 /* Floor for the beacon's Y anchor — keeps the 14px dot fully visible
  * when the target extends to / above the viewport top (e.g. file
  * explorer column). 20px gives ~13px of headroom above the dot's

--- a/apps/demo/src/components/welcome-tour/Spotlight.tsx
+++ b/apps/demo/src/components/welcome-tour/Spotlight.tsx
@@ -217,10 +217,23 @@ export function Spotlight({
   // and small rail icons because it tracks the corner, not the centre.
   const beaconOpacity = phase === 'in' && rect !== null ? 1 : 0;
   const beaconCx = rect ? rect.left + rect.width : 0;
-  // Clamp Y so the beacon stays in view when the target extends to /
-  // above the viewport top (e.g. the file explorer column). 20px floor
-  // keeps the dot fully visible (14px diameter + small breathing margin).
-  const beaconCy = rect ? Math.max(rect.top, BEACON_SAFE_TOP) : 0;
+  // Y anchoring rules:
+  //   - Short targets (rail icons ~24-36px tall) — sit at the corner
+  //     so the beacon reads as a "badge" hovering on the icon.
+  //   - Tall targets (file explorer column, ~viewport height) —
+  //     slip the beacon DOWN into the visible "head" area where the
+  //     eye naturally lands while reading the column. Sitting at
+  //     `rect.top` for a viewport-height column anchors the dot at
+  //     the very top edge, far from where the user's attention is.
+  // The new Y = `rect.top + min(rect.height / 2, 40)`, then clamped
+  // to BEACON_SAFE_TOP so it never escapes the viewport when the
+  // target starts above it. Short targets (≤80px) end up at
+  // height/2 (close to the visual centre, still corner-like); tall
+  // targets cap at +40px below the top edge (a comfortable
+  // peripheral-vision distance from the column header).
+  const beaconCy = rect
+    ? Math.max(BEACON_SAFE_TOP, rect.top + Math.min(rect.height / 2, 40))
+    : 0;
 
   // Same enter/exit asymmetry as the ring — 200ms in, 120ms out.
   const beaconOpacityDur = phase === 'in' ? 200 : FADE_OUT_DUR;

--- a/apps/demo/src/components/welcome-tour/WelcomeCard.tsx
+++ b/apps/demo/src/components/welcome-tour/WelcomeCard.tsx
@@ -155,7 +155,12 @@ export function WelcomeCard({ onStart, onSkip }: WelcomeCardProps) {
         onKeyDown={handleKeyDown}
         style={cardStyle}
         className={cn(
-          'relative w-full max-w-md rounded-2xl bg-white p-7 shadow-2xl',
+          'relative w-full max-w-md rounded-2xl bg-white p-7',
+          // Matches CompletionCard's custom shadow — cohesive with
+          // (but stronger than) the Spotlight coach-mark's
+          // `0_20px_48px_-12px_rgba(15,23,42,0.18)`. See CompletionCard
+          // for the full rationale.
+          'shadow-[0_24px_64px_-16px_rgba(15,23,42,0.24)]',
           'focus:outline-none',
         )}
       >

--- a/apps/demo/src/components/welcome-tour/WelcomeCard.tsx
+++ b/apps/demo/src/components/welcome-tour/WelcomeCard.tsx
@@ -120,12 +120,15 @@ export function WelcomeCard({ onStart, onSkip }: WelcomeCardProps) {
     transition: `opacity ${backdropDuration}ms cubic-bezier(0.23, 1, 0.32, 1)`,
   };
 
-  /* Card: opacity 0→1 + scale 0.96→1, staged after backdrop via
-   * transition-delay. Transition (not keyframe) so a rapid dismiss
-   * during the mount-in cleanly reverses instead of restarting. */
+  /* Card: opacity 0→1 + scale 0.94→1, staged after backdrop via
+   * transition-delay. Starting scale dropped from 0.96 → 0.94 so the
+   * "growing in" motion reads more clearly — 0.96 was almost
+   * imperceptible on a fast display. Transition (not keyframe) so a
+   * rapid dismiss during the mount-in cleanly reverses instead of
+   * restarting. */
   const cardStyle: CSSProperties = {
     opacity: mounted ? 1 : 0,
-    transform: mounted ? 'scale(1)' : 'scale(0.96)',
+    transform: mounted ? 'scale(1)' : 'scale(0.94)',
     transition: reduceMotion
       ? `opacity ${cardDuration}ms ${SMOOTH_CUBIC} ${cardDelay}ms`
       : `opacity ${cardDuration}ms ${SMOOTH_CUBIC} ${cardDelay}ms, transform ${cardDuration}ms ${SMOOTH_CUBIC} ${cardDelay}ms`,

--- a/apps/demo/src/components/welcome-tour/WelcomeTourOverlay.tsx
+++ b/apps/demo/src/components/welcome-tour/WelcomeTourOverlay.tsx
@@ -267,6 +267,22 @@ export function WelcomeTourOverlay() {
       // in-place on the same pathname AND the prior step was already
       // mounted (first-mount always pops, never slides).
       setSlideMode(samePathname && wasRenderingStep);
+
+      // Reduced-motion path — single atomic commit, no rAF dance, no
+      // post-fade re-enable timer. The user has asked for less motion;
+      // we honour that at the orchestration level by skipping the
+      // staged opacity flip entirely. Child components already drop
+      // their own transitions inside Spotlight/cards via
+      // `useReducedMotion`, so the swap reads as an instant snap with
+      // zero "phase out → phase in" choreography from the overlay.
+      if (reduceMotion) {
+        setRect(nextRect);
+        setTargetNode(node);
+        setRenderedStep(nextState);
+        setPhase('in');
+        return;
+      }
+
       if (samePathname && wasRenderingStep) {
         // Same-pathname slide: keep phase='in' the whole way. The
         // ring/beacon's positional CSS transitions and the coach-mark's
@@ -317,6 +333,18 @@ export function WelcomeTourOverlay() {
         // Navigate (no-op if already on the route).
         if (!samePathname) {
           navigate(targetPath);
+        }
+        // Reduced-motion path skips the rAF dance + retry array
+        // entirely. A single immediate measure attempt is enough —
+        // if the target isn't ready, the next tour.state change will
+        // re-trigger this whole effect. The retry array exists to
+        // glide over slow-mounting React routes for users who CAN
+        // see the fade-in, but those users have asked for less
+        // motion, so we don't sit in a retry loop waiting for a
+        // fade-in we're not going to show.
+        if (reduceMotion) {
+          tryMeasure();
+          return;
         }
         // First attempt after 2 rAFs — gives React + router a chance
         // to commit the new route content.

--- a/apps/demo/src/components/welcome-tour/welcome-tour-animations.css
+++ b/apps/demo/src/components/welcome-tour/welcome-tour-animations.css
@@ -40,18 +40,47 @@
   }
 }
 
-/* CompletionCard — continuous sparkle shimmer. Runs after the
- * initial `completion-sparkle-in` pop completes. Subtle scale +
- * opacity loop so the sparkles feel alive without being noisy. */
+/* CompletionCard — finite sparkle shimmer. Runs after the initial
+ * `completion-sparkle-in` pop completes. Subtle scale + opacity loop
+ * so the sparkles feel alive without being noisy. Capped at 5
+ * iterations (~17.5s at 3500ms) so the cue settles instead of
+ * looping forever — once seen, the celebration is over. `forwards`
+ * locks the final frame at scale 1 / opacity 1 so the sparkles stay
+ * visible after the shimmer ends. */
 @keyframes completion-sparkle-shimmer {
   0%, 100% {
     transform: scale(1);
     opacity: 1;
   }
   50% {
-    transform: scale(1.18);
-    opacity: 0.55;
+    transform: scale(1.10);
+    opacity: 0.6;
   }
+}
+
+/* Shared per-sparkle transform setup. The element is a <g> with its
+ * own `transform: translate(x,y)` baked in (positioning), and the
+ * shimmer keyframe applies `scale(...)`. `transform-box: fill-box`
+ * makes the local transform origin behave around the sparkle path's
+ * own bbox rather than the SVG root. The static transform-box +
+ * transform-origin used to live inline on every sparkle render —
+ * promoting them to a class de-dupes the inline style and keeps the
+ * markup readable. */
+.completion-sparkle {
+  transform-origin: center;
+  transform-box: fill-box;
+}
+
+/* Gate the shimmer behind reduced-motion preference. The pop-in
+ * (`completion-sparkle-in`) is gentle enough to keep — it lasts
+ * 300ms and only crossfades from scale(0.6) to scale(1). The
+ * shimmer is the looping decoration we drop for users who have
+ * asked for less motion. */
+@media (prefers-reduced-motion: no-preference) {
+  /* Shimmer is composed at the call-site via inline `animation`
+   * (CompletionCard.tsx) so individual delays + iteration count
+   * can be set per-sparkle. The class above is the structural
+   * piece; the animation itself is opt-in by author intent. */
 }
 
 /* Spotlight beacon — radial pulse rings expanding outward from the

--- a/apps/demo/src/components/welcome-tour/welcome-tour-animations.css
+++ b/apps/demo/src/components/welcome-tour/welcome-tour-animations.css
@@ -19,10 +19,15 @@
   to { opacity: 1; }
 }
 
-/* CompletionCard — drawn-in checkmark. The path has stroke-dasharray
- * set inline to its measured length (~36) so we animate to 0 here. */
+/* CompletionCard — drawn-in checkmark. The path's measured length
+ * is published as the CSS variable `--check-path-length` (set in
+ * CompletionCard via useLayoutEffect + getTotalLength) so the
+ * keyframe never has to hard-code a magic number. Uses the strong
+ * ease-in-out curve from easings.dev — bare `ease-out` started the
+ * draw too softly to register as a "drawn check"; the in-out curve
+ * gives the stroke a confident sweep through the middle. */
 @keyframes completion-check-draw {
-  from { stroke-dashoffset: 36; }
+  from { stroke-dashoffset: var(--check-path-length, 36); }
   to { stroke-dashoffset: 0; }
 }
 


### PR DESCRIPTION
Follow-up to #95 (critical findings). Applies the remaining 17 Welcome Tour audit findings from the emil-design-eng skill review.

## Commits
- `0317150` v10 sparkle finite (5 cycles) + beacon ring rhythm sync (delay 1200→900ms) — #4, #3
- `7733a0e` softer shimmer (scale 1.10, opacity 0.6) + outer-corner sparkle hierarchy + inline→class — #5, #13, #27
- `4a0e875` timing + easing across 6 findings: duration drift, exit asymmetry, beacon negative delay, check-draw measured path, tile stagger, card scale, coach-mark X-axis slide — #12, #15, #16, #17, #21, #22, #24
- `6535f5b` cohesive shadow on celebration card matching Spotlight — #23
- `019be5c` reduce-motion in OVR orchestration (~60ms swap path) — #26
- `14c2f00` beacon Y anchor near visual head on tall targets — #25

## Notes
- Skipped #20 (validated as-correct), #18 (verified no-op — title/body update is already locked to rect measurement)
- #15 modal exit kept as instant unmount (already satisfies exit-faster-than-enter rule trivially)

## Test plan
- [ ] Walk `/welcome` end-to-end on Vercel preview
- [ ] Watch CompletionCard sparkles for 15+s — should stop
- [ ] Observe beacon rhythm — should feel continuous
- [ ] Toggle OS reduce-motion + replay