### PR TITLE
C5a: generalize Welcome Tour over steps[] + externalize copy

### DIFF
--- a/apps/demo/src/components/welcome-tour-config.tsx
+++ b/apps/demo/src/components/welcome-tour-config.tsx
@@ -1,0 +1,170 @@
+// Hiver-specific Welcome Tour configuration.
+//
+// All demo-specific copy, icons, routes, and rect-computation logic
+// lives here. The welcome-tour/ module itself is generic over this
+// config — moving the module to kb-ui in a follow-up PR will not
+// require any changes to this file (only the import path on line 1).
+
+import {
+  AlertCircle,
+  BarChartSquare02,
+  Command,
+  Folder,
+  Keyboard01,
+  MessageChatCircle,
+  Pencil02,
+  ShieldTick,
+} from '@untitledui/icons';
+import { AiIcon } from '@test-kb-ui/kb-ui';
+import type {
+  CompletionContent,
+  TourStep,
+  WelcomeContent,
+} from './welcome-tour';
+import type { SpotlightRect } from './welcome-tour/Spotlight';
+import { DEFAULT_KB_CATEGORY_SLUG, routes } from '../lib/routes';
+
+/* ── Step-specific rect helpers ─────────────────────────────── */
+
+/**
+ * Sidebar Explorer — union the header + tree (or flat) sub-elements
+ * so the ring hugs the visible UI instead of the full-height aside.
+ * Falls back to the registered node's full rect if either
+ * sub-element is missing.
+ */
+function explorerRect(node: HTMLElement): SpotlightRect | null {
+  const header = node.querySelector<HTMLElement>(
+    '[data-kb-part="explorer-header"]',
+  );
+  const body =
+    node.querySelector<HTMLElement>('[data-kb-part="explorer-tree"]') ??
+    node.querySelector<HTMLElement>('[data-kb-part="explorer-flat"]');
+  if (header === null || body === null) return null;
+  const h = header.getBoundingClientRect();
+  const b = body.getBoundingClientRect();
+  const top = Math.min(h.top, b.top);
+  const left = Math.min(h.left, b.left);
+  const right = Math.max(h.right, b.right);
+  const bottom = Math.max(h.bottom, b.bottom);
+  if (right <= left || bottom <= top) return null;
+  return { top, left, width: right - left, height: bottom - top };
+}
+
+/* ── Steps ──────────────────────────────────────────────────── */
+
+export const HIVER_TOUR_STEPS: TourStep[] = [
+  {
+    id: 'sidebar-explorer',
+    title: 'Browse like files',
+    body:
+      'Your articles and categories now live in a tree on the left. Click to open, drag to reorganize.',
+    route: routes.kb.category(DEFAULT_KB_CATEGORY_SLUG),
+    computeRect: explorerRect,
+  },
+  {
+    id: 'rail-ai',
+    title: 'AI Gaps & Suggestions',
+    body:
+      'We surface missing or thin content based on real customer questions. Tackle the highest-impact gaps first.',
+    route: routes.aiOptimise.hub(),
+    // Rail icon buttons have transparent backgrounds — flag so the
+    // overlay can paint a white fill behind the lifted target.
+    targetNeedsBackgroundFill: true,
+  },
+  {
+    id: 'rail-analytics',
+    title: 'Analytics for every article',
+    body:
+      'See views, helpful votes, search performance, and how AI is using your content to answer tickets.',
+    route: routes.analytics.articlePerformance(),
+    targetNeedsBackgroundFill: true,
+  },
+];
+
+/* ── Welcome card content ───────────────────────────────────── */
+
+export const HIVER_WELCOME: WelcomeContent = {
+  title: 'Welcome back, your KB just got a refresh',
+  body:
+    "A few things moved around. Here’s a quick tour of what’s new — under a minute.",
+  ctaLabel: 'Show me what’s new',
+  skipLabel: 'I’ll explore on my own',
+  features: [
+    {
+      id: 'file-explorer',
+      title: 'File explorer in the sidebar',
+      body: 'Browse your categories and articles like files in a tree.',
+      icon: <Folder className="text-slate-700" />,
+    },
+    {
+      id: 'ai-gaps',
+      title: 'AI Gaps & Suggestions',
+      body: 'See where your content needs improvement, powered by real ticket conversations.',
+      icon: <AiIcon size={18} />,
+    },
+    {
+      id: 'analytics',
+      title: 'Detailed analytics',
+      body: 'Per-article performance, search insights, and AI answer quality.',
+      icon: <BarChartSquare02 className="text-slate-700" />,
+    },
+  ],
+};
+
+/* ── Completion card content ────────────────────────────────── */
+
+export const HIVER_COMPLETION: CompletionContent = {
+  title: 'Tour complete',
+  body: 'A few other improvements you’ll notice as you go',
+  ctaLabel: 'Got it',
+  // 6 distinct features — all real per kb-mcp/product/feature-map.md.
+  // No overlap with the WelcomeCard's File explorer / AI Gaps /
+  // Analytics tiles.
+  features: [
+    {
+      id: 'slash-editor',
+      title: 'Slash-command editor',
+      body:
+        'Type / anywhere to insert headings, lists, code, tables, and more',
+      icon: <Command className="h-[18px] w-[18px] text-slate-700" />,
+    },
+    {
+      id: 'bubble-menu',
+      title: 'Selection bubble menu',
+      body: 'Select text for instant formatting, links, and AI actions',
+      icon: <Pencil02 className="h-[18px] w-[18px] text-slate-700" />,
+    },
+    {
+      id: 'publish-gate',
+      title: 'Smart publish gate',
+      body:
+        'Publishing stays disabled until your AI suggestions are reviewed',
+      icon: <ShieldTick className="h-[18px] w-[18px] text-slate-700" />,
+    },
+    {
+      id: 'conversation-sources',
+      title: 'Conversation sources',
+      body: 'Every AI suggestion shows the customer tickets behind it',
+      icon: (
+        <MessageChatCircle className="h-[18px] w-[18px] text-slate-700" />
+      ),
+    },
+    {
+      id: 'attention-flags',
+      title: 'Articles needing attention',
+      body: 'Analytics flags low-helpfulness articles automatically',
+      icon: <AlertCircle className="h-[18px] w-[18px] text-slate-700" />,
+    },
+    {
+      id: 'keyboard-first',
+      title: 'Keyboard-first workflow',
+      body:
+        'Press ? for shortcuts; navigate AI review with j/k, decide with y/n',
+      icon: <Keyboard01 className="h-[18px] w-[18px] text-slate-700" />,
+    },
+  ],
+};
+
+/* ── Storage key (byte-identical to pre-refactor) ───────────── */
+
+export const HIVER_TOUR_STORAGE_KEY = 'hiver-kb-welcome-tour-v1';

--- a/apps/demo/src/components/welcome-tour/CompletionCard.tsx
+++ b/apps/demo/src/components/welcome-tour/CompletionCard.tsx
@@ -1,9 +1,12 @@
-// Completion card — shown after the user clicks "Got it" on step 3.
+// Completion card — shown after the user clicks "Got it" on the
+// final step.
 //
