### PR TITLE
lift(kb-ui): ShortcutsModal + Kbd from demo (generalized over groups)

### DIFF
--- a/apps/demo/src/components/ShortcutsCheatSheet.tsx
+++ b/apps/demo/src/components/ShortcutsCheatSheet.tsx
@@ -1,12 +1,13 @@
-// Phase 7.5.8 — Keyboard shortcut cheat sheet overlay. Chrome (overlay,
-// focus trap, animation, a11y title) is now provided by kb-ui's `Modal`
-// primitive; this component owns only the catalogue + custom-event wiring
-// that bridges `useGlobalShortcuts` into open/close state.
+// Phase 7.5.8 — Keyboard shortcut cheat sheet overlay.
+//
+// The library's `ShortcutsModal` owns the chrome (modal, header, Kbd
+// rows). This wrapper holds the demo-specific bits:
+//   - the shortcut catalog (Editor / AI Gaps / Anywhere)
+//   - the custom-event bridge from `useGlobalShortcuts` to open/close
+//   - the `?` intro line that references `<Kbd>` inline
 
-import { Modal } from '@test-kb-ui/kb-ui';
-import { XClose } from '@untitledui/icons';
+import { Kbd, ShortcutsModal, type ShortcutGroup } from '@test-kb-ui/kb-ui';
 import { useEffect, useState } from 'react';
-import { cn } from '../lib/cn';
 
 /* ─────────────────────────────────────────────────────────────
  * Custom events — bridge between `useGlobalShortcuts` and this
@@ -17,11 +18,8 @@ export const SHORTCUT_OPEN_EVENT = 'demo:open-shortcuts';
 export const SHORTCUT_CLOSE_EVENT = 'demo:close-shortcuts';
 
 /* ─────────────────────────────────────────────────────────────
- * Shortcut catalogue
+ * Shortcut catalog (demo-only content)
  * ───────────────────────────────────────────────────────────── */
