### PR TITLE
Phase D1: Overlays motion (Modal/SideSheet)

### DIFF
--- a/packages/kb-ui/src/components/overlays/Modal.tsx
+++ b/packages/kb-ui/src/components/overlays/Modal.tsx
@@ -252,13 +252,28 @@ export function Modal({
 
   /* Portal mode — centered modal over a dimmed backdrop. Backdrop
    * uses text-primary/40 wash + z-90 to match the existing demo
-   * ConfirmDialog stacking; content sits on z-91. */
+   * ConfirmDialog stacking; content sits on z-91.
+   *
+   * Motion (Phase D1, emil-design-eng skill):
+   *   - Backdrop: opacity fade — 200ms enter / 140ms exit
+   *   - Content: scale 0.96 → 1 + opacity fade — 200ms enter / 140ms exit
+   *     transform-origin: center (skill confirms modals stay centered)
+   *   - Exit faster than enter (close feels snappy, not draggy)
+   *   - Keyframes (not transitions) so Radix can suspend unmount via
+   *     `animationend` while the exit animation plays out
+   *   - `motion-safe:` gates the animation — reduced-motion users get
+   *     instant mount/unmount (Radix detects no animation and unmounts
+   *     immediately, which is the correct accessible default) */
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Overlay
           data-kb-part="modal-overlay"
-          className="fixed inset-0 z-[90] bg-text-primary/40"
+          className={cn(
+            'fixed inset-0 z-[90] bg-text-primary/40',
+            'motion-safe:data-[state=open]:animate-kb-backdrop-in',
+            'motion-safe:data-[state=closed]:animate-kb-backdrop-out',
+          )}
         />
 
         <Dialog.Content
@@ -269,7 +284,9 @@ export function Modal({
             'max-w-[calc(100vw-32px)]',
             'flex flex-col bg-white border border-card-border overflow-hidden',
             'shadow-[0_24px_48px_rgba(15,23,42,0.20)]',
-            'animate-toast-in focus:outline-none',
+            'focus:outline-none',
+            'motion-safe:data-[state=open]:animate-kb-modal-in',
+            'motion-safe:data-[state=closed]:animate-kb-modal-out',
             className,
           )}
           aria-describedby={undefined}

--- a/packages/kb-ui/src/components/overlays/SideSheet.tsx
+++ b/packages/kb-ui/src/components/overlays/SideSheet.tsx
@@ -121,7 +121,20 @@ export function SideSheet({
     );
   }
 
-  /* Portal mode — original behavior, unchanged. */
+  /* Portal mode — right-docked sheet over a dimmed backdrop.
+   *
+   * Motion (Phase D1, emil-design-eng skill):
+   *   - Backdrop: opacity fade — 200ms enter / 140ms exit (same as Modal)
+   *   - Sheet: slide-in from right edge — 240ms strong ease-out
+   *     (Vaul-style timing for drawer-shaped surfaces)
+   *   - Sheet exit: 180ms (faster than enter)
+   *   - transform-origin: right — this is the SKILL EXCEPTION to the
+   *     modal-center rule; sheets are anchored to the edge they slide
+   *     from
+   *   - Keyframes (not transitions) so Radix suspends unmount via
+   *     `animationend` while the slide-out plays
+   *   - `motion-safe:` gates motion — reduced-motion users get instant
+   *     mount/unmount, which is the correct accessible default */
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
@@ -129,7 +142,11 @@ export function SideSheet({
          * dark wash so feature sheets composing on top look identical. */}
         <Dialog.Overlay
           data-kb-part="side-sheet-overlay"
-          className="fixed inset-0 z-40 bg-black/85"
+          className={cn(
+            'fixed inset-0 z-40 bg-black/85',
+            'motion-safe:data-[state=open]:animate-kb-backdrop-in',
+            'motion-safe:data-[state=closed]:animate-kb-backdrop-out',
+          )}
         />
 
         {/* Right-docked sheet. Width is dynamic so it lives on inline
@@ -142,6 +159,8 @@ export function SideSheet({
             'border-l border-card-border',
             'shadow-[-4px_0_16px_rgba(15,23,42,0.08)]',
             'focus:outline-none',
+            'motion-safe:data-[state=open]:animate-kb-sheet-in-right',
+            'motion-safe:data-[state=closed]:animate-kb-sheet-out-right',
             className,
           )}
           aria-describedby={undefined}

--- a/packages/kb-ui/src/tokens.css
+++ b/packages/kb-ui/src/tokens.css
@@ -218,6 +218,78 @@ html {
   --ease-in-out-strong: cubic-bezier(0.77, 0, 0.175, 1);
   --ease-press:         cubic-bezier(0.34, 1.56, 0.64, 1);
 
+  /* ─────────────────────────────────────────────────────────────
+   * Overlay motion — Phase D1 (Emil's overlays pass)
+   *
+   * Modals and side sheets share a tight motion vocabulary. Tokens
+   * are registered as `--animate-*` so Tailwind v4 auto-generates
+   * the `animate-kb-*` utilities AND composes them with variants
+   * like `motion-safe:` and `data-[state=open]:` — the variant
+   * composition is the whole point (legacy `@layer utilities` keyframes
+   * don't compose).
+   *
+   * Vocabulary:
+   *  - Enter: strong ease-out, 200-240ms, transform + opacity only
+   *  - Exit:  same curve, faster (140-180ms) — exit beats enter so
+   *           close feels snappy rather than draggy
+   *  - Modal: scale 0.96 → 1 (never 0; nothing in the real world
+   *           appears from nothing) + opacity, `transform-origin:
+   *           center` (modals aren't anchored to a trigger — skill
+   *           confirms)
+   *  - Sheet: translateX 100% → 0 (translate doesn't care about
+   *           transform-origin; the slide direction encodes the
+   *           "anchored to right edge" feel)
+   *
+   * Keyframes (not transitions) because Radix Dialog suspends
+   * unmount via `animationend`, not `transitionend`. Transitions
+   * would unmount the content instantly on close, breaking exit.
+   * Keyframes ≤240ms keep mid-animation interruption rare; when
+   * it does happen, `data-state` flip retargets the next animation
+   * rather than snapping back to zero. */
+  --animate-kb-modal-in:      kb-modal-in 200ms var(--ease-out-strong);
+  --animate-kb-modal-out:     kb-modal-out 140ms var(--ease-out-strong);
+  --animate-kb-backdrop-in:   kb-backdrop-in 200ms ease;
+  --animate-kb-backdrop-out:  kb-backdrop-out 140ms ease;
+  --animate-kb-sheet-in-right:  kb-sheet-in-right 240ms var(--ease-out-strong);
+  --animate-kb-sheet-out-right: kb-sheet-out-right 180ms var(--ease-out-strong);
+
+  @keyframes kb-modal-in {
+    from {
+      opacity: 0;
+      transform: translate(-50%, -50%) scale(0.96);
+    }
+    to {
+      opacity: 1;
+      transform: translate(-50%, -50%) scale(1);
+    }
+  }
+  @keyframes kb-modal-out {
+    from {
+      opacity: 1;
+      transform: translate(-50%, -50%) scale(1);
+    }
+    to {
+      opacity: 0;
+      transform: translate(-50%, -50%) scale(0.96);
+    }
+  }
+  @keyframes kb-backdrop-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+  @keyframes kb-backdrop-out {
+    from { opacity: 1; }
+    to   { opacity: 0; }
+  }
+  @keyframes kb-sheet-in-right {
+    from { transform: translateX(100%); }
+    to   { transform: translateX(0); }
+  }
+  @keyframes kb-sheet-out-right {
+    from { transform: translateX(0); }
+    to   { transform: translateX(100%); }
+  }
+
   /* Font family */
   --font-sans: Inter, system-ui, sans-serif;
 }
@@ -281,120 +353,5 @@ html {
   }
   .animate-kb-chip-enter {
     animation: kb-chip-enter 200ms var(--ease-out-strong);
-  }
-
-  /* ─────────────────────────────────────────────────────────────
-   * Overlay motion — Phase D1 (Emil's overlays pass)
-   *
-   * Modals and side sheets share a tight motion vocabulary:
-   *  - Enter: strong ease-out, 200-240ms, transform + opacity only
-   *  - Exit:  same curve, faster (140-180ms) — exit is faster than
-   *           enter so the close feels snappy rather than draggy
-   *  - Modals scale from 0.96 (never 0) with `transform-origin: center`
-   *    because modals aren't anchored to a trigger
-   *  - Sheets slide from their edge (translateX 100%) with
-   *    `transform-origin: right` — the EXCEPTION to the modal-center
-   *    rule from the emil-design-eng skill
-   *
-   * Keyframes (not transitions) are used here for one specific
-   * reason: Radix Dialog suspends unmount via `animationend`, not
-   * `transitionend`. Transitions would unmount the content
-   * instantly on close. Keyframes are short enough (≤240ms) that
-   * mid-animation interruption is rarely visible; for the cases
-   * where it matters, `data-state` change retargets the next
-   * animation rather than snapping back to zero.
-   * ───────────────────────────────────────────────────────────── */
-
-  /* Modal content — center scale-in from 0.96 + opacity fade.
-   * 200ms strong ease-out per Emil's playbook (modals 200-500ms,
-   * staying on the snappy end keeps the UI feeling responsive). */
-  @keyframes kb-modal-in {
-    from {
-      opacity: 0;
-      transform: translate(-50%, -50%) scale(0.96);
-    }
-    to {
-      opacity: 1;
-      transform: translate(-50%, -50%) scale(1);
-    }
-  }
-  .animate-kb-modal-in {
-    animation: kb-modal-in 200ms var(--ease-out-strong);
-    transform-origin: center;
-  }
-
-  /* Modal content — exit. Faster than enter (140ms vs 200ms) so
-   * close feels snappy. Same scale curve in reverse. */
-  @keyframes kb-modal-out {
-    from {
-      opacity: 1;
-      transform: translate(-50%, -50%) scale(1);
-    }
-    to {
-      opacity: 0;
-      transform: translate(-50%, -50%) scale(0.96);
-    }
-  }
-  .animate-kb-modal-out {
-    animation: kb-modal-out 140ms var(--ease-out-strong);
-    transform-origin: center;
-  }
-
-  /* Backdrop fade — opacity only, matches the content's timing on
-   * enter (200ms) and exit (140ms). Slightly weaker curve (`ease`)
-   * because opacity-only fades don't need the same punch as scale. */
-  @keyframes kb-backdrop-in {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-  }
-  .animate-kb-backdrop-in {
-    animation: kb-backdrop-in 200ms ease;
-  }
-
-  @keyframes kb-backdrop-out {
-    from {
-      opacity: 1;
-    }
-    to {
-      opacity: 0;
-    }
-  }
-  .animate-kb-backdrop-out {
-    animation: kb-backdrop-out 140ms ease;
-  }
-
-  /* Side sheet (right-docked) — slide in from the right edge.
-   * 240ms strong ease-out per Vaul's drawer timing. Origin is the
-   * right edge of the sheet because that's where it's "attached"
-   * — the emil-design-eng skill EXCEPTION to the modal-center rule. */
-  @keyframes kb-sheet-in-right {
-    from {
-      transform: translateX(100%);
-    }
-    to {
-      transform: translateX(0);
-    }
-  }
-  .animate-kb-sheet-in-right {
-    animation: kb-sheet-in-right 240ms var(--ease-out-strong);
-    transform-origin: right;
-  }
-
-  /* Side sheet exit — faster than enter (180ms vs 240ms). */
-  @keyframes kb-sheet-out-right {
-    from {
-      transform: translateX(0);
-    }
-    to {
-      transform: translateX(100%);
-    }
-  }
-  .animate-kb-sheet-out-right {
-    animation: kb-sheet-out-right 180ms var(--ease-out-strong);
-    transform-origin: right;
   }
 }

--- a/packages/kb-ui/src/tokens.css
+++ b/packages/kb-ui/src/tokens.css
@@ -282,4 +282,119 @@ html {
   .animate-kb-chip-enter {
     animation: kb-chip-enter 200ms var(--ease-out-strong);
   }
+
+  /* ─────────────────────────────────────────────────────────────
+   * Overlay motion — Phase D1 (Emil's overlays pass)
+   *
+   * Modals and side sheets share a tight motion vocabulary:
+   *  - Enter: strong ease-out, 200-240ms, transform + opacity only
+   *  - Exit:  same curve, faster (140-180ms) — exit is faster than
+   *           enter so the close feels snappy rather than draggy
+   *  - Modals scale from 0.96 (never 0) with `transform-origin: center`
+   *    because modals aren't anchored to a trigger
+   *  - Sheets slide from their edge (translateX 100%) with
+   *    `transform-origin: right` — the EXCEPTION to the modal-center
+   *    rule from the emil-design-eng skill
+   *
+   * Keyframes (not transitions) are used here for one specific
+   * reason: Radix Dialog suspends unmount via `animationend`, not
+   * `transitionend`. Transitions would unmount the content
+   * instantly on close. Keyframes are short enough (≤240ms) that
+   * mid-animation interruption is rarely visible; for the cases
+   * where it matters, `data-state` change retargets the next
+   * animation rather than snapping back to zero.
+   * ───────────────────────────────────────────────────────────── */
+
+  /* Modal content — center scale-in from 0.96 + opacity fade.
+   * 200ms strong ease-out per Emil's playbook (modals 200-500ms,
+   * staying on the snappy end keeps the UI feeling responsive). */
+  @keyframes kb-modal-in {
+    from {
+      opacity: 0;
+      transform: translate(-50%, -50%) scale(0.96);
+    }
+    to {
+      opacity: 1;
+      transform: translate(-50%, -50%) scale(1);
+    }
+  }
+  .animate-kb-modal-in {
+    animation: kb-modal-in 200ms var(--ease-out-strong);
+    transform-origin: center;
+  }
+
+  /* Modal content — exit. Faster than enter (140ms vs 200ms) so
+   * close feels snappy. Same scale curve in reverse. */
+  @keyframes kb-modal-out {
+    from {
+      opacity: 1;
+      transform: translate(-50%, -50%) scale(1);
+    }
+    to {
+      opacity: 0;
+      transform: translate(-50%, -50%) scale(0.96);
+    }
+  }
+  .animate-kb-modal-out {
+    animation: kb-modal-out 140ms var(--ease-out-strong);
+    transform-origin: center;
+  }
+
+  /* Backdrop fade — opacity only, matches the content's timing on
+   * enter (200ms) and exit (140ms). Slightly weaker curve (`ease`)
+   * because opacity-only fades don't need the same punch as scale. */
+  @keyframes kb-backdrop-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  .animate-kb-backdrop-in {
+    animation: kb-backdrop-in 200ms ease;
+  }
+
+  @keyframes kb-backdrop-out {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
+  }
+  .animate-kb-backdrop-out {
+    animation: kb-backdrop-out 140ms ease;
+  }
+
+  /* Side sheet (right-docked) — slide in from the right edge.
+   * 240ms strong ease-out per Vaul's drawer timing. Origin is the
+   * right edge of the sheet because that's where it's "attached"
+   * — the emil-design-eng skill EXCEPTION to the modal-center rule. */
+  @keyframes kb-sheet-in-right {
+    from {
+      transform: translateX(100%);
+    }
+    to {
+      transform: translateX(0);
+    }
+  }
+  .animate-kb-sheet-in-right {
+    animation: kb-sheet-in-right 240ms var(--ease-out-strong);
+    transform-origin: right;
+  }
+
+  /* Side sheet exit — faster than enter (180ms vs 240ms). */
+  @keyframes kb-sheet-out-right {
+    from {
+      transform: translateX(0);
+    }
+    to {
+      transform: translateX(100%);
+    }
+  }
+  .animate-kb-sheet-out-right {
+    animation: kb-sheet-out-right 180ms var(--ease-out-strong);
+    transform-origin: right;
+  }
 }


### PR DESCRIPTION
## Summary

Phase D1 — motion pass on the four kb-ui overlay surfaces (Modal, NewCategoryModal, SideSheet, SourcesSideSheet), following the emil-design-eng skill (authored from Emil Kowalski's playbook — same pedigree as Sonner and Vaul).

NewCategoryModal and SourcesSideSheet inherit motion from their base primitives — no per-component churn.

## Commits

| Commit | What |
| --- | --- |
| `020a4c9` | tokens: add overlay motion keyframes (modal scale + sheet slide + backdrop fade) |
| `6050b77` | Modal: scale-in + backdrop fade with strong ease-out, faster exit |
| `f3ba3bd` | SideSheet: slide-in from right + backdrop fade, faster exit (Vaul-style) |
| `9760b82` | tokens: move overlay keyframes to @theme so motion-safe + data-state variants compose |

## Motion vocabulary (from emil-design-eng skill)

| Surface | Enter | Exit | Curve | transform-origin |
| --- | --- | --- | --- | --- |
| Modal content | scale 0.96 → 1 + opacity, 200ms | scale 1 → 0.96 + opacity, 140ms | `cubic-bezier(0.23, 1, 0.32, 1)` (strong ease-out) | `center` (skill exception — modals not anchored to trigger) |
| Modal backdrop | opacity fade, 200ms | opacity fade, 140ms | `ease` | n/a |
| SideSheet content | translateX 100% → 0, 240ms | translateX 0 → 100%, 180ms | strong ease-out (Vaul timing) | n/a (translation) |
| SideSheet backdrop | opacity fade, 200ms | opacity fade, 140ms | `ease` | n/a |

Principles applied:
- Custom easing curves (no bare `ease-out`) — uses existing `--ease-out-strong` token from Phase C
- Scale-in from 0.96, never from 0 (nothing in the real world appears from nothing)
- Exit faster than enter (close feels snappy, not draggy)
- Transform + opacity only — no layout-thrashing properties
- Reduced-motion full collapse via `motion-safe:` — Radix detects no animation and unmounts immediately
- Keyframes (not transitions) because Radix Dialog suspends unmount via `animationend`, not `transitionend` — transitions would break exit entirely
- Mid-animation interruption: `data-state` flip retargets the next animation; durations ≤240ms keep interruption rare

## Tailwind v4 detail (commit 4)

Initial implementation put keyframes in `@layer utilities { .animate-kb-modal-in { ... } }`. CSS inspection of the Storybook build revealed that `motion-safe:data-[state=open]:animate-kb-modal-in` and friends were silently NOT generated by Tailwind's variant engine — `@layer utilities` only exposes bare classes.

Fix: declare animations as `--animate-*` theme variables inside `@theme`. Tailwind v4 then auto-generates the `animate-kb-*` utility AND composes it with `motion-safe:` and `data-[state=open]:`. Verified the six expected variant rules now exist in compiled CSS.

## What didn't change (intentional)

- ConfirmDialog, ShortcutsModal — compose on Modal, inherit motion automatically, no edits
- NewCategoryModal — composes on Modal, inherits motion, no edits
- SourcesSideSheet — composes on SideSheet, inherits motion, no edits
- Inline modes (Modal `inline`, SideSheet `inline`) — bypass Radix, no motion classes applied. These are used in FigmaCompare review panes where instant mount is desired
- Legacy keyframes (kb-toast-in, kb-suggestion-mount, kb-chip-enter) — only used bare (no variant prefixes), so no functional change; left in `@layer utilities`

## Verification

- `tsc` clean across `packages/kb-ui` and `apps/demo`
- `npm run --workspace=packages/kb-ui build-storybook` — built successfully
- `npm run --workspace=packages/kb-ui build` — clean (615 KB ESM)
- Live: `/welcome` and `/kb/getting-started` (NewCategoryModal via "+ New" → Folder), Storybook at `Components/Overlays/Modal` and `.../SideSheet`

## Test plan

- [ ] Open Modal in Storybook — should scale-in from 0.96 with backdrop fade
- [ ] Close Modal — should scale-out + fade in ~140ms (visibly faster than open)
- [ ] Open NewCategoryModal in demo (`/kb/getting-started` → "+ New" → Folder) — same motion as base Modal
- [ ] Open SourcesSideSheet — should slide in from right edge
- [ ] Close SourcesSideSheet — should slide out faster than it came in
- [ ] System prefers-reduced-motion ON — overlays should mount/unmount instantly with no transform animation
- [ ] Mid-animation: spam open/close — should retarget cleanly, no snap-to-zero