-// v4: unified visual language with WelcomeCard. Same width (max-w-md),
-// same chip pattern ("YOU'RE ALL SET"), same tile styling, same
-// typography (20px headline), same spacing rhythm (p-7, mt-5, mt-1,
-// mt-6, mt-7). Now surfaces 6 distinct features in a 2x3 grid.
+// v5: copy + feature tiles externalized to the `content` prop.
+// Visual chrome (chip, headline scale, tile structure, check-draw,
+// sparkles, animations, focus trap, backdrop) is unchanged. Tile
+// stagger delays now derive from feature count so 1, 2, 3, … N tiles
+// all read the same (200ms initial delay + 60ms per tile), preserving
+// the cascade rhythm the original 6-tile timing established.
 
 import {
   useEffect,
@@ -13,71 +16,28 @@ import {
   type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
-import {
-  AlertCircle,
-  Command,
-  Keyboard01,
-  MessageChatCircle,
-  Pencil02,
-  ShieldTick,
-  X,
-} from '@untitledui/icons';
+import { X } from '@untitledui/icons';
 import { Button } from '@test-kb-ui/kb-ui';
 import { cn } from '../../lib/cn';
 import { useReducedMotion } from './useReducedMotion';
+import type { CompletionContent, WelcomeFeature } from './WelcomeTourContext';
 
 const SMOOTH_CUBIC = 'cubic-bezier(0.16, 1, 0.3, 1)';
-
-type ChangelogTile = {
-  icon: React.ReactNode;
-  title: string;
-  body: string;
-};
-
-/* 6 distinct features — all real per kb-mcp/product/feature-map.md.
-   No overlap with WelcomeCard's File explorer / AI Gaps / Analytics tiles. */
-const TILES: ChangelogTile[] = [
-  {
-    icon: <Command className="h-[18px] w-[18px] text-slate-700" />,
-    title: 'Slash-command editor',
-    body: 'Type / anywhere to insert headings, lists, code, tables, and more',
-  },
-  {
-    icon: <Pencil02 className="h-[18px] w-[18px] text-slate-700" />,
-    title: 'Selection bubble menu',
-    body: 'Select text for instant formatting, links, and AI actions',
-  },
-  {
-    icon: <ShieldTick className="h-[18px] w-[18px] text-slate-700" />,
-    title: 'Smart publish gate',
-    body: 'Publishing stays disabled until your AI suggestions are reviewed',
-  },
-  {
-    icon: <MessageChatCircle className="h-[18px] w-[18px] text-slate-700" />,
-    title: 'Conversation sources',
-    body: 'Every AI suggestion shows the customer tickets behind it',
-  },
-  {
-    icon: <AlertCircle className="h-[18px] w-[18px] text-slate-700" />,
-    title: 'Articles needing attention',
-    body: 'Analytics flags low-helpfulness articles automatically',
-  },
-  {
-    icon: <Keyboard01 className="h-[18px] w-[18px] text-slate-700" />,
-    title: 'Keyboard-first workflow',
-    body: 'Press ? for shortcuts; navigate AI review with j/k, decide with y/n',
-  },
-];
 
 /* Tile stagger — starts at 200ms so the cascade kicks in shortly
  * after the card lands (card itself transitions in over ~350ms,
  * with 200ms the first tile begins under the headline before the
  * card fully settles). 60ms between tiles keeps the cascade tight
  * — long enough to read as a sequence, short enough to avoid
- * blocking interaction. Previously front-loaded at 300ms with 50ms
- * steps, which pushed the last tile (550ms) past the user's
- * attention window. */
-const TILE_DELAYS_MS = [200, 260, 320, 380, 440, 500];
+ * blocking interaction. The original config was [200, 260, 320, 380,
+ * 440, 500] for 6 tiles; derived form preserves that rhythm for any
+ * tile count. */
+const TILE_DELAY_BASE_MS = 200;
+const TILE_DELAY_STEP_MS = 60;
+function tileDelayMs(index: number): number {
+  return TILE_DELAY_BASE_MS + index * TILE_DELAY_STEP_MS;
+}
+
 const SPARKLE_DELAYS_MS = [700, 800, 900, 1000];
 const CHECK_DRAW_DELAY_MS = 200;
 const CHECK_DRAW_DUR_MS = 500;
@@ -90,14 +50,18 @@ const SPARKLE_SHIMMER_PHASE_MS = [0, 700, 1400, 350];
 const SPARKLE_SHIMMER_DURATION_MS = 3500;
 
 export type CompletionCardProps = {
+  content: CompletionContent;
   onDismiss: () => void;
 };
 
-export function CompletionCard({ onDismiss }: CompletionCardProps) {
+export function CompletionCard({ content, onDismiss }: CompletionCardProps) {
   const cardRef = useRef<HTMLDivElement | null>(null);
   const cleanupRef = useRef<(() => void) | null>(null);
   const checkPathRef = useRef<SVGPathElement | null>(null);
   const reduceMotion = useReducedMotion();
+
+  const ctaLabel = content.ctaLabel ?? 'Got it';
+  const features: WelcomeFeature[] = content.features ?? [];
 
   /* Measured length of the check stroke. Read from the DOM via
    * `getTotalLength()` so the keyframe's `stroke-dashoffset: from`
@@ -210,12 +174,13 @@ export function CompletionCard({ onDismiss }: CompletionCardProps) {
         transition: `opacity 100ms cubic-bezier(0.23, 1, 0.32, 1)`,
       };
     }
+    const delay = tileDelayMs(index);
     return {
       opacity: mounted ? 1 : 0,
       transform: mounted ? 'translateY(0)' : 'translateY(6px)',
       transition:
-        `opacity 350ms cubic-bezier(0.23, 1, 0.32, 1) ${TILE_DELAYS_MS[index]}ms, ` +
-        `transform 350ms cubic-bezier(0.23, 1, 0.32, 1) ${TILE_DELAYS_MS[index]}ms`,
+        `opacity 350ms cubic-bezier(0.23, 1, 0.32, 1) ${delay}ms, ` +
+        `transform 350ms cubic-bezier(0.23, 1, 0.32, 1) ${delay}ms`,
       willChange: 'opacity, transform',
     };
   };
@@ -440,40 +405,44 @@ export function CompletionCard({ onDismiss }: CompletionCardProps) {
           id="completion-title"
           className="mt-5 text-center text-[20px] font-semibold leading-7 text-slate-900"
         >
-          Tour complete
+          {content.title}
         </h2>
         <p
           id="completion-subtitle"
           className="mt-1 text-center text-[14px] leading-relaxed text-slate-600"
         >
-          A few other improvements you&rsquo;ll notice as you go
+          {content.body}
         </p>
 
-        {/* 2x3 changelog grid — 6 tiles. */}
-        <div className="mt-6 grid grid-cols-2 gap-3">
-          {TILES.map((tile, i) => (
-            <div
-              key={tile.title}
-              style={tileStyle(i)}
-              className={cn(
-                'rounded-lg border border-slate-200 bg-white p-3',
-                'transition-colors hover:bg-slate-50',
-              )}
-            >
-              <div className="flex items-center gap-3">
-                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-slate-100">
-                  {tile.icon}
+        {/* 2-column changelog grid — driven by features count. */}
+        {features.length > 0 && (
+          <div className="mt-6 grid grid-cols-2 gap-3">
+            {features.map((feature, i) => (
+              <div
+                key={feature.id}
+                style={tileStyle(i)}
+                className={cn(
+                  'rounded-lg border border-slate-200 bg-white p-3',
+                  'transition-colors hover:bg-slate-50',
+                )}
+              >
+                <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-slate-100">
+                    {feature.icon}
+                  </div>
+                  <div className="text-[13px] font-semibold leading-5 text-slate-900">
+                    {feature.title}
+                  </div>
                 </div>
-                <div className="text-[13px] font-semibold leading-5 text-slate-900">
-                  {tile.title}
-                </div>
+                {feature.body !== undefined && (
+                  <p className="mt-1 text-[12px] leading-relaxed text-slate-500">
+                    {feature.body}
+                  </p>
+                )}
               </div>
-              <p className="mt-1 text-[12px] leading-relaxed text-slate-500">
-                {tile.body}
-              </p>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        )}
 
         {/* Footer — single primary CTA. */}
         <div className="mt-7 flex items-center justify-end">
@@ -482,7 +451,7 @@ export function CompletionCard({ onDismiss }: CompletionCardProps) {
             onClick={onDismiss}
             data-completion-primary="true"
           >
-            Got it
+            {ctaLabel}
           </Button>
         </div>
       </div>

--- a/apps/demo/src/components/welcome-tour/Spotlight.tsx
+++ b/apps/demo/src/components/welcome-tour/Spotlight.tsx
@@ -67,7 +67,7 @@ export type SpotlightRect = {
 
 export type CoachMarkContent = {
   title: string;
-  body: string;
+  body: React.ReactNode;
   stepIndex: number; // 0-based — 0 = first step
   totalSteps: number;
   primaryLabel: string;

--- a/apps/demo/src/components/welcome-tour/WelcomeCard.tsx
+++ b/apps/demo/src/components/welcome-tour/WelcomeCard.tsx
@@ -1,8 +1,8 @@
 // Step 0 — the centered welcome modal that introduces the tour.
 //
-// v5: drop the abstract glyph illustration entirely. Cards lead with the
-// "WHAT'S NEW" chip — same pattern Lovable/Relume/Linear use for "what's
-// new" surfaces. No mystery symbol; the chip + headline carry the moment.
+// v6: copy + feature tiles externalized to the `content` prop. Visual
+// chrome (chip, headline scale, tile structure, animations, focus
+// trap, backdrop) is unchanged.
 
 import {
   useEffect,
@@ -11,24 +11,21 @@ import {
   useState,
   type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
 } from 'react';
-import {
-  ArrowRight,
-  BarChartSquare02,
-  Folder,
-  XClose,
-} from '@untitledui/icons';
-import { AiIcon, Button } from '@test-kb-ui/kb-ui';
+import { ArrowRight, XClose } from '@untitledui/icons';
+import { Button } from '@test-kb-ui/kb-ui';
 import { cn } from '../../lib/cn';
 import { useReducedMotion } from './useReducedMotion';
+import type { WelcomeContent, WelcomeFeature } from './WelcomeTourContext';
 
 /* Smooth Apple-style cubic for entrance animations. */
 const SMOOTH_CUBIC = 'cubic-bezier(0.16, 1, 0.3, 1)';
 
 type FeatureRowProps = {
-  icon: React.ReactNode;
+  icon: ReactNode;
   title: string;
-  description: string;
+  description?: string;
 };
 
 function FeatureRow({ icon, title, description }: FeatureRowProps) {
@@ -49,22 +46,29 @@ function FeatureRow({ icon, title, description }: FeatureRowProps) {
           {title}
         </div>
       </div>
-      <p className="mt-1 text-[12px] leading-relaxed text-slate-500">
-        {description}
-      </p>
+      {description !== undefined && (
+        <p className="mt-1 text-[12px] leading-relaxed text-slate-500">
+          {description}
+        </p>
+      )}
     </div>
   );
 }
 
 export type WelcomeCardProps = {
+  content: WelcomeContent;
   onStart: () => void;
   onSkip: () => void;
 };
 
-export function WelcomeCard({ onStart, onSkip }: WelcomeCardProps) {
+export function WelcomeCard({ content, onStart, onSkip }: WelcomeCardProps) {
   const cardRef = useRef<HTMLDivElement | null>(null);
   const cleanupRef = useRef<(() => void) | null>(null);
   const reduceMotion = useReducedMotion();
+
+  const ctaLabel = content.ctaLabel ?? 'Show me around';
+  const skipLabel = content.skipLabel ?? 'Skip';
+  const features: WelcomeFeature[] = content.features ?? [];
 
   /* Focus trap — keep Tab cycling within the card. */
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
@@ -204,47 +208,41 @@ export function WelcomeCard({ onStart, onSkip }: WelcomeCardProps) {
           id="welcome-tour-title"
           className="mt-5 text-center text-[20px] font-semibold leading-7 text-slate-900"
         >
-          Welcome back, your KB just got a refresh
+          {content.title}
         </h2>
 
         <p
           id="welcome-tour-subtitle"
           className="mt-1 text-center text-[14px] leading-relaxed text-slate-600"
         >
-          A few things moved around. Here&rsquo;s a quick tour of what&rsquo;s
-          new &mdash; under a minute.
+          {content.body}
         </p>
 
         {/* Feature tiles — full-width rows. Same internal structure as
             CompletionCard tiles, just in single-column layout. */}
-        <div className="mt-6 flex flex-col gap-3">
-          <FeatureRow
-            icon={<Folder className="text-slate-700" />}
-            title="File explorer in the sidebar"
-            description="Browse your categories and articles like files in a tree."
-          />
-          <FeatureRow
-            icon={<AiIcon size={18} />}
-            title="AI Gaps & Suggestions"
-            description="See where your content needs improvement, powered by real ticket conversations."
-          />
-          <FeatureRow
-            icon={<BarChartSquare02 className="text-slate-700" />}
-            title="Detailed analytics"
-            description="Per-article performance, search insights, and AI answer quality."
-          />
-        </div>
+        {features.length > 0 && (
+          <div className="mt-6 flex flex-col gap-3">
+            {features.map((feature) => (
+              <FeatureRow
+                key={feature.id}
+                icon={feature.icon}
+                title={feature.title}
+                description={feature.body}
+              />
+            ))}
+          </div>
+        )}
 
         <div className="mt-7 flex items-center justify-end gap-2">
           <Button variant="ghost" onClick={onSkip}>
-            I&rsquo;ll explore on my own
+            {skipLabel}
           </Button>
           <Button
             variant="primary"
             onClick={onStart}
             data-welcome-primary="true"
           >
-            Show me what&rsquo;s new
+            {ctaLabel}
             <ArrowRight className="h-[14px] w-[14px]" />
           </Button>
         </div>

--- a/apps/demo/src/components/welcome-tour/WelcomeTourContext.tsx
+++ b/apps/demo/src/components/welcome-tour/WelcomeTourContext.tsx
@@ -2,20 +2,33 @@
 //
 // Lives in apps/demo only. NOT part of kb-ui. This module is the
 // orchestrator; visual chrome lives in `WelcomeTourOverlay`,
-// `WelcomeCard`, and `Spotlight`.
+// `WelcomeCard`, `CompletionCard`, and `Spotlight`.
 //
-// State machine:
-//   'closed' → 'welcome' → 'step-explorer' → 'step-ai' → 'step-analytics'
+// Generalised over a steps[] array — the state machine has no
+// hardcoded knowledge of step ids, copy, routes, or rect logic.
+// Consumers pass in:
+//   - `steps`: ordered list of TourStep, each with an `id` (registry
+//     key), `title`, `body`, and optional route/computeRect/meta.
+//   - `welcome`: intro card copy + optional feature chips.
+//   - `completion`: gratification card copy + optional feature tiles.
+//   - `storageKey`: app-namespaced localStorage key for "seen" tracking.
+//   - `resetQueryParam`: query param that triggers a force-reset
+//     (defaults to 'welcome').
+//   - `autoShowDelayMs`: delay before auto-showing on first visit
+//     (defaults to 700ms).
+//
+// State machine (now indexed by step number, not step name):
+//   'closed' → 'welcome' → step 0 → step 1 → … → step N-1
 //            → 'completion' → 'done'
 //
-// 'completion' is the gratification card — shown after step-analytics's
-// "Got it". Skip from any step still jumps straight to 'done' (no
-// completion card on skip — the user opted out, don't reward).
+// 'completion' is the gratification card — shown after the final
+// step's "Got it". Skip from any step still jumps straight to 'done'
+// (no completion card on skip — the user opted out, don't reward).
 //
-// Auto-show logic: on mount, if `localStorage.getItem(STORAGE_KEY) !== 'seen'`
-// (and no explicit reset via `?welcome=1`), schedule a 700ms timer that
-// flips state to 'welcome'. The query-param reset clears the flag and
-// forces the tour to run again.
+// Auto-show logic: on mount, if `localStorage.getItem(storageKey) !== 'seen'`
+// (and no explicit reset via the configured query param), schedule a
+// `autoShowDelayMs` timer that flips state to 'welcome'. The
+// query-param reset clears the flag and forces the tour to run again.
 
 import {
   createContext,
@@ -28,26 +41,96 @@ import {
   type ReactNode,
 } from 'react';
 import { WelcomeTourOverlay } from './WelcomeTourOverlay';
+import type { SpotlightRect } from './Spotlight';
 
-export const STORAGE_KEY = 'hiver-kb-welcome-tour-v1';
-export const RESET_QUERY_PARAM = 'welcome';
+/* ── Public types ─────────────────────────────────────────── */
 
-export type TourState =
-  | 'closed'
-  | 'welcome'
-  | 'step-explorer'
-  | 'step-ai'
-  | 'step-analytics'
-  | 'completion'
-  | 'done';
+export type TourStep = {
+  /** Stable string id for this step. Used as the target registry key. */
+  id: string;
+  /** Card content rendered when this step is active. */
+  title: string;
+  body: ReactNode;
+  /**
+   * Optional route the overlay should navigate to when this step
+   * becomes active. Omit for steps that should not navigate.
+   */
+  route?: string;
+  /**
+   * Optional custom rect computation. When provided, replaces the
+   * default `getBoundingClientRect()` on the registered node — useful
+   * for unions of header + body sub-elements, or any rect that
+   * doesn't match the registered container's bounding box.
+   */
+  computeRect?: (node: HTMLElement) => SpotlightRect | null;
+  /**
+   * Optional flag — when true, the Spotlight will paint a white fill
+   * behind the target while it sits above the dim. Pass-through to
+   * the (currently unused) Spotlight prop — kept for future use.
+   */
+  targetNeedsBackgroundFill?: boolean;
+  /** Optional opaque payload step cards may want (preview image, etc.). */
+  meta?: Record<string, unknown>;
+};
 
-export type TourTargetId =
-  | 'sidebar-explorer'
-  | 'rail-ai'
-  | 'rail-analytics';
+export type WelcomeFeature = {
+  id: string;
+  title: string;
+  body?: string;
+  icon?: ReactNode;
+};
+
+export type WelcomeContent = {
+  title: string;
+  body: ReactNode;
+  /** Primary CTA label. Defaults to 'Show me around'. */
+  ctaLabel?: string;
+  /** Skip-link label. Defaults to 'Skip'. */
+  skipLabel?: string;
+  /** Optional list of feature chips/highlights rendered on the welcome card. */
+  features?: WelcomeFeature[];
+};
+
+export type CompletionContent = {
+  title: string;
+  body: ReactNode;
+  /** Primary CTA label. Defaults to 'Got it'. */
+  ctaLabel?: string;
+  /** Optional feature list — mirrors WelcomeContent.features. */
+  features?: WelcomeFeature[];
+};
+
+/* ── Internal state ───────────────────────────────────────── */
+
+export type TourPhase = 'closed' | 'welcome' | 'step' | 'completion' | 'done';
+
+export type TourState = {
+  phase: TourPhase;
+  /** 0-based step index. Only meaningful when phase === 'step'. */
+  stepIndex: number;
+};
+
+/** True when the tour is currently rendered to the screen. */
+export function isActiveTourState(state: TourState): boolean {
+  return (
+    state.phase === 'welcome' ||
+    state.phase === 'step' ||
+    state.phase === 'completion'
+  );
+}
 
 type WelcomeTourContextValue = {
   state: TourState;
+  /** Total number of steps (steps.length). */
+  totalSteps: number;
+  /** Current step — null unless `state.phase === 'step'`. */
+  currentStep: TourStep | null;
+  /** All steps, in order. */
+  steps: ReadonlyArray<TourStep>;
+  /** Intro card content. */
+  welcome: WelcomeContent;
+  /** Completion card content. */
+  completion: CompletionContent;
   start: () => void;
   next: () => void;
   back: () => void;
@@ -59,60 +142,60 @@ type WelcomeTourContextValue = {
    * don't trigger re-renders of every consumer; the overlay calls
    * `getTarget(id)` on demand inside its own effect.
    */
-  registerTarget: (id: TourTargetId, node: HTMLElement | null) => void;
-  getTarget: (id: TourTargetId) => HTMLElement | null;
+  registerTarget: (id: string, node: HTMLElement | null) => void;
+  getTarget: (id: string) => HTMLElement | null;
 };
 
 const WelcomeTourContext = createContext<WelcomeTourContextValue | null>(null);
 
-/** Next-step map for the linear flow. */
-const NEXT_STATE: Record<TourState, TourState> = {
-  closed: 'closed',
-  welcome: 'step-explorer',
-  'step-explorer': 'step-ai',
-  'step-ai': 'step-analytics',
-  'step-analytics': 'completion',
-  completion: 'done',
-  done: 'done',
-};
+const DEFAULT_RESET_QUERY_PARAM = 'welcome';
+const DEFAULT_AUTO_SHOW_DELAY_MS = 700;
 
-/** Previous-step map. `welcome` has no previous; `completion`/`done` are terminal. */
-const PREV_STATE: Record<TourState, TourState> = {
-  closed: 'closed',
-  welcome: 'welcome',
-  'step-explorer': 'welcome',
-  'step-ai': 'step-explorer',
-  'step-analytics': 'step-ai',
-  completion: 'completion',
-  done: 'done',
-};
-
-/** Stable list of state values we treat as "tour is on screen". */
-const ACTIVE_STATES: ReadonlySet<TourState> = new Set<TourState>([
-  'welcome',
-  'step-explorer',
-  'step-ai',
-  'step-analytics',
-  'completion',
-]);
-
-export function isActiveTourState(state: TourState): boolean {
-  return ACTIVE_STATES.has(state);
-}
-
-type ProviderProps = {
+export type WelcomeTourProviderProps = {
+  /** Ordered list of tour steps. Must be non-empty. */
+  steps: TourStep[];
+  /** Copy for the intro card. */
+  welcome: WelcomeContent;
+  /** Copy for the completion card. */
+  completion: CompletionContent;
+  /** localStorage key for "seen" tracking. Required — app-namespaced. */
+  storageKey: string;
+  /** Query param that triggers a reset of the seen flag. Defaults to 'welcome'. */
+  resetQueryParam?: string;
+  /** Delay before auto-showing the welcome card on first visit. Defaults to 700ms. */
+  autoShowDelayMs?: number;
   children: ReactNode;
 };
 
-export function WelcomeTourProvider({ children }: ProviderProps) {
-  const [state, setState] = useState<TourState>('closed');
-  const targetsRef = useRef<Map<TourTargetId, HTMLElement>>(new Map());
+export function WelcomeTourProvider({
+  steps,
+  welcome,
+  completion,
+  storageKey,
+  resetQueryParam = DEFAULT_RESET_QUERY_PARAM,
+  autoShowDelayMs = DEFAULT_AUTO_SHOW_DELAY_MS,
+  children,
+}: WelcomeTourProviderProps) {
+  if (steps.length === 0) {
+    throw new Error('<WelcomeTourProvider> requires at least one step');
+  }
+
+  const [state, setState] = useState<TourState>({
+    phase: 'closed',
+    stepIndex: 0,
+  });
+  const targetsRef = useRef<Map<string, HTMLElement>>(new Map());
   const autoShowTimerRef = useRef<number | null>(null);
+
+  // Keep the latest `steps` accessible inside callbacks without
+  // adding it to every dep array (steps.length is what we read).
+  const stepsRef = useRef(steps);
+  stepsRef.current = steps;
 
   /* ── Target registry ──────────────────────────────────────── */
 
   const registerTarget = useCallback(
-    (id: TourTargetId, node: HTMLElement | null) => {
+    (id: string, node: HTMLElement | null) => {
       const map = targetsRef.current;
       if (node === null) {
         map.delete(id);
@@ -123,20 +206,20 @@ export function WelcomeTourProvider({ children }: ProviderProps) {
     [],
   );
 
-  const getTarget = useCallback((id: TourTargetId): HTMLElement | null => {
+  const getTarget = useCallback((id: string): HTMLElement | null => {
     return targetsRef.current.get(id) ?? null;
   }, []);
 
   /* ── Auto-show on mount ───────────────────────────────────── */
 
   useEffect(() => {
-    // Check URL for ?welcome=1 reset flag.
+    // Check URL for `?<resetQueryParam>=1` reset flag.
     const searchParams = new URLSearchParams(window.location.search);
-    const wantsReset = searchParams.get(RESET_QUERY_PARAM) === '1';
+    const wantsReset = searchParams.get(resetQueryParam) === '1';
 
     if (wantsReset) {
       try {
-        window.localStorage.removeItem(STORAGE_KEY);
+        window.localStorage.removeItem(storageKey);
       } catch {
         // Storage may be unavailable (private mode); fall through.
       }
@@ -144,7 +227,7 @@ export function WelcomeTourProvider({ children }: ProviderProps) {
 
     let seen = false;
     try {
-      seen = window.localStorage.getItem(STORAGE_KEY) === 'seen';
+      seen = window.localStorage.getItem(storageKey) === 'seen';
     } catch {
       // If storage is unavailable, treat as not-seen so the tour still
       // runs in private browsing — better UX than silently doing nothing.
@@ -153,8 +236,12 @@ export function WelcomeTourProvider({ children }: ProviderProps) {
     if (seen) return;
 
     autoShowTimerRef.current = window.setTimeout(() => {
-      setState((prev) => (prev === 'closed' ? 'welcome' : prev));
-    }, 700);
+      setState((prev) =>
+        prev.phase === 'closed'
+          ? { phase: 'welcome', stepIndex: 0 }
+          : prev,
+      );
+    }, autoShowDelayMs);
 
     return () => {
       if (autoShowTimerRef.current !== null) {
@@ -162,7 +249,7 @@ export function WelcomeTourProvider({ children }: ProviderProps) {
         autoShowTimerRef.current = null;
       }
     };
-  }, []);
+  }, [storageKey, resetQueryParam, autoShowDelayMs]);
 
   /* ── Body scroll lock while tour is on screen ─────────────── */
 
@@ -180,43 +267,82 @@ export function WelcomeTourProvider({ children }: ProviderProps) {
 
   const markSeen = useCallback(() => {
     try {
-      window.localStorage.setItem(STORAGE_KEY, 'seen');
+      window.localStorage.setItem(storageKey, 'seen');
     } catch {
       // Ignore — see auto-show note above.
     }
-  }, []);
+  }, [storageKey]);
 
   const start = useCallback(() => {
-    setState('welcome');
+    setState({ phase: 'welcome', stepIndex: 0 });
   }, []);
 
   const next = useCallback(() => {
     setState((prev) => {
-      const target = NEXT_STATE[prev];
-      if (target === 'done') {
-        markSeen();
+      const total = stepsRef.current.length;
+      switch (prev.phase) {
+        case 'welcome':
+          return { phase: 'step', stepIndex: 0 };
+        case 'step': {
+          const nextIndex = prev.stepIndex + 1;
+          if (nextIndex < total) {
+            return { phase: 'step', stepIndex: nextIndex };
+          }
+          return { phase: 'completion', stepIndex: prev.stepIndex };
+        }
+        case 'completion':
+          markSeen();
+          return { phase: 'done', stepIndex: prev.stepIndex };
+        case 'closed':
+        case 'done':
+        default:
+          return prev;
       }
-      return target;
     });
   }, [markSeen]);
 
   const back = useCallback(() => {
-    setState((prev) => PREV_STATE[prev]);
+    setState((prev) => {
+      const total = stepsRef.current.length;
+      switch (prev.phase) {
+        case 'step':
+          if (prev.stepIndex === 0) {
+            return { phase: 'welcome', stepIndex: 0 };
+          }
+          return { phase: 'step', stepIndex: prev.stepIndex - 1 };
+        case 'completion':
+          return { phase: 'step', stepIndex: total - 1 };
+        // 'welcome' has no previous; 'closed'/'done' are terminal.
+        case 'welcome':
+        case 'closed':
+        case 'done':
+        default:
+          return prev;
+      }
+    });
   }, []);
 
   const skip = useCallback(() => {
     markSeen();
-    setState('done');
+    setState((prev) => ({ phase: 'done', stepIndex: prev.stepIndex }));
   }, [markSeen]);
 
   const finish = useCallback(() => {
     markSeen();
-    setState('done');
+    setState((prev) => ({ phase: 'done', stepIndex: prev.stepIndex }));
   }, [markSeen]);
+
+  const currentStep: TourStep | null =
+    state.phase === 'step' ? (steps[state.stepIndex] ?? null) : null;
 
   const value = useMemo<WelcomeTourContextValue>(
     () => ({
       state,
+      totalSteps: steps.length,
+      currentStep,
+      steps,
+      welcome,
+      completion,
       start,
       next,
       back,
@@ -225,7 +351,20 @@ export function WelcomeTourProvider({ children }: ProviderProps) {
       registerTarget,
       getTarget,
     }),
-    [state, start, next, back, skip, finish, registerTarget, getTarget],
+    [
+      state,
+      steps,
+      currentStep,
+      welcome,
+      completion,
+      start,
+      next,
+      back,
+      skip,
+      finish,
+      registerTarget,
+      getTarget,
+    ],
   );
 
   return (
@@ -255,7 +394,7 @@ export function useWelcomeTour(): WelcomeTourContextValue {
  * Returns a `(node: HTMLElement | null) => void` ref callback.
  */
 export function useTourTarget(
-  id: TourTargetId,
+  id: string,
 ): (node: HTMLElement | null) => void {
   const ctx = useContext(WelcomeTourContext);
   // Stable callback (ctx is stable too — registerTarget is memoized).

--- a/apps/demo/src/components/welcome-tour/WelcomeTourOverlay.tsx
+++ b/apps/demo/src/components/welcome-tour/WelcomeTourOverlay.tsx
@@ -1,11 +1,16 @@
 // Portal-rendered overlay that orchestrates the welcome tour.
 //
+// Driven entirely by the steps[] / welcome / completion config the
+// consumer passed to <WelcomeTourProvider>. No hardcoded step ids,
+// routes, or copy.
+//
 // v2 responsibilities:
 //   - Portals to document.body so it's not clipped by the shell.
 //   - Cross-fades between steps: when state changes, fades out the
-//     current ring + coach mark (180ms), navigates, waits for the new
-//     target to be measurable (2x rAF), then fades the new ring + card
-//     in at their final positions (240ms).
+//     current ring + coach mark (120ms), navigates (if the step has
+//     a `route`), waits for the new target to be measurable (2x rAF
+//     + spaced retries), then fades the new ring + card in at their
+//     final positions (240ms).
 //   - Re-measures on debounced window resize (150ms) — no
 //     ResizeObserver.
 //   - No celebration. "Got it" just transitions to 'done' which fades
@@ -18,54 +23,15 @@ import { createPortal } from 'react-dom';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
   useWelcomeTour,
-  type TourState,
-  type TourTargetId,
   isActiveTourState,
+  type TourState,
+  type TourStep,
 } from './WelcomeTourContext';
 import { WelcomeCard } from './WelcomeCard';
 import { CompletionCard } from './CompletionCard';
 import { Spotlight, type SpotlightRect, type CoachMarkContent } from './Spotlight';
 import { useReducedMotion } from './useReducedMotion';
-import { DEFAULT_KB_CATEGORY_SLUG, routes } from '../../lib/routes';
 import './welcome-tour-animations.css';
-
-type StepKey = 'step-explorer' | 'step-ai' | 'step-analytics';
-
-/* Step → target id mapping. */
-const STEP_TARGET: Record<StepKey, TourTargetId> = {
-  'step-explorer': 'sidebar-explorer',
-  'step-ai': 'rail-ai',
-  'step-analytics': 'rail-analytics',
-};
-
-/* Step → route path mapping. */
-const STEP_ROUTE: Record<StepKey, string> = {
-  'step-explorer': routes.kb.category(DEFAULT_KB_CATEGORY_SLUG),
-  'step-ai': routes.aiOptimise.hub(),
-  'step-analytics': routes.analytics.articlePerformance(),
-};
-
-/* Coach-mark content per step. */
-const STEP_CONTENT: Record<
-  StepKey,
-  { title: string; body: string; stepIndex: number }
-> = {
-  'step-explorer': {
-    title: 'Browse like files',
-    body: 'Your articles and categories now live in a tree on the left. Click to open, drag to reorganize.',
-    stepIndex: 0,
-  },
-  'step-ai': {
-    title: 'AI Gaps & Suggestions',
-    body: 'We surface missing or thin content based on real customer questions. Tackle the highest-impact gaps first.',
-    stepIndex: 1,
-  },
-  'step-analytics': {
-    title: 'Analytics for every article',
-    body: 'See views, helpful votes, search performance, and how AI is using your content to answer tickets.',
-    stepIndex: 2,
-  },
-};
 
 /** Cross-route fade-out duration before we navigate + remeasure.
  *  Compressed from the previous 180ms (out) + 240ms (in) ≥ 400ms total
@@ -83,55 +49,29 @@ const REDUCED_MOTION_SWAP_MS = 60;
  *  catches second-render targets without dragging the happy path. */
 const MEASURE_RETRY_DELAYS = [80, 180, 320];
 
-/** Total step count surfaced to the coach mark indicator. */
-const TOTAL_STEPS = 3;
-
-function isStepState(state: TourState): state is StepKey {
-  return (
-    state === 'step-explorer' ||
-    state === 'step-ai' ||
-    state === 'step-analytics'
-  );
-}
-
 /**
- * Compute the spotlight rect for a given step. Most steps use the
- * registered target's full bounding rect — but `step-explorer`
- * unions the header + tree elements inside the FileExplorerNav so
- * the ring hugs the visible UI instead of the full-height aside.
+ * Default spotlight rect computation — used when a step doesn't
+ * provide its own `computeRect`. Returns the registered node's
+ * bounding rect, or null if the node is detached / collapsed.
  */
-function computeRectForStep(
-  step: StepKey,
-  registeredNode: HTMLElement,
-): SpotlightRect | null {
-  if (step === 'step-explorer') {
-    const header = registeredNode.querySelector<HTMLElement>(
-      '[data-kb-part="explorer-header"]',
-    );
-    const body =
-      registeredNode.querySelector<HTMLElement>(
-        '[data-kb-part="explorer-tree"]',
-      ) ??
-      registeredNode.querySelector<HTMLElement>(
-        '[data-kb-part="explorer-flat"]',
-      );
-    if (header !== null && body !== null) {
-      const h = header.getBoundingClientRect();
-      const b = body.getBoundingClientRect();
-      const top = Math.min(h.top, b.top);
-      const left = Math.min(h.left, b.left);
-      const right = Math.max(h.right, b.right);
-      const bottom = Math.max(h.bottom, b.bottom);
-      if (right > left && bottom > top) {
-        return { top, left, width: right - left, height: bottom - top };
-      }
-    }
-    // Fall through to the registered node's full rect if either
-    // sub-element is missing — better to show something than nothing.
-  }
-  const r = registeredNode.getBoundingClientRect();
+function defaultComputeRect(node: HTMLElement): SpotlightRect | null {
+  const r = node.getBoundingClientRect();
   if (r.width === 0 && r.height === 0) return null;
   return { top: r.top, left: r.left, width: r.width, height: r.height };
+}
+
+function computeRectForStep(
+  step: TourStep,
+  registeredNode: HTMLElement,
+): SpotlightRect | null {
+  if (typeof step.computeRect === 'function') {
+    const rect = step.computeRect(registeredNode);
+    if (rect !== null) return rect;
+    // Fall through to default if the step's computeRect bailed out
+    // (e.g. expected sub-elements missing) — better to show something
+    // than nothing.
+  }
+  return defaultComputeRect(registeredNode);
 }
 
 export function WelcomeTourOverlay() {
@@ -200,23 +140,32 @@ export function WelcomeTourOverlay() {
    * old rect — a flash the user would catch.
    */
 
+  // Snapshot the step we're transitioning to. Hoisted out of the
+  // effect so it's stable for the closure cycle below.
+  const nextState = tour.state;
+  const nextStep: TourStep | null =
+    nextState.phase === 'step'
+      ? (tour.steps[nextState.stepIndex] ?? null)
+      : null;
+  const stepTargetId: string | null = nextStep?.id ?? null;
+  const stepRoute: string | null = nextStep?.route ?? null;
+
   useEffect(() => {
     const cycle = ++measureCycleRef.current;
-    const nextState = tour.state;
 
     // Non-step states.
-    if (!isStepState(nextState)) {
+    if (nextState.phase !== 'step') {
       // If we were rendering a step and the user just finished/skipped
       // out (or earned the completion card), play one final fade-out
       // before unmounting. We do NOT update renderedStep yet — keeping
       // it on the prior step keeps the Spotlight mounted while
       // phase='out' drives the fade.
-      const wasRenderingStep = isStepState(renderedStep);
+      const wasRenderingStep = renderedStep.phase === 'step';
       if (
         wasRenderingStep &&
-        (nextState === 'done' ||
-          nextState === 'closed' ||
-          nextState === 'completion')
+        (nextState.phase === 'done' ||
+          nextState.phase === 'closed' ||
+          nextState.phase === 'completion')
       ) {
         setPhase('out');
         // Tightened from 220ms to match the new compressed fade-out
@@ -237,11 +186,14 @@ export function WelcomeTourOverlay() {
       return;
     }
 
-    const targetId = STEP_TARGET[nextState];
-    const targetPath = STEP_ROUTE[nextState];
+    if (stepTargetId === null) {
+      // Defensive — the phase says 'step' but the step is missing.
+      return;
+    }
 
-    const wasRenderingStep = isStepState(renderedStep);
-    const samePathname = location.pathname === targetPath;
+    const wasRenderingStep = renderedStep.phase === 'step';
+    const samePathname =
+      stepRoute === null || location.pathname === stepRoute;
     // Same-pathname slide: skip fade-out, no opacity dip.
     // Cross-route swap: short fade-out (or 60ms in reduced-motion).
     const needsFadeOut = wasRenderingStep && !samePathname;
@@ -319,9 +271,12 @@ export function WelcomeTourOverlay() {
 
     const tryMeasure = (): boolean => {
       if (cycle !== measureCycleRef.current) return true; // cancelled
-      const node = tour.getTarget(targetId);
+      const node = tour.getTarget(stepTargetId);
       if (node === null) return false;
-      const nextRect = computeRectForStep(nextState, node);
+      // We just confirmed the step exists (nextState.phase === 'step'),
+      // so nextStep is non-null here.
+      const step = nextStep as TourStep;
+      const nextRect = computeRectForStep(step, node);
       if (nextRect === null) return false;
       applyMeasured(nextRect, node);
       return true;
@@ -330,9 +285,9 @@ export function WelcomeTourOverlay() {
     timers.push(
       window.setTimeout(() => {
         if (cycle !== measureCycleRef.current) return;
-        // Navigate (no-op if already on the route).
-        if (!samePathname) {
-          navigate(targetPath);
+        // Navigate (no-op if already on the route, or no route configured).
+        if (stepRoute !== null && !samePathname) {
+          navigate(stepRoute);
         }
         // Reduced-motion path skips the rAF dance + retry array
         // entirely. A single immediate measure attempt is enough —
@@ -370,23 +325,25 @@ export function WelcomeTourOverlay() {
     return () => {
       timers.forEach((t) => window.clearTimeout(t));
     };
-    // We intentionally exclude `location.pathname` and `renderedStep`
-    // from deps — the cycle is driven by tour.state changes only.
-    // (reduceMotion is also stable across a single tour run.)
+    // We intentionally exclude `location.pathname`, `renderedStep`, and
+    // `nextStep` from deps — the cycle is driven by tour.state changes
+    // only (nextState.phase + nextState.stepIndex). (reduceMotion is
+    // also stable across a single tour run.)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tour.state]);
+  }, [nextState.phase, nextState.stepIndex]);
 
   /* ── Window resize re-measure (debounced 150ms) ──────────── */
 
   useEffect(() => {
-    if (!isStepState(renderedStep)) return;
-    const targetId = STEP_TARGET[renderedStep];
-    const step = renderedStep;
+    if (renderedStep.phase !== 'step') return;
+    const step = tour.steps[renderedStep.stepIndex];
+    if (step === undefined) return;
+    const stepId = step.id;
     let timer: number | null = null;
     const handle = () => {
       if (timer !== null) window.clearTimeout(timer);
       timer = window.setTimeout(() => {
-        const node = tour.getTarget(targetId);
+        const node = tour.getTarget(stepId);
         if (node === null) return;
         const nextRect = computeRectForStep(step, node);
         if (nextRect === null) return;
@@ -402,15 +359,20 @@ export function WelcomeTourOverlay() {
 
   /* ── Build coach-mark content ────────────────────────────── */
 
-  const coachMark: CoachMarkContent | null = isStepState(renderedStep)
+  const renderedStepData: TourStep | null =
+    renderedStep.phase === 'step'
+      ? (tour.steps[renderedStep.stepIndex] ?? null)
+      : null;
+
+  const coachMark: CoachMarkContent | null = renderedStepData
     ? (() => {
-        const base = STEP_CONTENT[renderedStep];
-        const isLast = base.stepIndex === TOTAL_STEPS - 1;
+        const total = tour.totalSteps;
+        const isLast = renderedStep.stepIndex === total - 1;
         return {
-          title: base.title,
-          body: base.body,
-          stepIndex: base.stepIndex,
-          totalSteps: TOTAL_STEPS,
+          title: renderedStepData.title,
+          body: renderedStepData.body,
+          stepIndex: renderedStep.stepIndex,
+          totalSteps: total,
           primaryLabel: isLast ? 'Got it' : 'Next',
           primaryIsFinish: isLast,
         };
@@ -424,21 +386,27 @@ export function WelcomeTourOverlay() {
   // The visible state is renderedStep (which lags tour.state during
   // fade-out). This keeps the overlay mounted through the closing
   // fade after "Got it" / "Skip".
-  if (renderedStep === 'closed' || renderedStep === 'done') return null;
+  if (renderedStep.phase === 'closed' || renderedStep.phase === 'done') {
+    return null;
+  }
 
   let content: React.ReactNode = null;
 
-  if (renderedStep === 'welcome') {
-    content = <WelcomeCard onStart={tour.next} onSkip={tour.skip} />;
-  } else if (renderedStep === 'completion') {
-    content = <CompletionCard onDismiss={tour.next} />;
-  } else if (coachMark) {
-    // Rail icon buttons (rail-ai, rail-analytics) have transparent
-    // backgrounds — when we lift them above the dim, we need to paint
-    // a white background underneath so they read cleanly. The sidebar
-    // explorer is a full surface card and already has its own bg.
+  if (renderedStep.phase === 'welcome') {
+    content = (
+      <WelcomeCard
+        content={tour.welcome}
+        onStart={tour.next}
+        onSkip={tour.skip}
+      />
+    );
+  } else if (renderedStep.phase === 'completion') {
+    content = (
+      <CompletionCard content={tour.completion} onDismiss={tour.next} />
+    );
+  } else if (coachMark && renderedStepData) {
     const targetNeedsBackgroundFill =
-      renderedStep === 'step-ai' || renderedStep === 'step-analytics';
+      renderedStepData.targetNeedsBackgroundFill ?? false;
     content = (
       <Spotlight
         rect={rect}

--- a/apps/demo/src/components/welcome-tour/index.ts
+++ b/apps/demo/src/components/welcome-tour/index.ts
@@ -1,8 +1,24 @@
 // Public surface for the welcome-tour prototype module.
 //
-// Consumers only need the Provider + the `useTourTarget` ref-callback
-// hook (to register DOM nodes that subsequent steps will spotlight).
-// Everything else (overlay, card, spotlight) is wired internally.
+// Consumers need:
+//   - <WelcomeTourProvider steps welcome completion storageKey>
+//   - useTourTarget(id) — ref callback to register DOM nodes
+//   - useWelcomeTour() — escape-hatch into the state machine
+//
+// Everything else (overlay, cards, spotlight) is wired internally.
 
-export { WelcomeTourProvider, useWelcomeTour, useTourTarget } from './WelcomeTourContext';
-export type { TourState, TourTargetId } from './WelcomeTourContext';
+export {
+  WelcomeTourProvider,
+  useWelcomeTour,
+  useTourTarget,
+  isActiveTourState,
+} from './WelcomeTourContext';
+export type {
+  TourState,
+  TourPhase,
+  TourStep,
+  WelcomeContent,
+  CompletionContent,
+  WelcomeFeature,
+  WelcomeTourProviderProps,
+} from './WelcomeTourContext';

--- a/apps/demo/src/routes/ShellLayout.tsx
+++ b/apps/demo/src/routes/ShellLayout.tsx
@@ -27,6 +27,12 @@ import {
   WelcomeTourProvider,
   useTourTarget,
 } from '../components/welcome-tour';
+import {
+  HIVER_COMPLETION,
+  HIVER_TOUR_STEPS,
+  HIVER_TOUR_STORAGE_KEY,
+  HIVER_WELCOME,
+} from '../components/welcome-tour-config';
 
 function RouteAwareExplorer() {
   const { pathname } = useLocation();
@@ -109,7 +115,12 @@ export default function ShellLayout() {
   useFocusOnRouteChange();
   return (
     <SidebarCollapseProvider storageKey="kb-demo.sidebar.collapsed">
-      <WelcomeTourProvider>
+      <WelcomeTourProvider
+        steps={HIVER_TOUR_STEPS}
+        welcome={HIVER_WELCOME}
+        completion={HIVER_COMPLETION}
+        storageKey={HIVER_TOUR_STORAGE_KEY}
+      >
         <ShellLayoutInner />
       </WelcomeTourProvider>
     </SidebarCollapseProvider>

--- a/apps/demo/src/routes/WelcomeRedirect.tsx
+++ b/apps/demo/src/routes/WelcomeRedirect.tsx
@@ -12,7 +12,7 @@
 import { useEffect, useRef } from 'react';
 import { Navigate } from 'react-router-dom';
 import { DEFAULT_KB_CATEGORY_SLUG, routes } from '../lib/routes';
-import { STORAGE_KEY } from '../components/welcome-tour/WelcomeTourContext';
+import { HIVER_TOUR_STORAGE_KEY } from '../components/welcome-tour-config';
 
 export default function WelcomeRedirect() {
   // Strict-mode runs effects twice in dev — gate so we only clear once.
@@ -22,7 +22,7 @@ export default function WelcomeRedirect() {
     if (clearedRef.current) return;
     clearedRef.current = true;
     try {
-      window.localStorage.removeItem(STORAGE_KEY);
+      window.localStorage.removeItem(HIVER_TOUR_STORAGE_KEY);
     } catch {
       // Storage may be unavailable (private mode) — the ?welcome=1
       // query param path will still trigger the tour.


### PR DESCRIPTION
- WelcomeTourProvider now drives state/copy from `steps`, `welcome`, `completion`, `storageKey` props (plus optional `resetQueryParam`, `autoShowDelayMs`); state machine collapses to `{ phase, stepIndex }` and `useTourTarget(id)` takes a plain `string`.
- Demo copy + Hiver-specific routes + the explorer header+tree union live in `apps/demo/src/components/welcome-tour-config.tsx`; WelcomeCard / CompletionCard render content from props with byte-identical visual chrome (chip, animations, focus trap, backdrop).
- Storage key preserved as `'hiver-kb-welcome-tour-v1'` so existing users don't see a tour reset.