-
-type Shortcut = { keys: string[]; label: string };
-type ShortcutGroup = { title: string; items: Shortcut[] };
 
 const groups: ShortcutGroup[] = [
   {
@@ -70,88 +68,16 @@ export function ShortcutsCheatSheet() {
   }, []);
 
   return (
-    <Modal
+    <ShortcutsModal
       open={open}
       onOpenChange={setOpen}
-      width={480}
-      title="Keyboard shortcuts"
-      titleTrailing={
-        <button
-          type="button"
-          aria-label="Close shortcuts"
-          onClick={() => setOpen(false)}
-          className={cn(
-            'shrink-0 rounded-[4px] p-1 text-text-muted',
-            'hover:bg-surface-muted hover:text-text-primary',
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20',
-          )}
-        >
-          <XClose aria-hidden="true" className="h-4 w-4" />
-        </button>
+      groups={groups}
+      intro={
+        <>
+          Speed up common actions. Press <Kbd>?</Kbd> any time to reopen this
+          sheet.
+        </>
       }
-    >
-      <p className="text-[13px] leading-5 text-text-muted">
-        Speed up common actions. Press <Kbd>?</Kbd> any time to reopen this sheet.
-      </p>
-
-      <div className="flex flex-col gap-5">
-        {groups.map((group) => (
-          <section
-            key={group.title}
-            aria-labelledby={`shortcut-group-${slug(group.title)}`}
-          >
-            <h3
-              id={`shortcut-group-${slug(group.title)}`}
-              className="text-[11px] font-semibold uppercase tracking-wide text-text-muted"
-            >
-              {group.title}
-            </h3>
-            <ul className="mt-2 flex flex-col gap-1.5">
-              {group.items.map((s, i) => (
-                <li
-                  key={`${group.title}-${i}`}
-                  className="flex items-center justify-between"
-                >
-                  <span className="text-[14px] leading-5 text-text-primary">
-                    {s.label}
-                  </span>
-                  <span className="flex items-center gap-1">
-                    {s.keys.map((k, ki) => (
-                      <Kbd key={ki}>{k}</Kbd>
-                    ))}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </section>
-        ))}
-      </div>
-    </Modal>
+    />
   );
-}
-
-/* ─────────────────────────────────────────────────────────────
- * Visual helper
- * ───────────────────────────────────────────────────────────── */
-
-function Kbd({ children }: { children: React.ReactNode }) {
-  return (
-    <kbd
-      className={cn(
-        'inline-flex h-6 min-w-[24px] items-center justify-center px-1.5',
-        'rounded-[4px] border border-border-faint bg-surface-subtle',
-        'text-[12px] font-medium leading-none text-text-primary',
-        // Use system font for kbd so the on-platform mod symbols (⌘ ⏎)
-        // render with their native glyph instead of the body font.
-        'font-sans',
-        'shadow-[inset_0_-1px_0_rgba(15,23,42,0.08)]',
-      )}
-    >
-      {children}
-    </kbd>
-  );
-}
-
-function slug(s: string): string {
-  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-');
 }

--- a/packages/kb-ui/src/components/overlays/ShortcutsModal.stories.tsx
+++ b/packages/kb-ui/src/components/overlays/ShortcutsModal.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import '../../tokens.css';
+import { ShortcutsModal, type ShortcutGroup } from './ShortcutsModal';
+import { Button } from '../primitives/Button';
+import { Kbd } from '../primitives/Kbd';
+
+/* ─────────────────────────────────────────────────────────────
+ * A single multi-group story exercising header (title + close X),
+ * intro paragraph with inline `<Kbd>`, and three sections rendered
+ * from `groups`.
+ *
+ * Groups below are illustrative — generic enough to show layout
+ * without implying any product-specific lock-in.
+ * ───────────────────────────────────────────────────────────── */
+
+const meta: Meta<typeof ShortcutsModal> = {
+  title: 'Components/Overlays/Shortcuts Modal',
+  component: ShortcutsModal,
+  parameters: { layout: 'centered' },
+  globals: { backgrounds: { value: 'canvas' } },
+};
+export default meta;
+
+const groups: ShortcutGroup[] = [
+  {
+    title: 'Editor',
+    items: [
+      { keys: ['⌘', 'S'], label: 'Save draft' },
+      { keys: ['⌘', '⏎'], label: 'Publish article' },
+      { keys: ['Esc'], label: 'Close panel' },
+    ],
+  },
+  {
+    title: 'AI Gaps Review',
+    items: [
+      { keys: ['J'], label: 'Next suggestion' },
+      { keys: ['↓'], label: 'Next suggestion' },
+      { keys: ['K'], label: 'Previous suggestion' },
+      { keys: ['↑'], label: 'Previous suggestion' },
+      { keys: ['Y'], label: 'Accept suggestion' },
+      { keys: ['⏎'], label: 'Accept suggestion' },
+      { keys: ['N'], label: 'Reject suggestion' },
+      { keys: ['Esc'], label: 'Close sources sheet' },
+    ],
+  },
+  {
+    title: 'Anywhere',
+    items: [{ keys: ['?'], label: 'Show this cheat sheet' }],
+  },
+];
+
+function ShortcutsModalDefaultWrapper() {
+  const [open, setOpen] = useState(true);
+  return (
+    <>
+      <Button variant="primary" onClick={() => setOpen(true)}>
+        Open shortcuts
+      </Button>
+      <ShortcutsModal
+        open={open}
+        onOpenChange={setOpen}
+        groups={groups}
+        intro={
+          <>
+            Speed up common actions. Press <Kbd>?</Kbd> any time to reopen this
+            sheet.
+          </>
+        }
+      />
+    </>
+  );
+}
+
+export const Default: StoryObj<typeof ShortcutsModal> = {
+  render: () => <ShortcutsModalDefaultWrapper />,
+};

--- a/packages/kb-ui/src/components/overlays/ShortcutsModal.tsx
+++ b/packages/kb-ui/src/components/overlays/ShortcutsModal.tsx
@@ -1,0 +1,112 @@
+// ShortcutsModal — generic keyboard cheat-sheet overlay.
+//
+// Renders a kb-ui `Modal` with a header (title + close X), an optional
+// intro paragraph, and one `<section>` per shortcut group. Each row is
+// `[label] [keys]` with keys rendered as `Kbd` chips.
+//
+// The library's responsibility ends at "render a modal given groups
+// data" — app-side glue (custom events, hotkey bindings, where the
+// catalog lives) stays in the consumer.
+
+import * as React from 'react';
+import { XClose } from '@untitledui/icons';
+import { cn } from '../../utils/cn';
+import { Modal } from './Modal';
+import { Kbd } from '../primitives/Kbd';
+
+/* ─────────────────────────────────────────────────────────────
+ * Types
+ * ───────────────────────────────────────────────────────────── */
+
+export type Shortcut = { keys: string[]; label: string };
+
+export type ShortcutGroup = { title: string; items: Shortcut[] };
+
+export type ShortcutsModalProps = {
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+  groups: ShortcutGroup[];
+  /** Title shown in the modal header. Defaults to 'Keyboard shortcuts'. */
+  title?: string;
+  /**
+   * Optional intro line shown above the groups. Pass a node to allow
+   * inline `<Kbd>` chips inside the copy. Defaults to undefined (no intro).
+   */
+  intro?: React.ReactNode;
+};
+
+/* ─────────────────────────────────────────────────────────────
+ * Component
+ * ───────────────────────────────────────────────────────────── */
+
+export function ShortcutsModal({
+  open,
+  onOpenChange,
+  groups,
+  title = 'Keyboard shortcuts',
+  intro,
+}: ShortcutsModalProps) {
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      width={480}
+      title={title}
+      titleTrailing={
+        <button
+          type="button"
+          aria-label="Close shortcuts"
+          onClick={() => onOpenChange(false)}
+          className={cn(
+            'shrink-0 rounded-[4px] p-1 text-text-muted',
+            'hover:bg-surface-muted hover:text-text-primary',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20',
+          )}
+        >
+          <XClose aria-hidden="true" className="h-4 w-4" />
+        </button>
+      }
+    >
+      {intro !== undefined && (
+        <p className="text-[13px] leading-5 text-text-muted">{intro}</p>
+      )}
+
+      <div className="flex flex-col gap-5">
+        {groups.map((group) => {
+          const headingId = `shortcut-group-${slug(group.title)}`;
+          return (
+            <section key={group.title} aria-labelledby={headingId}>
+              <h3
+                id={headingId}
+                className="text-[11px] font-semibold uppercase tracking-wide text-text-muted"
+              >
+                {group.title}
+              </h3>
+              <ul className="mt-2 flex flex-col gap-1.5">
+                {group.items.map((s, i) => (
+                  <li
+                    key={`${group.title}-${i}`}
+                    className="flex items-center justify-between"
+                  >
+                    <span className="text-[14px] leading-5 text-text-primary">
+                      {s.label}
+                    </span>
+                    <span className="flex items-center gap-1">
+                      {s.keys.map((k, ki) => (
+                        <Kbd key={ki}>{k}</Kbd>
+                      ))}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          );
+        })}
+      </div>
+    </Modal>
+  );
+}
+
+function slug(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+}

--- a/packages/kb-ui/src/components/overlays/index.ts
+++ b/packages/kb-ui/src/components/overlays/index.ts
@@ -17,3 +17,9 @@ export type {
 } from './NewCategoryModal';
 export { ConfirmDialog } from './ConfirmDialog';
 export type { ConfirmDialogProps } from './ConfirmDialog';
+export { ShortcutsModal } from './ShortcutsModal';
+export type {
+  ShortcutsModalProps,
+  Shortcut,
+  ShortcutGroup,
+} from './ShortcutsModal';

--- a/packages/kb-ui/src/components/primitives/Kbd.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Kbd.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../tokens.css';
+import { Kbd } from './Kbd';
+
+/* ─────────────────────────────────────────────────────────────
+ * Three discrete stories exercising `Kbd`:
+ *
+ *   - SingleKey    — bare letter glyph
+ *   - ModifierPlus — modifier + letter (rendered with platform glyph)
+ *   - MultiChord   — three-key chord with separators
+ *
+ * Per project convention these are discrete stories (no
+ * argTypes/controls) so each appears in the Storybook sidebar.
+ * ───────────────────────────────────────────────────────────── */
+
+const meta: Meta<typeof Kbd> = {
+  title: 'Components/Primitives/Kbd',
+  component: Kbd,
+  parameters: { layout: 'centered' },
+  globals: { backgrounds: { value: 'white' } },
+};
+export default meta;
+
+export const SingleKey: StoryObj<typeof Kbd> = {
+  render: () => <Kbd>?</Kbd>,
+};
+
+export const ModifierPlus: StoryObj<typeof Kbd> = {
+  render: () => (
+    <span className="inline-flex items-center gap-1">
+      <Kbd>⌘</Kbd>
+      <Kbd>S</Kbd>
+    </span>
+  ),
+};
+
+export const MultiChord: StoryObj<typeof Kbd> = {
+  render: () => (
+    <span className="inline-flex items-center gap-1">
+      <Kbd>⌘</Kbd>
+      <Kbd>⇧</Kbd>
+      <Kbd>P</Kbd>
+    </span>
+  ),
+};

--- a/packages/kb-ui/src/components/primitives/Kbd.tsx
+++ b/packages/kb-ui/src/components/primitives/Kbd.tsx
@@ -1,0 +1,35 @@
+// Kbd — inline keyboard-glyph chip.
+//
+// Display primitive that renders a single key (or modifier glyph) as a
+// `<kbd>` element with the canonical kb-ui keyboard chip styling.
+// Reused by `ShortcutsModal` for the cheat-sheet rows, and intended
+// to be usable inline anywhere a keyboard key is mentioned in copy.
+
+import * as React from 'react';
+import { cn } from '../../utils/cn';
+
+export type KbdProps = {
+  /** The key glyph or label — usually a single character or short string. */
+  children: React.ReactNode;
+  /** Extra classes merged into the chip. */
+  className?: string;
+};
+
+export function Kbd({ children, className }: KbdProps) {
+  return (
+    <kbd
+      className={cn(
+        'inline-flex h-6 min-w-[24px] items-center justify-center px-1.5',
+        'rounded-[4px] border border-border-faint bg-surface-subtle',
+        'text-[12px] font-medium leading-none text-text-primary',
+        // Use system font for kbd so the on-platform mod symbols (⌘ ⏎)
+        // render with their native glyph instead of the body font.
+        'font-sans',
+        'shadow-[inset_0_-1px_0_rgba(15,23,42,0.08)]',
+        className,
+      )}
+    >
+      {children}
+    </kbd>
+  );
+}

--- a/packages/kb-ui/src/components/primitives/index.ts
+++ b/packages/kb-ui/src/components/primitives/index.ts
@@ -12,6 +12,8 @@ export { Divider } from './Divider';
 export type { DividerProps } from './Divider';
 export { Field } from './Field';
 export type { FieldProps } from './Field';
+export { Kbd } from './Kbd';
+export type { KbdProps } from './Kbd';
 export { Textarea } from './Textarea';
 export type { TextareaProps } from './Textarea';
 export { TextInput } from './TextInput';


### PR DESCRIPTION
## What moved to kb-ui
- `packages/kb-ui/src/components/overlays/ShortcutsModal.tsx` — generic shortcuts modal (Modal chrome + close-X + intro slot + grouped sections), API is `{ open, onOpenChange, groups, title?, intro? }`. Plus `ShortcutsModal.stories.tsx`.

## What stayed in demo
- `apps/demo/src/components/ShortcutsCheatSheet.tsx` is now a ~50-line wrapper that keeps the hardcoded shortcut catalog (Editor / AI Gaps / Anywhere), the `SHORTCUT_OPEN_EVENT` / `SHORTCUT_CLOSE_EVENT` constants, and the `useEffect` event subscription. Library has no knowledge of these.

## Kbd primitive split
- Pulled the inline `<Kbd>` helper out as a standalone primitive at `packages/kb-ui/src/components/primitives/Kbd.tsx` with three discrete stories (single key, modifier+key, multi-chord). Exported through the primitives barrel for reuse outside the shortcuts modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)