### PR TITLE
Phase D3: Demo motion (Toast / ProgressBar / EmptyStates / UnsavedGuard)

### DIFF
--- a/apps/demo/src/components/EmptyStateVariants.tsx
+++ b/apps/demo/src/components/EmptyStateVariants.tsx
@@ -10,7 +10,7 @@
 // unused — the page-header "+ New article" remains the only
 // blank-start entrypoint.
 
-import type { ComponentType, SVGProps } from 'react';
+import type { ComponentType, CSSProperties, SVGProps } from 'react';
 import {
   BookOpen01,
   FileShield02,
@@ -33,6 +33,14 @@ type TemplateCardProps = {
   containerClass: string;
   iconClass: string;
   onClick: () => void;
+  /**
+   * Mount delay in ms, fed to the CSS `--kb-empty-card-delay` variable
+   * to produce a staggered entrance across the 2×2 grid. Stagger feels
+   * natural; everything-at-once feels cheap (Emil's framework). Kept
+   * under 80ms-per-card so the cascade stays under 300ms total — never
+   * blocks interaction.
+   */
+  mountDelayMs: number;
 };
 
 function TemplateCard({
@@ -42,12 +50,20 @@ function TemplateCard({
   containerClass,
   iconClass,
   onClick,
+  mountDelayMs,
 }: TemplateCardProps) {
+  // Per-card delay flows through a CSS var so the shared utility class
+  // can drive the stagger without per-card style sheets.
+  const style = {
+    '--kb-empty-card-delay': `${mountDelayMs}ms`,
+  } as CSSProperties;
+
   return (
     <button
       type="button"
       onClick={onClick}
-      className="group flex cursor-pointer flex-col rounded-[12px] border border-[#e2e8f0] bg-white p-5 text-left transition-all hover:-translate-y-[1px] hover:border-[#cbd5e1] hover:shadow-sm"
+      style={style}
+      className={cardClass}
     >
       <div
         className={`flex h-10 w-10 items-center justify-center rounded-full ${containerClass}`}
@@ -63,6 +79,21 @@ function TemplateCard({
     </button>
   );
 }
+
+// Card class extracted so the `transition-all` → `transition-[transform,box-shadow,border-color]`
+// swap and the mount-animation class live in one place. We narrow the
+// transition properties because `transition-all` would also animate the
+// mount-translate, fighting the keyframe (Emil's checklist: "Specify
+// exact properties; avoid transition: all"). The active:scale press
+// gives buttons a snappy "heard you" feel.
+const cardClass = [
+  'group flex cursor-pointer flex-col rounded-[12px] border border-[#e2e8f0]',
+  'bg-white p-5 text-left',
+  'transition-[transform,box-shadow,border-color] duration-200 ease-out',
+  'hover:-translate-y-[1px] hover:border-[#cbd5e1] hover:shadow-sm',
+  'active:scale-[0.99] active:transition-none',
+  'animate-kb-empty-card-mount',
+].join(' ');
 
 export function EmptyStateGallery({
   onCreate: _onCreate,
@@ -89,7 +120,10 @@ export function EmptyStateGallery({
           the structure.
         </p>
 
-        {/* 2×2 template grid */}
+        {/* 2×2 template grid.
+         * Stagger delays are 0/60/120/180ms — under 80ms-per-card per
+         * Emil's stagger guidance, total cascade ≈300ms. Reading order
+         * is left-to-right, top-to-bottom (matches users' eye path). */}
         <div className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2">
           <TemplateCard
             Icon={BookOpen01}
@@ -98,6 +132,7 @@ export function EmptyStateGallery({
             containerClass="bg-sky-50 border border-sky-100"
             iconClass="text-sky-600"
             onClick={() => console.log('template:step-by-step-guide')}
+            mountDelayMs={0}
           />
           <TemplateCard
             Icon={MessageQuestionCircle}
@@ -106,6 +141,7 @@ export function EmptyStateGallery({
             containerClass="bg-violet-50 border border-violet-100"
             iconClass="text-violet-600"
             onClick={() => console.log('template:faq-collection')}
+            mountDelayMs={60}
           />
           <TemplateCard
             Icon={FileShield02}
@@ -114,6 +150,7 @@ export function EmptyStateGallery({
             containerClass="bg-emerald-50 border border-emerald-100"
             iconClass="text-emerald-600"
             onClick={() => console.log('template:policy-overview')}
+            mountDelayMs={120}
           />
           <TemplateCard
             Icon={Tool01}
@@ -122,6 +159,7 @@ export function EmptyStateGallery({
             containerClass="bg-amber-50 border border-amber-100"
             iconClass="text-amber-600"
             onClick={() => console.log('template:troubleshooting')}
+            mountDelayMs={180}
           />
         </div>
 

--- a/apps/demo/src/components/PageProgressBar.tsx
+++ b/apps/demo/src/components/PageProgressBar.tsx
@@ -4,6 +4,22 @@
 // Renders a 2px bar at the very top of the content slot with a
 // 30%-wide accent band that slides left → right in a loop. Replaces
 // the ad-hoc `h-1 animate-pulse` placeholder used in Phase 7.5.3.
+//
+// Phase D3 — motion pass:
+//   - Slide period eased from 1.1s → 1.4s. Reads as "working" rather
+//     than "panicking" without losing the indeterminate feel. Still
+//     linear (per Emil's framework: constant motion uses linear; ease
+//     curves would make each cycle look like it's accelerating and
+//     decelerating, which is wrong for a true loading indicator).
+//   - Track + band fade in over 180ms on mount via
+//     `animate-kb-progress-bar-mount` so the bar doesn't pop into
+//     existence at full opacity. Suspense mounts/unmounts this on
+//     every chunk load, and a sharp pop reads as a layout glitch.
+//   - prefers-reduced-motion: the slide animation is killed (band
+//     fills the full width at reduced opacity) but the bar remains
+//     visible — loading indication is functional, not decorative.
+//     Mount fade is also disabled to avoid the bar visibly fading in
+//     on every transition.
 
 export function PageProgressBar() {
   return (
@@ -12,7 +28,7 @@ export function PageProgressBar() {
       aria-label="Loading"
       aria-busy="true"
       data-kb-part="page-progress-bar"
-      className="relative h-[2px] w-full overflow-hidden bg-surface-muted"
+      className="relative h-[2px] w-full overflow-hidden bg-surface-muted animate-kb-progress-bar-mount"
     >
       <div
         className="absolute top-0 h-full w-[30%] bg-text-primary animate-progress-slide"

--- a/apps/demo/src/components/Toast.tsx
+++ b/apps/demo/src/components/Toast.tsx
@@ -1,4 +1,5 @@
 // Phase 7.5.8 — Single-instance toast notification.
+// Phase D3 — Emil's motion pass.
 //
 // Spec (PRD §12.1 + TRD §8.1):
 //   - One toast at a time. Calling `showToast` while one is on screen
@@ -11,7 +12,28 @@
 //       info    → gray   left border + i icon,   3s autohide
 //   - Hovering pauses the autohide timer (the toast stays until the
 //     pointer leaves OR the user clicks the × button).
-//   - Subtle entrance: fade-in + 8px slide from above (~200ms).
+//
+// Phase D3 motion vocabulary (Emil-flavored):
+//   - Enter: 240ms strong ease-out, opacity + translateY(-12→0) + scale
+//     0.97→1. Never from scale(0) — "nothing in the real world appears
+//     from nothing." Top-anchored slide matches the toast's fixed
+//     position so it reads as "coming in from the edge it lives at."
+//   - Exit:  160ms strong ease-out, opacity + translateY(0→-8) + scale
+//     1→0.98. Exit beats enter; close should feel snappy, not draggy
+//     (skill checklist: "Make exit faster than enter").
+//   - A countdown bar at the bottom visualizes the remaining autohide
+//     time. Linear timing because it's a true progress indicator. The
+//     bar's `animationPlayState` flips to `paused` on hover, perfectly
+//     mirroring the timer-pause behavior we already had.
+//   - prefers-reduced-motion: opacity-only enter/exit, countdown bar
+//     hidden. Auto-dismiss still works; we just strip the motion sugar.
+//
+// Exit-motion implementation: a small `closing` flag flips the
+// animation class for 160ms before the toast actually unmounts. This
+// keeps the public API unchanged — callers still call `showToast` /
+// `dismissToast`, and replacements ("show another toast while one is
+// up") still work because each call assigns a fresh id (keying React
+// to a new instance).
 //
 // API:
 //   const { showToast, dismissToast } = useToast();
@@ -27,6 +49,7 @@ import {
   useEffect,
   useRef,
   useState,
+  type CSSProperties,
   type ReactNode,
 } from 'react';
 import {
@@ -62,39 +85,68 @@ const AUTOHIDE_MS: Record<ToastVariant, number> = {
   error: 5000,
 };
 
+// Must match the duration of `.animate-kb-toast-exit` in tokens.css.
+// Kept as a constant so the provider unmounts the toast at the moment
+// the exit animation finishes — no flash, no premature snap.
+const EXIT_DURATION_MS = 160;
+
 /* ─────────────────────────────────────────────────────────────
  * Provider
  * ───────────────────────────────────────────────────────────── */
 
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toast, setToast] = useState<Toast | null>(null);
-  const timerRef = useRef<number | null>(null);
+  const [closing, setClosing] = useState(false);
+  const autoHideTimerRef = useRef<number | null>(null);
+  const exitTimerRef = useRef<number | null>(null);
   // `pausedRef` lets us skip auto-dismiss while the user is hovering;
-  // the timer fires but we ignore it and re-arm a fresh one on leave.
+  // we drop the pending timer entirely on enter and re-arm it on leave.
   const pausedRef = useRef(false);
 
-  const clearTimer = useCallback(() => {
-    if (timerRef.current !== null) {
-      window.clearTimeout(timerRef.current);
-      timerRef.current = null;
+  const clearAutoHide = useCallback(() => {
+    if (autoHideTimerRef.current !== null) {
+      window.clearTimeout(autoHideTimerRef.current);
+      autoHideTimerRef.current = null;
     }
   }, []);
 
+  const clearExit = useCallback(() => {
+    if (exitTimerRef.current !== null) {
+      window.clearTimeout(exitTimerRef.current);
+      exitTimerRef.current = null;
+    }
+  }, []);
+
+  // Begin the exit animation, then unmount once it finishes.
+  const beginExit = useCallback(() => {
+    clearAutoHide();
+    setClosing(true);
+    clearExit();
+    exitTimerRef.current = window.setTimeout(() => {
+      setToast(null);
+      setClosing(false);
+      exitTimerRef.current = null;
+    }, EXIT_DURATION_MS);
+  }, [clearAutoHide, clearExit]);
+
   const armTimer = useCallback(
     (variant: ToastVariant) => {
-      clearTimer();
-      timerRef.current = window.setTimeout(() => {
+      clearAutoHide();
+      autoHideTimerRef.current = window.setTimeout(() => {
         if (pausedRef.current) return;
-        setToast(null);
-        timerRef.current = null;
+        beginExit();
       }, AUTOHIDE_MS[variant]);
     },
-    [clearTimer],
+    [clearAutoHide, beginExit],
   );
 
   const showToast = useCallback(
     (message: string, variant: ToastVariant = 'info') => {
       pausedRef.current = false;
+      // If a previous toast is currently mid-exit, cancel it so the
+      // replacement enters immediately rather than waiting 160ms.
+      clearExit();
+      setClosing(false);
       // Generate a fresh id every call so React remounts the toast div
       // and the entrance animation runs again, even when the variant
       // and message text happen to match the previous toast.
@@ -105,26 +157,31 @@ export function ToastProvider({ children }: { children: ReactNode }) {
       setToast({ id, message, variant });
       armTimer(variant);
     },
-    [armTimer],
+    [armTimer, clearExit],
   );
 
   const dismissToast = useCallback(() => {
-    clearTimer();
-    setToast(null);
-  }, [clearTimer]);
+    if (toast) beginExit();
+  }, [toast, beginExit]);
 
   const handleMouseEnter = useCallback(() => {
     pausedRef.current = true;
-    clearTimer();
-  }, [clearTimer]);
+    clearAutoHide();
+  }, [clearAutoHide]);
 
   const handleMouseLeave = useCallback(() => {
     pausedRef.current = false;
-    if (toast) armTimer(toast.variant);
-  }, [armTimer, toast]);
+    if (toast && !closing) armTimer(toast.variant);
+  }, [armTimer, toast, closing]);
 
   // Cleanup on unmount.
-  useEffect(() => clearTimer, [clearTimer]);
+  useEffect(
+    () => () => {
+      clearAutoHide();
+      clearExit();
+    },
+    [clearAutoHide, clearExit],
+  );
 
   return (
     <ToastContext.Provider value={{ showToast, dismissToast }}>
@@ -133,6 +190,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
         <ToastUI
           key={toast.id}
           toast={toast}
+          closing={closing}
           onDismiss={dismissToast}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
@@ -160,6 +218,7 @@ export function useToast(): ToastContextValue {
 
 type ToastUIProps = {
   toast: Toast;
+  closing: boolean;
   onDismiss: () => void;
   onMouseEnter: () => void;
   onMouseLeave: () => void;
@@ -167,10 +226,17 @@ type ToastUIProps = {
 
 function ToastUI({
   toast,
+  closing,
   onDismiss,
   onMouseEnter,
   onMouseLeave,
 }: ToastUIProps) {
+  // `hovered` flips the countdown bar's `animationPlayState` so the
+  // visual pause matches the timer pause already happening in the
+  // provider. We track it locally because the parent doesn't need to
+  // re-render on hover.
+  const [hovered, setHovered] = useState(false);
+
   // Variant-specific accent colors. We keep the surface white and use
   // the left border + icon color to communicate severity — matches the
   // production-grade toast pattern (Linear, Vercel) and avoids loud
@@ -185,6 +251,11 @@ function ToastUI({
     error: 'text-[#dc2626]',
     info: 'text-text-muted',
   };
+  const countdownColor: Record<ToastVariant, string> = {
+    success: 'bg-[#16a34a]',
+    error: 'bg-[#dc2626]',
+    info: 'bg-text-muted',
+  };
   const Icon =
     toast.variant === 'success'
       ? Check
@@ -192,20 +263,37 @@ function ToastUI({
         ? AlertCircle
         : InfoCircle;
 
+  // Inline CSS var feeds the countdown keyframes so success/info (3s)
+  // and error (5s) share one rule without per-variant utility classes.
+  const countdownStyle = {
+    '--toast-duration': `${AUTOHIDE_MS[toast.variant]}ms`,
+    animationPlayState: hovered ? 'paused' : 'running',
+  } as CSSProperties;
+
   return (
     <div
       role={toast.variant === 'error' ? 'alert' : 'status'}
       aria-live={toast.variant === 'error' ? 'assertive' : 'polite'}
       data-toast-variant={toast.variant}
+      data-state={closing ? 'closing' : 'open'}
       className={cn(
-        'fixed top-4 right-4 z-[100] flex items-start gap-3',
+        'fixed top-4 right-4 z-[100] flex items-start gap-3 overflow-hidden',
         'min-w-[280px] max-w-[420px] rounded-[8px] border border-card-border border-l-[3px] bg-white',
         'px-4 py-3 shadow-[0_8px_24px_rgba(15,23,42,0.10)]',
-        'animate-toast-in',
+        // Enter vs exit animation classes are mutually exclusive — both
+        // keyframes use `forwards` semantics so the end state sticks
+        // until React unmounts (no flicker between exit-end and unmount).
+        closing ? 'animate-kb-toast-exit' : 'animate-kb-toast-enter',
         variantClasses[toast.variant],
       )}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
+      onMouseEnter={() => {
+        setHovered(true);
+        onMouseEnter();
+      }}
+      onMouseLeave={() => {
+        setHovered(false);
+        onMouseLeave();
+      }}
     >
       <Icon
         aria-hidden="true"
@@ -220,12 +308,31 @@ function ToastUI({
         aria-label="Dismiss notification"
         className={cn(
           'shrink-0 rounded-[4px] p-0.5 text-text-muted',
+          'transition-colors duration-150',
           'hover:bg-surface-muted hover:text-text-primary',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20',
+          // Snappy :active scale per Emil — buttons must feel responsive.
+          'active:scale-[0.94] active:transition-none',
         )}
       >
         <XClose aria-hidden="true" className="h-3.5 w-3.5" />
       </button>
+
+      {/* Autohide countdown bar. Render only when not closing so it
+       * doesn't visually compete with the exit motion. Aria-hidden
+       * because the role=status announcement covers urgency cues. */}
+      {!closing && (
+        <span
+          aria-hidden="true"
+          className={cn(
+            'pointer-events-none absolute bottom-0 left-0 h-[2px] w-full origin-left',
+            'animate-kb-toast-countdown',
+            countdownColor[toast.variant],
+            'opacity-40',
+          )}
+          style={countdownStyle}
+        />
+      )}
     </div>
   );
 }

--- a/apps/demo/src/tokens.css
+++ b/apps/demo/src/tokens.css
@@ -25,25 +25,98 @@
  * Toast entrance animation + the indeterminate progress slide here.
  * Both are scoped to `@layer utilities` so they sit alongside the
  * generated atomic classes and stay JIT-tree-shakeable.
+ *
+ * Phase D3 (motion pass): toast motion vocabulary expanded to support
+ * exit + reduced-motion variants; progress bar gets a gentle fade-in
+ * so it doesn't pop; empty-state template cards get staggered mount.
  * ───────────────────────────────────────────────────────────── */
 
 @layer utilities {
-  /* Toast entrance — fade-in + 8px slide from above (~200ms) */
-  @keyframes kb-toast-in {
+  /* Toast enter — slide-down from above + opacity, anchored to top-right.
+   * Starts from translateY(-12px) scale(0.97) (never from scale(0); per
+   * Emil's "nothing in the real world appears from nothing"). Uses the
+   * strong ease-out curve from kb-ui tokens for an intentional feel. */
+  @keyframes kb-toast-enter {
     from {
       opacity: 0;
-      transform: translateY(-8px);
+      transform: translateY(-12px) scale(0.97);
     }
     to {
       opacity: 1;
-      transform: translateY(0);
+      transform: translateY(0) scale(1);
     }
   }
-  .animate-toast-in {
-    animation: kb-toast-in 200ms ease-out;
+  .animate-kb-toast-enter {
+    animation: kb-toast-enter 240ms var(--ease-out-strong);
   }
 
-  /* Indeterminate progress bar — slides a 30%-wide band L → R in a loop. */
+  /* Toast exit — exit beats enter so close feels snappy rather than
+   * draggy. Reverses to translateY(-8px) (slightly less travel than
+   * enter; the toast is acknowledging dismissal, not retreating). */
+  @keyframes kb-toast-exit {
+    from {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+    to {
+      opacity: 0;
+      transform: translateY(-8px) scale(0.98);
+    }
+  }
+  .animate-kb-toast-exit {
+    animation: kb-toast-exit 160ms var(--ease-out-strong) forwards;
+  }
+
+  /* Reduced-motion variants — opacity only, no transform.
+   * Motion sickness fix: remove the slide, keep the fade so the user
+   * still gets the state-change cue. */
+  @media (prefers-reduced-motion: reduce) {
+    .animate-kb-toast-enter {
+      animation: kb-toast-enter-reduced 180ms ease-out;
+    }
+    .animate-kb-toast-exit {
+      animation: kb-toast-exit-reduced 120ms ease-out forwards;
+    }
+  }
+  @keyframes kb-toast-enter-reduced {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+  @keyframes kb-toast-exit-reduced {
+    from { opacity: 1; }
+    to   { opacity: 0; }
+  }
+
+  /* Toast auto-dismiss timer indicator — countdown bar at the bottom
+   * of the toast. CSS animation drives the width from 100% → 0 over
+   * the toast's visible lifetime. We expose the duration via a CSS
+   * custom property `--toast-duration` set inline so success (3s),
+   * info (3s), and error (5s) all share one rule. The animation is
+   * paused on hover via `[data-paused] &` so the visual matches the
+   * timer pause behavior already implemented in Toast.tsx. */
+  @keyframes kb-toast-countdown {
+    from { transform: scaleX(1); }
+    to   { transform: scaleX(0); }
+  }
+  .animate-kb-toast-countdown {
+    animation: kb-toast-countdown var(--toast-duration, 3000ms) linear forwards;
+    transform-origin: left center;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    /* Don't run a constantly-shrinking bar for motion-sensitive users.
+     * The toast still auto-dismisses; we just hide the visualization. */
+    .animate-kb-toast-countdown {
+      animation: none;
+      opacity: 0;
+    }
+  }
+
+  /* Indeterminate progress bar — slides a 30%-wide band L → R in a loop.
+   * Linear timing because constant motion (per Emil's framework: linear
+   * is correct for spinners/marquees/indeterminate progress; ease would
+   * make the band look like it's accelerating/decelerating each cycle).
+   * 1.4s feels less frantic than the legacy 1.1s and reads as "working"
+   * rather than "panicking". */
   @keyframes kb-progress-slide {
     0% {
       left: -30%;
@@ -53,7 +126,62 @@
     }
   }
   .animate-progress-slide {
-    animation: kb-progress-slide 1.1s linear infinite;
+    animation: kb-progress-slide 1.4s linear infinite;
+  }
+
+  /* Progress bar mount — gentle fade-in so the bar doesn't pop into
+   * existence at full opacity. 180ms is short enough that we still
+   * communicate "loading" instantly but the appearance feels intentional. */
+  @keyframes kb-progress-bar-mount {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+  .animate-kb-progress-bar-mount {
+    animation: kb-progress-bar-mount 180ms ease-out;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    /* Keep the bar visible (it's a functional loading indicator) but
+     * stop the indeterminate slide — the bar's presence alone signals
+     * loading; motion is decorative here, not required. */
+    .animate-progress-slide {
+      animation: none;
+      left: 0;
+      width: 100%;
+      opacity: 0.5;
+    }
+    .animate-kb-progress-bar-mount {
+      animation: none;
+    }
+  }
+
+  /* Empty-state template card mount — staggered fade + 6px lift.
+   * Each card uses the same keyframe but its `animation-delay` is set
+   * inline via a CSS custom property so the cascade is data-driven
+   * (per Emil: stagger reads as natural; everything-at-once feels
+   * cheap). Custom strong ease-out curve. */
+  @keyframes kb-empty-card-mount {
+    from {
+      opacity: 0;
+      transform: translateY(6px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  .animate-kb-empty-card-mount {
+    animation: kb-empty-card-mount 320ms var(--ease-out-strong) both;
+    animation-delay: var(--kb-empty-card-delay, 0ms);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .animate-kb-empty-card-mount {
+      animation: kb-empty-card-mount-reduced 200ms ease-out both;
+      animation-delay: 0ms;
+    }
+  }
+  @keyframes kb-empty-card-mount-reduced {
+    from { opacity: 0; }
+    to   { opacity: 1; }
   }
 
   /* Suppress the stray focus outline on programmatically-focused


### PR DESCRIPTION
## Summary

Demo-only motion pass for the four DEMO components flagged for Phase D3. No `kb-ui` changes. All Emil Kowalski's motion principles applied (skill loaded).

| Component | Status | What changed |
| --- | --- | --- |
| `Toast.tsx` | Upgraded | Enter 240ms strong ease-out (opacity + translateY(-12→0) + scale 0.97→1, never from 0); **exit 160ms** (exit beats enter); countdown bar at bottom; press feedback on dismiss; reduced-motion = opacity only |
| `PageProgressBar.tsx` | Upgraded | 1.1s → 1.4s slide (less frantic, still linear because constant motion); 180ms fade-in on mount; reduced-motion stops the slide but keeps the bar visible |
| `EmptyStateVariants.tsx` | Upgraded | Staggered template-card mount (0/60/120/180ms); narrowed `transition-all` → exact properties; active press feedback; reduced-motion synchronous fade |
| `useUnsavedChangesGuard.tsx` | **Skipped** — already covered | Uses kb-ui `ConfirmDialog` → `Modal`, both of which got the motion treatment in D1 (PR #104). No file change needed |

## Motion vocabulary added to `apps/demo/src/tokens.css`

- `animate-kb-toast-enter` / `animate-kb-toast-exit` (with reduced-motion variants)
- `animate-kb-toast-countdown` (drives the autohide bar; duration via `--toast-duration` CSS var)
- `animate-kb-progress-bar-mount` (gentle fade-in on Suspense mount)
- `animate-kb-empty-card-mount` (per-card stagger via `--kb-empty-card-delay` CSS var)

All keyframes scoped to `@layer utilities` and reach for the existing `--ease-out-strong` curve from `kb-ui` tokens (no new ease curves invented).

## Test plan

- [ ] Trigger a Toast — save an article on `/articles/:slug/edit`, watch the success toast slide down + countdown bar drain. Hover to pause both timer + bar; leave to resume.
- [ ] Trigger Toast variants — `error` (5s) on draft-discard with no draft; `info` (3s) on coming-soon menu items
- [ ] Toast exit — wait for autohide OR click dismiss × button; watch the snappy 160ms exit (faster than the 240ms enter)
- [ ] PageProgressBar — hard-refresh any route to see the Suspense fallback bar fade in and slide
- [ ] EmptyStateGallery — navigate to an empty category (e.g. `/kb/category/new-category-id`) to see the staggered card mount
- [ ] UnsavedGuard — start typing on `/articles/:slug/edit`, then click another rail item; the confirm dialog should mount with the D1 modal motion (no D3 change here)
- [ ] System Preferences > Accessibility > Reduce Motion enabled — all motions degrade to fades; no transforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)