### PR TITLE
feat(kb-ui): Tabs / Switch / Skeleton / CodeChip primitives (chunk 1/5 of SEO panel)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1572,6 +1572,36 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-tooltip": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
@@ -8110,6 +8140,7 @@
         "@radix-ui/react-select": "^2.1.0",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-switch": "^1.2.6",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.1.0",
         "@tiptap/extension-code-block-lowlight": "^3.22.4",
         "@tiptap/extension-highlight": "^3.22.4",

--- a/packages/kb-ui/package.json
+++ b/packages/kb-ui/package.json
@@ -82,6 +82,7 @@
     "@radix-ui/react-select": "^2.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-switch": "^1.2.6",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.1.0",
     "@tiptap/extension-code-block-lowlight": "^3.22.4",
     "@tiptap/extension-highlight": "^3.22.4",

--- a/packages/kb-ui/src/components/primitives/CodeChip.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/CodeChip.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../tokens.css';
+import { CodeChip } from './CodeChip';
+
+const meta: Meta<typeof CodeChip> = {
+  title: 'Components/Primitives/CodeChip',
+  component: CodeChip,
+  parameters: { layout: 'padded' },
+  globals: { backgrounds: { value: 'white' } },
+};
+export default meta;
+
+function CodeChipPlayground() {
+  return (
+    <div className="flex flex-col gap-6 font-sans" style={{ maxWidth: 420 }}>
+      <h2 className="text-[16px] font-semibold leading-6 text-text-primary">CodeChip</h2>
+
+      <section className="flex flex-col gap-2">
+        <p className="text-[12px] font-medium uppercase tracking-wide text-text-muted">
+          Inline in body text (SEO helper)
+        </p>
+        <p className="text-[14px] leading-5 text-text-muted">
+          When enabled this article will include <CodeChip>noindex</CodeChip>{' '}
+          and <CodeChip>nofollow</CodeChip> meta tags.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <p className="text-[12px] font-medium uppercase tracking-wide text-text-muted">
+          Standalone
+        </p>
+        <div className="flex gap-2">
+          <CodeChip>noindex</CodeChip>
+          <CodeChip>nofollow</CodeChip>
+          <CodeChip>robots</CodeChip>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export const Playground: StoryObj<typeof CodeChip> = {
+  render: () => <CodeChipPlayground />,
+};

--- a/packages/kb-ui/src/components/primitives/CodeChip.tsx
+++ b/packages/kb-ui/src/components/primitives/CodeChip.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { cn } from '../../utils/cn';
+
+/* ─────────────────────────────────────────────────────────────
+ * CodeChip — inline monospace pill. Used by the SEO panel's
+ * "Exclude from search engines" helper text to render the
+ * `noindex` / `nofollow` meta-tag names inline (Figma 2949:7970,
+ * 2949:7972).
+ *
+ * Sizing extracted from Figma:
+ *   bg:       #f7f7f7 (background/accents/gray/faint).
+ *             The closest kb-ui token is --color-surface-muted
+ *             (#f1f5f9) — within a 6-channel delta, basically
+ *             indistinguishable on white. We use surface-muted so
+ *             the chip stays in the token system; if pixel-strict
+ *             matching is needed later we can promote #f7f7f7 to
+ *             a named token.
+ *   text:     #0f172a (text-primary) — NOT muted; the chip itself
+ *             reads as a literal value, not metadata.
+ *   font:     13px medium, monospace (`font-mono`).
+ *   padding:  px 4px py 2px (Figma scale/space/sm + xs).
+ *   radius:   4px (Figma scale/radius/sm).
+ *
+ * Renders inline via `inline-flex items-center` so the chip flows
+ * with body text without forcing a line break. Static — no motion.
+ * ───────────────────────────────────────────────────────────── */
+
+export type CodeChipProps = React.HTMLAttributes<HTMLSpanElement>;
+
+export const CodeChip = React.forwardRef<HTMLSpanElement, CodeChipProps>(
+  ({ className, children, ...rest }, ref) => {
+    return (
+      <span
+        ref={ref}
+        className={cn(
+          'inline-flex items-center justify-center rounded-[4px] bg-surface-muted',
+          'px-1 py-0.5',
+          'font-mono text-[13px] font-medium leading-[19px] text-text-primary',
+          'align-baseline',
+          className,
+        )}
+        {...rest}
+      >
+        {children}
+      </span>
+    );
+  },
+);
+CodeChip.displayName = 'CodeChip';

--- a/packages/kb-ui/src/components/primitives/Skeleton.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Skeleton.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../tokens.css';
+import { Skeleton } from './Skeleton';
+
+const meta: Meta<typeof Skeleton> = {
+  title: 'Components/Primitives/Skeleton',
+  component: Skeleton,
+  parameters: { layout: 'padded' },
+  globals: { backgrounds: { value: 'white' } },
+};
+export default meta;
+
+function SkeletonPlayground() {
+  return (
+    <div className="flex flex-col gap-6 font-sans" style={{ maxWidth: 360 }}>
+      <h2 className="text-[16px] font-semibold leading-6 text-text-primary">Skeleton</h2>
+
+      <section className="flex flex-col gap-2">
+        <p className="text-[12px] font-medium uppercase tracking-wide text-text-muted">
+          Single bar (fills parent)
+        </p>
+        <Skeleton />
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <p className="text-[12px] font-medium uppercase tracking-wide text-text-muted">
+          Explicit size — 45% wide, 16px tall, pill ends
+        </p>
+        <Skeleton width="45%" height={16} radius={999} />
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <p className="text-[12px] font-medium uppercase tracking-wide text-text-muted">
+          Multi-row — 2 rows, 100% / 45%, 12px gap
+        </p>
+        <Skeleton rows={2} widths={['100%', '45%']} gap={12} height={12} />
+      </section>
+    </div>
+  );
+}
+
+export const Playground: StoryObj<typeof Skeleton> = {
+  render: () => <SkeletonPlayground />,
+};

--- a/packages/kb-ui/src/components/primitives/Skeleton.tsx
+++ b/packages/kb-ui/src/components/primitives/Skeleton.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react';
+import { cn } from '../../utils/cn';
+
+/* ─────────────────────────────────────────────────────────────
+ * Skeleton — shimmer placeholder. Used by the SEO panel's
+ * "Refine with AI" loading state on the description field
+ * (Figma 2949:8108).
+ *
+ * Single-bar usage:
+ *   <Skeleton />                              // fills parent
+ *   <Skeleton width="45%" height={16} />      // explicit dims
+ *   <Skeleton radius={999} />                 // pill ends
+ *
+ * Multi-row usage:
+ *   <Skeleton rows={2} widths={['100%','45%']} gap={12} />
+ *
+ * Motion: gradient sweep left-to-right via a pseudo-element
+ * `::after` overlay. The base fill is slate-100 (surface-muted)
+ * with a white-via-transparent gradient that translates from
+ * -100% → 100% over 1.6s linear infinite. `motion-safe:` gates
+ * the overlay so reduced-motion users see a flat fill.
+ *
+ * Keyframe `kb-skeleton-shimmer` is defined in tokens.css and
+ * the Tailwind v4 utility `animate-kb-skeleton-shimmer` is
+ * auto-generated from the `--animate-*` token there.
+ * ───────────────────────────────────────────────────────────── */
+
+type Size = number | string;
+
+export type SkeletonProps = Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> & {
+  /** Explicit width — defaults to fill parent. */
+  width?: Size;
+  /** Explicit height — defaults to 12px. */
+  height?: Size;
+  /** Border radius. Default 4px; pass 999 for pill ends. */
+  radius?: Size;
+  /** Multi-row mode — number of rows. */
+  rows?: number;
+  /** Width per row (used with `rows`). Last row defaults to 45% if shorter array. */
+  widths?: Array<Size>;
+  /** Gap between rows in px when `rows` is set. */
+  gap?: number;
+};
+
+function sizeToCss(v: Size | undefined): string | undefined {
+  if (v === undefined) return undefined;
+  return typeof v === 'number' ? `${v}px` : v;
+}
+
+function SkeletonBar({
+  width,
+  height = 12,
+  radius = 999,
+  className,
+  style,
+  ...rest
+}: SkeletonProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        // Base fill — slate-100 / surface-muted. The pseudo-element
+        // shimmer overlay rides on top via ::after; we mask it with
+        // overflow-hidden so the gradient never bleeds past the bar.
+        'relative overflow-hidden bg-surface-muted',
+        // Shimmer overlay. `before:` is a wide horizontal gradient
+        // that translateX(-100% → 100%). `motion-safe:` gates the
+        // animation so reduced-motion gets a flat fill. The
+        // `content-['']` is required for the pseudo-element to render.
+        "before:content-[''] before:absolute before:inset-0 before:-translate-x-full",
+        'before:bg-gradient-to-r before:from-transparent before:via-white/60 before:to-transparent',
+        'motion-safe:before:animate-kb-skeleton-shimmer',
+        className,
+      )}
+      style={{
+        width: sizeToCss(width) ?? '100%',
+        height: sizeToCss(height),
+        borderRadius: sizeToCss(radius),
+        ...style,
+      }}
+      {...rest}
+    />
+  );
+}
+
+export function Skeleton({
+  rows,
+  widths,
+  gap = 8,
+  className,
+  style,
+  width,
+  height,
+  radius,
+  ...rest
+}: SkeletonProps) {
+  if (rows && rows > 1) {
+    return (
+      <div
+        className={cn('flex flex-col w-full', className)}
+        style={{ gap: `${gap}px`, ...style }}
+      >
+        {Array.from({ length: rows }).map((_, i) => {
+          const w = widths?.[i] ?? (i === rows - 1 ? '45%' : '100%');
+          return (
+            <SkeletonBar
+              key={i}
+              width={w}
+              height={height}
+              radius={radius}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+  return (
+    <SkeletonBar
+      width={width}
+      height={height}
+      radius={radius}
+      className={className}
+      style={style}
+      {...rest}
+    />
+  );
+}

--- a/packages/kb-ui/src/components/primitives/Switch.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Switch.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import * as React from 'react';
+import '../../tokens.css';
+import { Switch } from './Switch';
+
+const meta: Meta<typeof Switch> = {
+  title: 'Components/Primitives/Switch',
+  component: Switch,
+  parameters: { layout: 'padded' },
+  globals: { backgrounds: { value: 'white' } },
+};
+export default meta;
+
+function SwitchPlayground() {
+  const [a, setA] = React.useState(false);
+  const [b, setB] = React.useState(true);
+  return (
+    <div className="flex flex-col gap-4 font-sans" style={{ maxWidth: 360 }}>
+      <h2 className="text-[16px] font-semibold leading-6 text-text-primary">Switch</h2>
+
+      <div className="flex items-center justify-between">
+        <label htmlFor="sw-a" className="text-[13px] font-medium leading-[19px] text-text-primary">
+          Exclude from search engines
+        </label>
+        <Switch id="sw-a" checked={a} onCheckedChange={setA} />
+      </div>
+
+      <div className="flex items-center justify-between">
+        <label htmlFor="sw-b" className="text-[13px] font-medium leading-[19px] text-text-primary">
+          Default-on toggle
+        </label>
+        <Switch id="sw-b" checked={b} onCheckedChange={setB} />
+      </div>
+
+      <div className="flex items-center justify-between">
+        <label htmlFor="sw-c" className="text-[13px] font-medium leading-[19px] text-text-primary">
+          Disabled
+        </label>
+        <Switch id="sw-c" checked={false} disabled />
+      </div>
+    </div>
+  );
+}
+
+export const Playground: StoryObj<typeof Switch> = {
+  render: () => <SwitchPlayground />,
+};

--- a/packages/kb-ui/src/components/primitives/Switch.tsx
+++ b/packages/kb-ui/src/components/primitives/Switch.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import * as SwitchPrimitive from '@radix-ui/react-switch';
+import { cn } from '../../utils/cn';
+
+/* ─────────────────────────────────────────────────────────────
+ * Switch — binary toggle. Used by the SEO panel's
+ * "Exclude from search engines" row (Figma 2949:7966 off /
+ *  2949:9536 on).
+ *
+ * Built on @radix-ui/react-switch for keyboard + ARIA semantics
+ * (role="switch", aria-checked, Space/Enter toggles).
+ *
+ * Sizing (measured from Figma):
+ *  - Track: 32 × 16, fully rounded (radius 8px = half-height)
+ *  - Knob:  12 × 12, ~2px inset
+ *  - Travel: ~16px (left:2.4 → left:17.8)
+ *
+ * Colors:
+ *  - Off track: #edf1f6 (background/neutral/default in Figma).
+ *    The closest kb-ui token is --color-border-faint (#cbd5e1)
+ *    which reads too dark — we use an inline color to match.
+ *    A token sweep could later promote #edf1f6 to a named token
+ *    if more components need it.
+ *  - On track: black (--color-btn-primary)
+ *  - Knob: white
+ *
+ * Motion: 200ms bg-color + transform with the strong ease-out
+ * curve, `motion-safe`-gated. Press feedback via
+ * `motion-safe:active:scale-[0.97]` on the track, mirroring
+ * Button's :active behavior.
+ * ───────────────────────────────────────────────────────────── */
+
+export type SwitchProps = React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>;
+
+export const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitive.Root>,
+  SwitchProps
+>(({ className, disabled, ...rest }, ref) => (
+  <SwitchPrimitive.Root
+    ref={ref}
+    disabled={disabled}
+    style={{
+      transition:
+        'background-color 200ms cubic-bezier(0.23, 1, 0.32, 1), transform 120ms cubic-bezier(0.23, 1, 0.32, 1)',
+    }}
+    className={cn(
+      // Track. Figma: 32×16, rounded-full, off bg #edf1f6, on bg black.
+      'relative inline-flex h-4 w-8 shrink-0 cursor-pointer items-center rounded-full',
+      'bg-[#edf1f6] data-[state=checked]:bg-black',
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-faint focus-visible:ring-offset-1',
+      !disabled && 'motion-safe:active:scale-[0.97]',
+      disabled && 'opacity-50 cursor-not-allowed',
+      className,
+    )}
+    {...rest}
+  >
+    <SwitchPrimitive.Thumb
+      style={{
+        transition: 'transform 200ms cubic-bezier(0.23, 1, 0.32, 1)',
+      }}
+      className={cn(
+        // Knob. Figma: 12×12, white, soft shadow, sits 2px from
+        // edges. Translate to ~16px on checked (32 - 12 - 2*2 = 16).
+        'pointer-events-none block size-3 rounded-full bg-white shadow-sm',
+        'translate-x-0.5 data-[state=checked]:translate-x-[18px]',
+      )}
+    />
+  </SwitchPrimitive.Root>
+));
+Switch.displayName = 'Switch';

--- a/packages/kb-ui/src/components/primitives/Tabs.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Tabs.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import * as React from 'react';
+import '../../tokens.css';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from './Tabs';
+
+const meta: Meta<typeof Tabs> = {
+  title: 'Components/Primitives/Tabs',
+  component: Tabs,
+  parameters: { layout: 'padded' },
+  globals: { backgrounds: { value: 'white' } },
+};
+export default meta;
+
+function TabsPlayground() {
+  const [value, setValue] = React.useState('seo');
+  return (
+    <div className="flex flex-col gap-4 font-sans" style={{ maxWidth: 360 }}>
+      <h2 className="text-[16px] font-semibold leading-6 text-text-primary">Tabs</h2>
+
+      <Tabs value={value} onValueChange={setValue}>
+        <TabsList>
+          <TabsTrigger value="general">General</TabsTrigger>
+          <TabsTrigger value="seo">SEO</TabsTrigger>
+        </TabsList>
+        <TabsContent value="general">
+          <p className="text-[14px] leading-5 text-text-muted">
+            General tab content.
+          </p>
+        </TabsContent>
+        <TabsContent value="seo">
+          <p className="text-[14px] leading-5 text-text-muted">
+            SEO tab content.
+          </p>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+export const Playground: StoryObj<typeof Tabs> = {
+  render: () => <TabsPlayground />,
+};

--- a/packages/kb-ui/src/components/primitives/Tabs.tsx
+++ b/packages/kb-ui/src/components/primitives/Tabs.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import { cn } from '../../utils/cn';
+
+/* ─────────────────────────────────────────────────────────────
+ * Tabs — pill segmented switcher used by the SEO panel for the
+ * General / SEO toggle (Figma 2949:7854).
+ *
+ * Built on @radix-ui/react-tabs so a11y (keyboard nav, ARIA
+ * tablist semantics, focus management) is handled by Radix.
+ * The visual shell is a soft slate-100 (surface-muted) track
+ * with white "lifted" active trigger — radix exposes
+ * `data-state="active|inactive"` which we style against.
+ *
+ * Motion: the active trigger crossfades its bg/shadow over 150ms
+ * with the strong ease-out curve (matches Button's transition
+ * vocabulary). Transform isn't animated — Radix mounts each
+ * trigger statically, so a CSS sliding "indicator" would require
+ * a measured-rect approach that's out of scope for chunk 1.
+ * `motion-safe:` gates the transition; reduced-motion users get
+ * an instant state swap.
+ * ───────────────────────────────────────────────────────────── */
+
+export type TabsProps = React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root>;
+export type TabsListProps = React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>;
+export type TabsTriggerProps = React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>;
+export type TabsContentProps = React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>;
+
+export const Tabs = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Root>,
+  TabsProps
+>(({ className, ...rest }, ref) => (
+  <TabsPrimitive.Root
+    ref={ref}
+    className={cn('flex flex-col gap-3', className)}
+    {...rest}
+  />
+));
+Tabs.displayName = 'Tabs';
+
+export const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  TabsListProps
+>(({ className, ...rest }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      // Figma 2949:7854 — track is bg slate-100 / surface-muted,
+      // 8px radius, 2px padding, 4px gap between triggers. The
+      // list hugs its triggers (`w-fit`) so the track doesn't
+      // stretch with a wider container — flexbox parents would
+      // otherwise stretch an `inline-flex` child to full width.
+      'inline-flex w-fit items-center gap-1 rounded-[8px] bg-surface-muted p-0.5',
+      className,
+    )}
+    {...rest}
+  />
+));
+TabsList.displayName = 'TabsList';
+
+export const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  TabsTriggerProps
+>(({ className, ...rest }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    // 150ms crossfade for bg/shadow/color on active flip. Matches
+    // Button's transition timing for visual consistency. Strong
+    // ease-out curve = punchier than the default `ease`.
+    style={{
+      transition:
+        'background-color 150ms cubic-bezier(0.23, 1, 0.32, 1), box-shadow 150ms cubic-bezier(0.23, 1, 0.32, 1), color 150ms ease',
+    }}
+    className={cn(
+      // Figma: w-[109px] equal-width per trigger, h ~32px from
+      // px-12 py-6, 13px medium, radius 8px when active (matches
+      // track radius minus padding). `min-w-[101px]` (109 - 4 - 4
+      // for the list padding) lets short labels keep a balanced
+      // width while longer labels grow naturally — preferable to a
+      // hard `w-[109px]` for a reusable primitive.
+      'inline-flex h-8 min-w-[101px] items-center justify-center rounded-[8px] px-3 py-1.5',
+      'font-sans text-[13px] font-medium leading-[19px]',
+      'outline-none focus-visible:ring-2 focus-visible:ring-border-faint focus-visible:ring-offset-1',
+      'motion-safe:transition-[background-color,box-shadow,color]',
+      // Inactive: muted slate-500 text, transparent bg.
+      'text-text-muted hover:text-text-secondary',
+      // Active: white bg, primary text, subtle elevation.
+      'data-[state=active]:bg-white data-[state=active]:text-text-primary data-[state=active]:shadow-sm',
+      'disabled:opacity-50 disabled:cursor-not-allowed',
+      className,
+    )}
+    {...rest}
+  />
+));
+TabsTrigger.displayName = 'TabsTrigger';
+
+export const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  TabsContentProps
+>(({ className, ...rest }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      'outline-none focus-visible:ring-2 focus-visible:ring-border-faint focus-visible:ring-offset-1 rounded-[6px]',
+      className,
+    )}
+    {...rest}
+  />
+));
+TabsContent.displayName = 'TabsContent';

--- a/packages/kb-ui/src/components/primitives/index.ts
+++ b/packages/kb-ui/src/components/primitives/index.ts
@@ -20,3 +20,16 @@ export { TextInput } from './TextInput';
 export type { TextInputProps } from './TextInput';
 export { Dropdown } from './Dropdown';
 export type { DropdownProps } from './Dropdown';
+export { Tabs, TabsList, TabsTrigger, TabsContent } from './Tabs';
+export type {
+  TabsProps,
+  TabsListProps,
+  TabsTriggerProps,
+  TabsContentProps,
+} from './Tabs';
+export { Switch } from './Switch';
+export type { SwitchProps } from './Switch';
+export { Skeleton } from './Skeleton';
+export type { SkeletonProps } from './Skeleton';
+export { CodeChip } from './CodeChip';
+export type { CodeChipProps } from './CodeChip';

--- a/packages/kb-ui/src/tokens.css
+++ b/packages/kb-ui/src/tokens.css
@@ -268,6 +268,18 @@ html {
    * (without it, scale-from-center looks wrong per the popover rule). */
   --animate-kb-dropdown-in:   kb-dropdown-in 150ms var(--ease-out-strong);
 
+  /* Skeleton shimmer sweep (chunk 1 of SEO panel).
+   * Registered as `--animate-*` so Tailwind v4 auto-generates the
+   * `animate-kb-skeleton-shimmer` utility AND composes with the
+   * `motion-safe:` variant — same pattern as the overlay tokens
+   * above. The shimmer is applied to a pseudo-element overlay; the
+   * keyframe translates a left-to-right gradient sweep across the
+   * skeleton bar. 1.6s linear infinite is the "fast enough to feel
+   * loading, slow enough to not flicker" sweet spot per the Emil
+   * playbook. Reduced-motion users see a flat slate-100 fill
+   * (the overlay is skipped via `motion-safe:`). */
+  --animate-kb-skeleton-shimmer: kb-skeleton-shimmer 1.6s linear infinite;
+
   @keyframes kb-modal-in {
     from {
       opacity: 0;
@@ -313,6 +325,10 @@ html {
       opacity: 1;
       transform: scale(1);
     }
+  }
+  @keyframes kb-skeleton-shimmer {
+    from { transform: translateX(-100%); }
+    to   { transform: translateX(100%); }
   }
 
   /* Font family */


### PR DESCRIPTION
## Summary

Chunk 1 of 5 for the SEO panel build. Four new primitives plus Playground stories, no consumer wiring yet.

- **Tabs** — pill segmented switcher on `@radix-ui/react-tabs`. Slate-100 track, white lifted active trigger, strong ease-out crossfade.
- **Switch** — binary toggle on `@radix-ui/react-switch`. 32x16 track, 12x12 knob, off bg `#edf1f6` / on bg black, 200ms transform.
- **Skeleton** — shimmer placeholder. Single / sized / multi-row APIs. Pseudo-element gradient sweep via new `--animate-kb-skeleton-shimmer` token in `tokens.css`.
- **CodeChip** — inline mono pill for `noindex` / `nofollow` in SEO helper text. Static, no motion.

## Verification gate

- `npm run --workspace=packages/kb-ui typecheck` — 0
- `npm run --workspace=packages/kb-ui build` — 0
- `npm run --workspace=packages/kb-ui build-storybook` — 0
- All four Playground iframe URLs respond 200, render with zero console errors via Playwright.

## Test plan

- [ ] Open Storybook locally and verify Components/Primitives/{Tabs, Switch, Skeleton, CodeChip} > Playground all render
- [ ] Toggle Switch and confirm knob travel + bg color flip
- [ ] Click Tabs trigger and confirm active state crossfade
- [ ] Confirm Skeleton shimmer sweeps left-to-right