### PR TITLE
Phase D2: Suggestion + Rail card motion

### DIFF
--- a/packages/kb-ui/src/components/content/AIConversationLogsCard.tsx
+++ b/packages/kb-ui/src/components/content/AIConversationLogsCard.tsx
@@ -67,7 +67,12 @@ function SortDropdown({ options, value, onChange }: SortDropdownProps) {
           className={cn(
             'inline-flex items-center gap-2 rounded-[6px] bg-surface-muted px-3 py-1.5',
             'text-[14px] font-medium leading-5 text-text-primary',
-            'hover:bg-card-border',
+            // Specific properties on the transition + strong ease-out curve.
+            // Emil-style press feedback: subtle 0.97 scale on `:active`
+            // confirms the click landed. `motion-safe:` gates the scale so
+            // reduced-motion users only see the colour flip.
+            'transition-[background-color,transform] duration-[160ms] [transition-timing-function:var(--ease-out-strong)]',
+            'hover:bg-card-border motion-safe:active:scale-[0.97]',
             'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/10',
             'data-[state=open]:bg-card-border',
           )}
@@ -87,7 +92,20 @@ function SortDropdown({ options, value, onChange }: SortDropdownProps) {
           className={cn(
             'z-50 min-w-[160px] rounded-[8px] border border-card-border bg-white p-1',
             'shadow-[0_4px_6px_-1px_rgba(0,0,0,0.05),0_2px_4px_-2px_rgba(0,0,0,0.10)]',
+            // Origin-aware popover entrance — scales from the trigger.
+            // Radix exposes the computed origin as a CSS var; we set it
+            // via inline `transformOrigin` below. Opacity 0 → 1 + scale
+            // 0.96 → 1 (never scale from 0 — nothing in the real world
+            // appears from nothing). 150ms with the strong ease-out curve
+            // per Emil's framework. Uses the kb-ui-internal
+            // `kb-dropdown-in` keyframe (defined in tokens.css) which
+            // is gated by `prefers-reduced-motion: reduce` via the global
+            // `motion-safe:` mechanism at the call site.
+            'motion-safe:data-[state=open]:animate-kb-dropdown-in',
           )}
+          style={{
+            transformOrigin: 'var(--radix-dropdown-menu-content-transform-origin)',
+          }}
         >
           {options.map((opt) => (
             <DropdownMenu.Item
@@ -96,6 +114,11 @@ function SortDropdown({ options, value, onChange }: SortDropdownProps) {
               className={cn(
                 'flex cursor-pointer items-center rounded-[6px] px-2 py-1.5',
                 'text-[14px] leading-5 text-text-primary',
+                // Specific property on the highlight transition — never
+                // `transition-colors` catch-all. Quick 120ms feel for the
+                // row-by-row hover ripple as the user arrow-keys through
+                // the menu.
+                'transition-[background-color] duration-[120ms] [transition-timing-function:var(--ease-out-strong)]',
                 'data-[highlighted]:bg-surface-subtle focus:outline-none',
               )}
             >
@@ -186,12 +209,29 @@ export function AIConversationLogsCard({
                         onCheckedChange={onTicketCreatedToggle}
                         data-kb-part="ai-conversation-logs-ticket-toggle"
                         className={cn(
-                          'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors',
+                          // Specific property on the track transition (no
+                          // `transition-colors` catch-all). The strong
+                          // ease-out curve makes the state flip read as
+                          // intentional rather than a soft fade. 200ms
+                          // is the upper end of "feels responsive" for
+                          // toggles per Emil's framework.
+                          'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full',
+                          'transition-[background-color] duration-[200ms] [transition-timing-function:var(--ease-out-strong)]',
                           'data-[state=unchecked]:bg-card-border data-[state=checked]:bg-text-primary',
                           'focus:outline-none focus-visible:ring-2 focus-visible:ring-black/20',
                         )}
                       >
-                        <Switch.Thumb className="block size-4 translate-x-0.5 rounded-full bg-white shadow transition-transform data-[state=checked]:translate-x-[18px]" />
+                        <Switch.Thumb
+                          className={cn(
+                            'block size-4 translate-x-0.5 rounded-full bg-white shadow',
+                            // Thumb slide uses the same curve as the track
+                            // so the two motions land together. `motion-safe`
+                            // gates the slide; reduced-motion users still
+                            // see the position change instantly.
+                            'motion-safe:transition-transform motion-safe:duration-[200ms] [transition-timing-function:var(--ease-out-strong)]',
+                            'data-[state=checked]:translate-x-[18px]',
+                          )}
+                        />
                       </Switch.Root>
                       <span className="text-[14px] font-normal leading-5 text-text-meta">
                         Ticket Created

--- a/packages/kb-ui/src/components/content/SuggestionCard.tsx
+++ b/packages/kb-ui/src/components/content/SuggestionCard.tsx
@@ -321,8 +321,27 @@ export function SuggestionCard({
         'flex w-full flex-col gap-[12px]',
         'rounded-[12px] border border-card-border bg-white',
         'px-[20px] py-[20px]',
-        'transition-colors duration-150',
-        clickable && 'cursor-pointer hover:bg-surface-subtle',
+        // Gentle mount — opacity + 4px lift on first appear. Same keyframe
+        // family as the inline SuggestionBlock highlight (Phase C) so cards
+        // and inline highlights settle in with one consistent motion vocab.
+        // `motion-safe:` gates the transform so reduced-motion users get
+        // an instant mount.
+        'motion-safe:animate-kb-suggestion-mount',
+        // Clickable cards lift on hover and press on :active. Non-clickable
+        // cards stay static (no false affordance). Specific properties on
+        // the transition — never `transition-colors` catch-all — and the
+        // custom strong ease-out curve per Emil's framework. Press scale
+        // gated `motion-safe:` so reduced-motion users get the color flip
+        // only. Hover gated with `(hover: hover)` via Tailwind's default
+        // hover variant (it already skips touch via the underlying media
+        // query in Tailwind v4 — verified during Phase C).
+        clickable && [
+          'cursor-pointer',
+          'transition-[background-color,box-shadow,transform] duration-[160ms]',
+          '[transition-timing-function:var(--ease-out-strong)]',
+          'hover:bg-surface-subtle hover:shadow-md motion-safe:hover:-translate-y-[1px]',
+          'motion-safe:active:scale-[0.99] motion-safe:active:translate-y-0',
+        ],
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-text-primary/20',
         className,
       )}

--- a/packages/kb-ui/src/tokens.css
+++ b/packages/kb-ui/src/tokens.css
@@ -253,6 +253,21 @@ html {
   --animate-kb-sheet-in-right:  kb-sheet-in-right 240ms var(--ease-out-strong);
   --animate-kb-sheet-out-right: kb-sheet-out-right 180ms var(--ease-out-strong);
 
+  /* Origin-aware dropdown entrance (Phase D2).
+   * Used by Radix Dropdown/Popover content where the trigger's
+   * computed origin is exposed via
+   * `--radix-dropdown-menu-content-transform-origin` (or the popover
+   * equivalent). Opacity 0 → 1 + scale 0.96 → 1 — never from 0, so the
+   * menu doesn't appear out of nowhere. 150ms with the strong ease-out
+   * curve is the dropdown sweet spot per Emil's framework. Apply via
+   * `motion-safe:data-[state=open]:animate-kb-dropdown-in` so reduced-
+   * motion users see no transform.
+   *
+   * Caller must set `transform-origin: var(--radix-*-content-transform-
+   * origin)` on the same element so the scale anchors to the trigger
+   * (without it, scale-from-center looks wrong per the popover rule). */
+  --animate-kb-dropdown-in:   kb-dropdown-in 150ms var(--ease-out-strong);
+
   @keyframes kb-modal-in {
     from {
       opacity: 0;
@@ -288,6 +303,16 @@ html {
   @keyframes kb-sheet-out-right {
     from { transform: translateX(0); }
     to   { transform: translateX(100%); }
+  }
+  @keyframes kb-dropdown-in {
+    from {
+      opacity: 0;
+      transform: scale(0.96);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
   }
 
   /* Font family */


### PR DESCRIPTION
## Summary
- **SuggestionCard** — hover lift (-1px), shadow expand, `:active:scale-[0.99]` press feedback when clickable; reuses `kb-suggestion-mount` for first-paint. Non-clickable cards stay static (no false affordance). Specific properties on the transition, `--ease-out-strong` curve, `motion-safe:` gates the transform.
- **AIConversationLogsCard** — Sort dropdown gains origin-aware entrance via new `kb-dropdown-in` keyframe (opacity 0→1 + scale 0.96→1 from trigger, 150ms strong ease-out). Trigger gets `:active:scale-[0.97]` press feedback. Switch track + thumb share the strong ease-out curve at 200ms.
- **tokens.css** — Additive `--animate-kb-dropdown-in` token + `kb-dropdown-in` keyframe. Token registered in `@theme` so Tailwind v4 composes with `motion-safe:` and `data-[state=open]:` variants.

## What was skipped + why
- **AIConversationLogEntry rows** — pure presentation, no expand/collapse, not clickable. Per skill: "If the purpose is just 'it looks cool' and the user will see it often, don't animate."
- **Card-list mount stagger** — entries can re-paint as new conversations land; stagger on every re-render would feel sluggish. Skipped.

## Test plan
- [x] tsc clean (`npx tsc --noEmit -p packages/kb-ui`)
- [x] Storybook smoke-boot passes (`npm run --workspace=packages/kb-ui build-storybook`)
- [x] Dev server returns 200 on `/welcome`
- [x] Reduce-motion gated on all transforms

## Storybook URLs (run `npm run --workspace=packages/kb-ui storybook`)
- SuggestionCard — http://localhost:6006/?path=/story/content-suggestioncard--default
- AIConversationLogsCard — http://localhost:6006/?path=/story/content-aiconversationlogscard--default

🤖 Generated with [Claude Code](https://claude.com/claude-code)