### PR TITLE
refactor(kb-ui): lift ConfirmDialog from demo

### DIFF
--- a/apps/demo/src/hooks/useUnsavedChangesGuard.tsx
+++ b/apps/demo/src/hooks/useUnsavedChangesGuard.tsx
@@ -23,7 +23,7 @@
 
 import { type ReactNode, useEffect } from 'react';
 import { useBlocker } from 'react-router-dom';
-import { ConfirmDialog } from '../components/ConfirmDialog';
+import { ConfirmDialog } from '@test-kb-ui/kb-ui';
 
 const DEFAULT_TITLE = 'Discard unsaved changes?';
 const DEFAULT_MESSAGE =

--- a/apps/demo/src/routes/kb/EditorPage.tsx
+++ b/apps/demo/src/routes/kb/EditorPage.tsx
@@ -58,7 +58,7 @@ import {
 } from '../../shell/EditorPageController';
 import { useUnsavedChangesGuard } from '../../hooks/useUnsavedChangesGuard';
 import { useToast } from '../../components/Toast';
-import { ConfirmDialog } from '../../components/ConfirmDialog';
+import { ConfirmDialog } from '@test-kb-ui/kb-ui';
 
 /* ─────────────────────────────────────────────────────────────
  * Constants

--- a/apps/demo/src/shell/BreadcrumbBar.tsx
+++ b/apps/demo/src/shell/BreadcrumbBar.tsx
@@ -35,7 +35,7 @@ import {
 import { routes } from '../lib/routes';
 import { useEditorPageControls } from './EditorPageController';
 import { useToast } from '../components/Toast';
-import { ConfirmDialog } from '../components/ConfirmDialog';
+import { ConfirmDialog } from '@test-kb-ui/kb-ui';
 import { useSidebarCollapse } from './SidebarCollapseContext';
 
 type BreadcrumbConfig = {

--- a/packages/kb-ui/src/components/overlays/ConfirmDialog.stories.tsx
+++ b/packages/kb-ui/src/components/overlays/ConfirmDialog.stories.tsx
@@ -1,0 +1,131 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { Trash01 } from '@untitledui/icons';
+import '../../tokens.css';
+import { ConfirmDialog } from './ConfirmDialog';
+import { Button } from '../primitives/Button';
+
+/* ─────────────────────────────────────────────────────────────
+ * Four discrete stories exercising every branch of
+ * `ConfirmDialog`:
+ *
+ *   - Primary       — title + message + primary confirm.
+ *   - Destructive   — title + message + danger confirm.
+ *   - WithTitleIcon — exercises the `titleIcon` slot alongside
+ *                     a destructive action.
+ *   - MessageOnly   — no title; exercises the optional-title
+ *                     branch where only the body copy renders.
+ *
+ * Per project convention these are discrete stories (no
+ * argTypes/controls) so each appears in the Storybook sidebar.
+ * Controls are reserved for collapsing sibling variants — here
+ * each story exercises a different branch worth eyeballing.
+ *
+ * Each story is a controlled wrapper opened from a trigger so
+ * the open/close cycle is exercisable — mirrors the pattern in
+ * Modal.stories / NewCategoryModal.stories next door.
+ * ───────────────────────────────────────────────────────────── */
+
+const meta: Meta<typeof ConfirmDialog> = {
+  title: 'Components/Overlays/Confirm Dialog',
+  component: ConfirmDialog,
+  parameters: { layout: 'centered' },
+  globals: { backgrounds: { value: 'canvas' } },
+};
+export default meta;
+
+function ConfirmDialogPrimary() {
+  const [open, setOpen] = useState(true);
+  return (
+    <>
+      <Button variant="primary" onClick={() => setOpen(true)}>
+        Open confirm
+      </Button>
+      <ConfirmDialog
+        open={open}
+        title="Publish article?"
+        message="This will make the article visible to all readers. You can unpublish at any time."
+        confirmLabel="Publish"
+        onConfirm={() => setOpen(false)}
+        onCancel={() => setOpen(false)}
+      />
+    </>
+  );
+}
+
+export const Primary: StoryObj<typeof ConfirmDialog> = {
+  render: () => <ConfirmDialogPrimary />,
+};
+
+function ConfirmDialogDestructive() {
+  const [open, setOpen] = useState(true);
+  return (
+    <>
+      <Button variant="primary" onClick={() => setOpen(true)}>
+        Open destructive confirm
+      </Button>
+      <ConfirmDialog
+        open={open}
+        title="Discard review?"
+        message="Your accept and reject decisions for this review will be cleared. The suggestions remain available to review again later."
+        confirmLabel="Discard review"
+        cancelLabel="Keep reviewing"
+        confirmVariant="destructive"
+        onConfirm={() => setOpen(false)}
+        onCancel={() => setOpen(false)}
+      />
+    </>
+  );
+}
+
+export const Destructive: StoryObj<typeof ConfirmDialog> = {
+  render: () => <ConfirmDialogDestructive />,
+};
+
+function ConfirmDialogWithTitleIcon() {
+  const [open, setOpen] = useState(true);
+  return (
+    <>
+      <Button variant="primary" onClick={() => setOpen(true)}>
+        Open confirm with icon
+      </Button>
+      <ConfirmDialog
+        open={open}
+        title="Delete article?"
+        titleIcon={<Trash01 />}
+        message="This article will be permanently removed. This action cannot be undone."
+        confirmLabel="Delete"
+        confirmVariant="destructive"
+        onConfirm={() => setOpen(false)}
+        onCancel={() => setOpen(false)}
+      />
+    </>
+  );
+}
+
+export const WithTitleIcon: StoryObj<typeof ConfirmDialog> = {
+  render: () => <ConfirmDialogWithTitleIcon />,
+};
+
+function ConfirmDialogMessageOnly() {
+  const [open, setOpen] = useState(true);
+  return (
+    <>
+      <Button variant="primary" onClick={() => setOpen(true)}>
+        Open message-only confirm
+      </Button>
+      <ConfirmDialog
+        open={open}
+        message="Your changes haven't been saved. Leave this page anyway?"
+        confirmLabel="Leave page"
+        cancelLabel="Stay"
+        onConfirm={() => setOpen(false)}
+        onCancel={() => setOpen(false)}
+      />
+    </>
+  );
+}
+
+export const MessageOnly: StoryObj<typeof ConfirmDialog> = {
+  render: () => <ConfirmDialogMessageOnly />,
+};

