### PR TITLE
Phase C: AI Gaps interaction motion

### DIFF
--- a/packages/kb-ui/src/components/content/AIGapRail.tsx
+++ b/packages/kb-ui/src/components/content/AIGapRail.tsx
@@ -423,14 +423,21 @@ function RailCard({
         // Absolute position so multiple cards can coexist in a tall
         // rail without flexbox squashing them together.
         'absolute left-0 right-0',
-        // 200ms ease-out per the chunk 3 spec — chunk 4/5 reflows
-        // (activation / accept / reject) inherit this animation.
-        'transition-[top,opacity] duration-200 ease-out',
+        // 260ms with strong custom in-out curve. Rail-card reflow is
+        // on-screen MOVEMENT (existing card moving to a new pinned top
+        // when neighbours accept/dismiss/activate), so `ease-in-out` is
+        // the right family per Emil's framework — natural accel/decel.
+        // The custom `--ease-in-out-strong` curve has more punch than
+        // bare `ease-in-out` and makes the reflow feel intentional.
+        // `prefers-reduced-motion: reduce` is honoured via the global
+        // gate in tokens.css.
+        'motion-safe:transition-[top,opacity] motion-safe:duration-[260ms]',
         ready ? 'opacity-100' : 'opacity-0',
       )}
       style={{
         top: `${top}px`,
         willChange: willChange ? 'top' : undefined,
+        transitionTimingFunction: 'var(--ease-in-out-strong)',
       }}
     >
       {showConnector && (

--- a/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
+++ b/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
@@ -153,9 +153,11 @@ function SourcesButton({
         // visual baseline alignment with the icon + adjacent NavArrow
         // / accept-reject pills (medium gave a heavier optical feel).
         'text-[14px] font-normal leading-[20px] text-text-meta',
+        // Specific properties on the transition (no `transition-colors`
+        // catch-all). Strong ease-out curve for instant hover feedback.
         disabled
           ? 'cursor-default'
-          : 'transition-colors hover:bg-surface-muted hover:text-text-primary',
+          : 'transition-[background-color,color,transform] duration-[160ms] [transition-timing-function:var(--ease-out-strong)] hover:bg-surface-muted hover:text-text-primary motion-safe:active:scale-[0.96]',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
       )}
     >
@@ -180,11 +182,17 @@ function RejectButton({
       aria-hidden={disabled || undefined}
       tabIndex={disabled ? -1 : undefined}
       aria-label={disabled ? undefined : 'Reject suggestion'}
+      // Emil-style press feedback: 0.94 scale on `:active`. Subtle but
+      // present, confirming the click landed. Specific property names
+      // on the transition (no `transition: all`). `motion-safe` gates
+      // the scale so reduced-motion users get the color flip only.
       className={cn(
         'inline-flex size-6 items-center justify-center rounded-full bg-[var(--color-btn-danger-bg)]',
         // Hover bg derived from --color-ai-removal (#d52c1f) at ~12% over white.
         'text-ai-removal',
-        disabled ? 'cursor-default' : 'transition-colors hover:bg-[#fad9d6]',
+        disabled
+          ? 'cursor-default'
+          : 'transition-[background-color,transform] duration-[160ms] [transition-timing-function:var(--ease-out-strong)] hover:bg-[#fad9d6] motion-safe:active:scale-[0.94]',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
       )}
     >
@@ -215,7 +223,12 @@ function AcceptButton({
         // step to keep affordance visible on the light fill.
         'inline-flex size-6 items-center justify-center rounded-full bg-surface-muted',
         'text-text-primary',
-        disabled ? 'cursor-default' : 'transition-colors hover:bg-card-border',
+        // Emil-style press feedback: 0.94 scale on `:active` + strong
+        // ease-out curve for instant feedback. Specific property names
+        // on the transition. `motion-safe` gates the scale.
+        disabled
+          ? 'cursor-default'
+          : 'transition-[background-color,transform] duration-[160ms] [transition-timing-function:var(--ease-out-strong)] hover:bg-card-border motion-safe:active:scale-[0.94]',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
       )}
     >
@@ -287,7 +300,9 @@ export function AIGapSuggestionCard({
           aria-label={`Undo ${state} for ${suggestion.title}`}
           className={cn(
             'ml-auto inline-flex size-7 items-center justify-center rounded-full',
-            'text-text-primary transition-colors',
+            // Specific properties on the transition + Emil-style press scale
+            // (motion-safe — reduced-motion users only see the color flip).
+            'text-text-primary transition-[background-color,transform] duration-[160ms] [transition-timing-function:var(--ease-out-strong)] motion-safe:active:scale-[0.92]',
             'hover:bg-surface-muted',
             'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
           )}

--- a/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
+++ b/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
@@ -280,6 +280,11 @@ export function AIGapSuggestionCard({
           // collapsed default (px-3 py-2). Do not re-add the 22/24
           // override — see comment above.
           'bg-canvas',
+          // Gentle settle on mount — fires when the active card flips
+          // to a decision chip. 200ms opacity+scale via the kb-ui
+          // `kb-chip-enter` keyframe. `motion-safe:` gates the animation
+          // so reduced-motion users see the chip mount instantly.
+          'motion-safe:animate-kb-chip-enter',
           className,
         )}
         data-kb-component="ai-gap-suggestion-card"

--- a/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
+++ b/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
@@ -378,6 +378,12 @@ export function AIGapSuggestionCard({
         // Override AICard's `p-4` default → Figma padding.
         'border-border shadow-lg px-[22px] py-[24px]',
         // Idle differs from active only by bg (canvas grey vs white).
+        // Transition the bg colour so the idle→active flip reads as a
+        // smooth state change rather than a hard flash. 200ms with the
+        // strong ease-out curve — same family as the other AI-Gap
+        // motion. Specific property (background-color) per Emil's rule
+        // against `transition: all` / `transition-colors`.
+        'transition-[background-color] duration-[200ms] [transition-timing-function:var(--ease-out-strong)]',
         isIdle ? 'bg-canvas' : 'bg-white',
         // Click-to-activate surface for idle cards. Pointer cursor + soft
         // hover lift indicate clickability without breaking the recessed

--- a/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
+++ b/packages/kb-ui/src/components/content/AIGapSuggestionCard.tsx
@@ -381,9 +381,13 @@ export function AIGapSuggestionCard({
         isIdle ? 'bg-canvas' : 'bg-white',
         // Click-to-activate surface for idle cards. Pointer cursor + soft
         // hover lift indicate clickability without breaking the recessed
-        // visual treatment.
+        // visual treatment. Tightened to specific properties + strong
+        // ease-out curve so the hover feels intentional (not the bare
+        // CSS `ease-out`). Subtle `:active:scale-[0.995]` confirms
+        // the click landed without competing with the card's own
+        // shadow lift. All transforms gated `motion-safe:`.
         isIdle && handleIdleActivate &&
-          'cursor-pointer transition-shadow hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/15',
+          'cursor-pointer transition-[box-shadow,transform] duration-[200ms] [transition-timing-function:var(--ease-out-strong)] hover:shadow-xl motion-safe:active:scale-[0.995] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/15',
         className,
       )}
       onClick={handleIdleActivate}

--- a/packages/kb-ui/src/components/content/NavArrow.tsx
+++ b/packages/kb-ui/src/components/content/NavArrow.tsx
@@ -35,9 +35,13 @@ export function NavArrow({ direction, onClick, disabled, className }: NavArrowPr
       className={cn(
         'inline-flex size-6 items-center justify-center rounded-[4px]',
         // Idle baseline. Hover affordances dropped when disabled.
+        // Emil-style press feedback: scale-down on `:active`. Specific
+        // property names on the transition (no `transition: all`).
+        // `motion-safe` gates the scale so reduced-motion users only
+        // see the color flip.
         disabled
           ? 'cursor-not-allowed text-text-disabled'
-          : 'text-text-muted transition-colors hover:bg-surface-muted hover:text-text-primary',
+          : 'text-text-muted transition-[background-color,color,transform] duration-[160ms] [transition-timing-function:var(--ease-out-strong)] hover:bg-surface-muted hover:text-text-primary motion-safe:active:scale-[0.92]',
         'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
         className,
       )}

--- a/packages/kb-ui/src/components/content/SuggestionBlock.tsx
+++ b/packages/kb-ui/src/components/content/SuggestionBlock.tsx
@@ -224,6 +224,14 @@ export function SuggestionBlock({
     ...(suggestionId ? { 'data-suggestion-id': suggestionId } : {}),
   } as const;
 
+  // Gentle 220ms fade-in + 4px lift on mount — fires when an inline
+  // suggestion region transitions from inactive (plain text) to active
+  // (colored wash). Without this the highlight appears as an instant
+  // flash, which feels jarring against the rest of the surface motion.
+  // `motion-safe:` gates the keyframe so reduced-motion users see the
+  // wash mount instantly.
+  const mountAnimClass = 'motion-safe:animate-kb-suggestion-mount';
+
   /* ── Replace ─────────────────────────────────────────────── */
 
   if (type === 'replace') {
@@ -233,7 +241,7 @@ export function SuggestionBlock({
 
     if (hasSentencePair) {
       return (
-        <div {...rootProps} className={cn('flex flex-col gap-2', className)}>
+        <div {...rootProps} className={cn('flex flex-col gap-2', mountAnimClass, className)}>
           {oldSentences && oldSentences.length > 0 && (
             <SentenceList variant="removal" sentences={oldSentences} />
           )}
@@ -246,7 +254,7 @@ export function SuggestionBlock({
 
     // Legacy block-mode replace.
     return (
-      <div {...rootProps} className={cn('flex flex-col gap-2', className)}>
+      <div {...rootProps} className={cn('flex flex-col gap-2', mountAnimClass, className)}>
         <BlockHalf variant="removal">{oldContent}</BlockHalf>
         <BlockHalf variant="addition">{newContent}</BlockHalf>
       </div>
@@ -257,7 +265,7 @@ export function SuggestionBlock({
 
   if (sentences && sentences.length > 0) {
     return (
-      <div {...rootProps} className={className}>
+      <div {...rootProps} className={cn(mountAnimClass, className)}>
         <SentenceList variant={type} sentences={sentences} />
       </div>
     );
@@ -270,6 +278,7 @@ export function SuggestionBlock({
       className={cn(
         'rounded-[8px] px-4 py-3',
         BLOCK_VARIANT_CLASS[type],
+        mountAnimClass,
         className,
       )}
     >

--- a/packages/kb-ui/src/tokens.css
+++ b/packages/kb-ui/src/tokens.css
@@ -206,6 +206,18 @@ html {
   --shadow-md: 0px 4px 6px -1px rgba(0, 0, 0, 0.05), 0px 2px 4px -2px rgba(0, 0, 0, 0.10);
   --shadow-lg: 0px 8px 12px -4px rgba(0, 0, 0, 0.05), 0px 4px 6px -2px rgba(0, 0, 0, 0.10);
 
+  /* ── Motion easings ─────────────────────────────
+   * Strong custom curves for UI motion. The built-in CSS easings feel
+   * weak; these add the punch that makes animations feel intentional.
+   * Source: easing.dev / Emil Kowalski's design-eng playbook.
+   *   --ease-out-strong   for entering/exiting elements (instant feedback)
+   *   --ease-in-out-strong for on-screen movement (rail reflow, position changes)
+   *   --ease-press        for button :active feedback (snappy)
+   */
+  --ease-out-strong:    cubic-bezier(0.23, 1, 0.32, 1);
+  --ease-in-out-strong: cubic-bezier(0.77, 0, 0.175, 1);
+  --ease-press:         cubic-bezier(0.34, 1.56, 0.64, 1);
+
   /* Font family */
   --font-sans: Inter, system-ui, sans-serif;
 }

--- a/packages/kb-ui/src/tokens.css
+++ b/packages/kb-ui/src/tokens.css
@@ -244,4 +244,42 @@ html {
   .animate-toast-in {
     animation: kb-toast-in 200ms ease-out;
   }
+
+  /* AI Gaps — SuggestionBlock highlight wash mount.
+   * Fires when an inline suggestion region transitions from inactive
+   * to active and the colored highlight DOM mounts. Subtle (opacity
+   * + 4px lift); gated by `motion-safe:` at call site so reduced-motion
+   * users get an instant mount. Custom strong ease-out curve. */
+  @keyframes kb-suggestion-mount {
+    from {
+      opacity: 0;
+      transform: translateY(4px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  .animate-kb-suggestion-mount {
+    animation: kb-suggestion-mount 220ms var(--ease-out-strong);
+  }
+
+  /* AI Gaps — collapsed decision chip enter.
+   * Fires when an AIGapSuggestionCard flips into its `accepted` or
+   * `dismissed` chip after the user's decision. Gentle "settle" —
+   * 0.96 scale lift + opacity fade so the chip arrives with a hint
+   * of confirmation rather than a hard swap. */
+  @keyframes kb-chip-enter {
+    from {
+      opacity: 0;
+      transform: scale(0.96);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+  .animate-kb-chip-enter {
+    animation: kb-chip-enter 200ms var(--ease-out-strong);
+  }
 }


### PR DESCRIPTION
## Summary

Per emil-design-eng skill — adds custom-curve motion to the AI Gaps review flow. Today every state flip (accept / dismiss / activate) is a hard swap; this PR adds Sonner-style mount/exit motion, press feedback, and a strong on-screen curve for the rail reflow.

## Commits

- `bab6b32` — motion tokens (`--ease-out-strong`, `--ease-in-out-strong`, `--ease-press`) + upgrade rail reflow to in-out-strong at 260ms
- `47566f9` — press scale on every pressable control (Accept/Reject pills, NavArrow, SourcesButton, Undo); tightened `transition-colors` to specific properties
- `abdebc3` — `kb-suggestion-mount` (220ms 4px lift) on SuggestionBlock activate + `kb-chip-enter` (200ms 0.96 scale) on decision-chip flip
- `0110bcb` — idle card hover/press feedback (specific properties + strong curve)
- `848d30d` — smooth idle→active bg-color flip on AIGapSuggestionCard

## What changed visually

| Moment | Before | After |
| --- | --- | --- |
| Active card → new active card (rail reflow) | bare `ease-out` at 200ms | `--ease-in-out-strong` at 260ms (on-screen movement) |
| Accept / dismiss flip | hard DOM swap | `kb-chip-enter` 200ms scale 0.96→1 + fade |
| Inactive → active inline highlight | instant wash flash | `kb-suggestion-mount` 220ms 4px lift + fade |
| Idle → active bg-color flip | instant | 200ms strong ease-out |
| Pressing any control | no `:active` feedback | scale 0.92-0.96 with strong curve |
| Hovering controls | `transition-colors` (everything) | specific properties + strong curve |

## What I confirmed is already fine

- `SourcesSideSheet` open/close — out of scope per file list
- `SuggestionCard` (used on hub) — D2 scope per task brief
- Smooth-scroll on active card change — already respects `prefers-reduced-motion` via `smoothScrollTo` utility

## Reduced motion

Every transform/keyframe is gated `motion-safe:` so `prefers-reduced-motion: reduce` users get instant DOM swaps and color flips with no movement.

## kb-ui contract

Additive only — no breaking API change. Components touched: `AIGapSuggestionCard`, `AIGapRail`, `SuggestionBlock`, `NavArrow`, `tokens.css`. All variants render the same DOM shape; CSS-only motion via new keyframes / class additions.

## Verification gate

- `tsc --noEmit` clean across both workspaces
- `npm run build-storybook` builds (8.5s, 1.6 MB iframe — same as baseline)
- Dev server at http://localhost:5174/ai-optimise returns 200; review route at http://localhost:5174/ai-optimise/how-to-reset-your-password/review also 200

## Test plan

- [ ] Open http://localhost:5174/ai-optimise → click into a card → review experience renders
- [ ] Click idle paired card → it activates with smooth bg-color flip + inline highlight mount lift
- [ ] Click Accept → chip flips in with subtle scale-up; rail reflows below with in-out curve
- [ ] Click Reject → same exit, chip "dismissed" pill mounts gently
- [ ] Press Accept/Reject buttons → see 0.94 scale feedback on `:active`
- [ ] Press NavArrow → see 0.92 scale feedback
- [ ] Hover idle card → see soft shadow lift via strong ease-out curve
- [ ] Toggle prefers-reduced-motion ON (macOS System Settings → Accessibility → Display → Reduce Motion) → every transform/keyframe drops, state flips remain instant

🤖 Generated with [Claude Code](https://claude.com/claude-code)