--- a/packages/kb-ui/src/components/overlays/ConfirmDialog.tsx
+++ b/packages/kb-ui/src/components/overlays/ConfirmDialog.tsx
@@ -1,12 +1,11 @@
-// Phase 7.5.8 — Branded confirm dialog used in place of `window.confirm`.
-//
-// Chrome (overlay, header background, shadow, focus trap, animation, a11y)
-// is provided by `@test-kb-ui/kb-ui`'s `Modal` primitive — see that component
-// for chrome-level concerns. This wrapper only owns the action layout
-// (subtle cancel + primary/danger confirm) and the optional title icon slot.
+// Branded confirm dialog used in place of `window.confirm`. Chrome (overlay,
+// header background, shadow, focus trap, animation, a11y) is provided by the
+// `Modal` primitive — this wrapper only owns the action layout (subtle cancel
+// + primary/danger confirm) and the optional title icon slot.
 
 import * as React from 'react';
-import { Modal, Button } from '@test-kb-ui/kb-ui';
+import { Modal } from './Modal';
+import { Button } from '../primitives/Button';
 
 export type ConfirmDialogProps = {
   /** Controls visibility. Parent owns the open/close lifecycle. */

--- a/packages/kb-ui/src/components/overlays/index.ts
+++ b/packages/kb-ui/src/components/overlays/index.ts
@@ -15,3 +15,5 @@ export type {
   NewCategoryFormValues,
   ParentCategoryOption,
 } from './NewCategoryModal';
+export { ConfirmDialog } from './ConfirmDialog';
+export type { ConfirmDialogProps } from './ConfirmDialog';


### PR DESCRIPTION
## Summary
- Lift `ConfirmDialog` from `apps/demo/src/components/` into `packages/kb-ui/src/components/overlays/` alongside `Modal`/`SideSheet`/`NewCategoryModal`.
- Swap the 3 demo callsites (BreadcrumbBar, useUnsavedChangesGuard, EditorPage) to `@test-kb-ui/kb-ui`; delete the original with no re-export shim.
- Adds 4 Storybook stories: `Primary`, `Destructive`, `WithTitleIcon`, `MessageOnly` — controlled wrappers exercising every prop branch.

## Test plan
- [x] `tsc --noEmit` clean on both workspaces
- [x] `npm run build --workspace=packages/kb-ui` clean
- [x] `npm run build-storybook --workspace=packages/kb-ui` clean
- [x] `npm run build --workspace=apps/demo` clean
- [x] Dev server boots cleanly on a swapped editor route

🤖 Generated with [Claude Code](https://claude.com/claude-code)