### PR TITLE
Chunk 2/5: SEO panel — General/SEO tabs + trim General to 3 fields

### DIFF
--- a/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
+++ b/apps/demo/src/routes/ai-optimise/ReviewPage.tsx
@@ -174,32 +174,13 @@ function buildPanelSettings(
 ): KbUiArticleSettings {
   const author = store.users[article.authorId];
   const category = selectCategoryById(store, article.categoryId);
-  const reviewers = article.settings.reviewerIds
-    .map((id) => store.users[id])
-    .filter(Boolean)
-    .map((u) => ({ name: u.name, initials: u.initials }));
-  const visibility =
-    article.settings.visibility === 'public' ? 'Public' : 'Internal';
   return {
     author: author
       ? { name: author.name, initials: author.initials }
       : undefined,
     category: category?.title,
     slug: article.settings.slug,
-    tags: article.settings.tags,
-    publishDate: article.settings.publishDate
-      ? formatPublishDate(article.settings.publishDate)
-      : undefined,
-    seoTitle: article.settings.seoTitle,
-    visibility,
-    reviewers,
   };
-}
-
-function formatPublishDate(iso: string): string {
-  const d = new Date(iso);
-  const month = d.toLocaleString('en-US', { month: 'short' });
-  return `${month} ${d.getUTCDate()}, ${d.getUTCFullYear()}`;
 }
 
 /* ─────────────────────────────────────────────────────────────

--- a/apps/demo/src/routes/kb/EditorPage.tsx
+++ b/apps/demo/src/routes/kb/EditorPage.tsx
@@ -37,7 +37,6 @@ import {
   ContentEditor,
   type ArticleSettings as KbUiArticleSettings,
   type ArticleSettingsPerson,
-  type ArticleVisibility as KbUiArticleVisibility,
 } from '@test-kb-ui/kb-ui';
 import { useMockStore } from '../../store/MockStoreContext';
 import {
@@ -69,34 +68,19 @@ const SAVE_DEBOUNCE_MS = 200;
 /* ─────────────────────────────────────────────────────────────
  * Adapters — store ArticleSettings ↔ kb-ui ArticleSettings
  *
- * The shapes diverge intentionally (TRD §5.1 uses domain primitives;
+ * The shapes diverge intentionally (the store uses domain primitives;
  * the kb-ui panel uses presentational types). These two functions are
  * the only place the conversion happens.
+ *
+ * Chunk 2 of the SEO panel scaffold trims the kb-ui panel down to the
+ * General tab (author + category + slug). Tags/publishDate/seoTitle/
+ * visibility/reviewers are no longer surfaced on the kb-ui side — chunk
+ * 3 will reintroduce the SEO-relevant fields on the SEO tab.
  * ───────────────────────────────────────────────────────────── */
-
-function toKbVisibility(v: StoreArticleSettings['visibility']): KbUiArticleVisibility {
-  return v === 'public' ? 'Public' : 'Internal';
-}
-
-function fromKbVisibility(v?: KbUiArticleVisibility): StoreArticleSettings['visibility'] {
-  // 'Draft' has no analogue in the store's `'public' | 'private'` axis;
-  // treat it as private (the closest "not yet visible to readers" value).
-  return v === 'Public' ? 'public' : 'private';
-}
 
 function toPerson(user: User | undefined): ArticleSettingsPerson | undefined {
   if (!user) return undefined;
   return { name: user.name, initials: user.initials };
-}
-
-function findUserByPerson(
-  users: Record<string, User>,
-  person: ArticleSettingsPerson | undefined,
-): User | undefined {
-  if (!person) return undefined;
-  return Object.values(users).find(
-    (u) => u.name === person.name && u.initials === person.initials,
-  );
 }
 
 function adaptStoreToKbSettings(
@@ -106,61 +90,27 @@ function adaptStoreToKbSettings(
   storeSettings: StoreArticleSettings,
 ): KbUiArticleSettings {
   const author = users[article.authorId];
-  const reviewers = storeSettings.reviewerIds
-    .map((id) => users[id])
-    .filter((u): u is User => Boolean(u))
-    .map((u) => ({ name: u.name, initials: u.initials }));
   return {
     author: toPerson(author),
     category: category?.title,
     slug: storeSettings.slug,
-    tags: storeSettings.tags,
-    publishDate: storeSettings.publishDate
-      ? formatPublishDate(storeSettings.publishDate)
-      : undefined,
-    seoTitle: storeSettings.seoTitle,
-    visibility: toKbVisibility(storeSettings.visibility),
-    reviewers,
   };
 }
 
 /**
  * Project edits made inside the kb-ui ArticleSettingsPanel back into the
  * store's settings shape. Only the fields the panel can actually mutate
- * (slug, tags, seoTitle, visibility, reviewers) are written; author /
- * category / publishDate stay frozen — those are surfaced as read-only
- * dropdowns in v1 (per `apps/demo/_diff-report.md` settings spec).
+ * (slug, post-chunk-2) are written; author / category stay frozen —
+ * those are surfaced as read-only dropdowns in v1.
  */
 function adaptKbToStoreSettings(
   prev: StoreArticleSettings,
   next: KbUiArticleSettings,
-  users: Record<string, User>,
 ): StoreArticleSettings {
-  const reviewerIds = (next.reviewers ?? [])
-    .map((p) => findUserByPerson(users, p))
-    .filter((u): u is User => Boolean(u))
-    .map((u) => u.id);
   return {
     ...prev,
     slug: next.slug ?? prev.slug,
-    tags: next.tags ?? prev.tags,
-    seoTitle: next.seoTitle ?? prev.seoTitle,
-    visibility: next.visibility
-      ? fromKbVisibility(next.visibility)
-      : prev.visibility,
-    reviewerIds,
   };
-}
-
-function formatPublishDate(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  // "Apr 12, 2026" — matches the kb-ui panel's expected display.
-  return d.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
 }
 
 /* ─────────────────────────────────────────────────────────────
@@ -360,12 +310,10 @@ function EditorPageBody({ article }: { article: Article }) {
 
   const handleSettingsChange = useCallback(
     (next: KbUiArticleSettings) => {
-      setStoreSettings((prev) =>
-        adaptKbToStoreSettings(prev, next, state.users),
-      );
+      setStoreSettings((prev) => adaptKbToStoreSettings(prev, next));
       setDirty(true);
     },
-    [state.users],
+    [],
   );
 
   const handleSaveAsDraft = useCallback(() => {

--- a/apps/demo/src/store/fixtures/articles.ts
+++ b/apps/demo/src/store/fixtures/articles.ts
@@ -60,11 +60,7 @@ export const articles: Article[] = [
 <p>Once Hiver is loaded, you'll see the shared-inbox list under your personal labels. If the rail is missing, disable and re-enable the extension from <code>chrome://extensions</code>, then refresh Gmail. Most install issues come from a stale Gmail tab — closing every Gmail tab and re-opening one fresh resolves them.</p>`,
     settings: {
       slug: 'installing-the-hiver-chrome-extension',
-      tags: ['onboarding', 'chrome-extension'],
-      publishDate: daysAgo(2),
       seoTitle: 'How to install the Hiver Chrome extension',
-      visibility: 'public',
-      reviewerIds: ['user-mira'],
     },
   },
   {
@@ -87,11 +83,7 @@ export const articles: Article[] = [
 <p>The invitee receives an email with a one-click link that drops them straight into the Hiver onboarding flow. Once they accept, they'll appear in the agent list with a green "Online" dot the next time they open Gmail. For tips on a smooth first day, read <a href="#">Onboarding new agents</a>.</p>`,
     settings: {
       slug: 'inviting-your-first-teammate',
-      tags: ['onboarding', 'team'],
-      publishDate: null,
       seoTitle: 'How to invite your first teammate to Hiver',
-      visibility: 'public',
-      reviewerIds: ['user-aanya'],
     },
   },
   {
@@ -114,11 +106,7 @@ export const articles: Article[] = [
 <p>If the connection appears successful but no conversations sync, check your tenant's conditional access rules — Hiver's IP range needs to be allowlisted on tenants that block "third-party connectors." See <a href="#">Microsoft 365 conditional access</a> for the IP list.</p>`,
     settings: {
       slug: 'connecting-an-outlook-mailbox',
-      tags: ['outlook', 'inbox-setup'],
-      publishDate: daysAgo(3),
       seoTitle: 'Connect an Outlook mailbox to Hiver',
-      visibility: 'public',
-      reviewerIds: [],
     },
   },
   {
@@ -142,11 +130,7 @@ export const articles: Article[] = [
 <p>The first new email to that address shows up as a Hiver conversation within 30 seconds. If you don't see one within five minutes, double-check the alias is forwarding correctly. See <a href="#">Diagnosing a quiet inbox</a>.</p>`,
     settings: {
       slug: 'creating-your-first-shared-inbox',
-      tags: ['shared-inboxes', 'getting-started'],
-      publishDate: daysAgo(1),
       seoTitle: 'Create your first shared inbox in Hiver',
-      visibility: 'public',
-      reviewerIds: ['user-tarun'],
     },
   },
   {
@@ -172,11 +156,7 @@ export const articles: Article[] = [
 <p>If you don't receive the email within five minutes, the most likely cause is that your team's mail server is quarantining no-reply addresses. Ask your IT admin to allowlist <code>noreply@hiverhq.com</code>. For more help, see <a href="#">Login troubleshooting</a>.</p>`,
     settings: {
       slug: 'how-to-reset-your-password',
-      tags: ['account', 'security'],
-      publishDate: daysAgo(5),
       seoTitle: 'How to reset your Hiver password',
-      visibility: 'public',
-      reviewerIds: ['user-aanya', 'user-devika'],
     },
     aiGapsSummary:
       'Refining the article with updated instruction set, updating link and by removing legacy instructions',
@@ -201,11 +181,7 @@ export const articles: Article[] = [
 <p>Every add/remove on a restricted inbox writes an entry to the audit log under <strong>Settings → Audit log</strong>. Filter by inbox ID to review the full access history. See <a href="#">Audit log filters</a> for advanced queries.</p>`,
     settings: {
       slug: 'restricting-an-inbox-to-specific-agents',
-      tags: ['permissions', 'security'],
-      publishDate: daysAgo(6),
       seoTitle: 'Restrict a Hiver inbox to specific agents',
-      visibility: 'public',
-      reviewerIds: ['user-mira'],
     },
   },
   {
@@ -228,11 +204,7 @@ export const articles: Article[] = [
 <p>By default templates are scoped to the inbox they were created in. Move a template to the workspace-level <em>Shared</em> folder to make it available everywhere. See <a href="#">Template variables reference</a> for the full placeholder list.</p>`,
     settings: {
       slug: 'creating-a-shared-template-library',
-      tags: ['templates'],
-      publishDate: daysAgo(2),
       seoTitle: 'Build a shared template library in Hiver',
-      visibility: 'public',
-      reviewerIds: ['user-mira'],
     },
   },
   {
@@ -255,11 +227,7 @@ export const articles: Article[] = [
 <p>Round-robin works for teams where every conversation takes roughly the same time — high-volume tier-1 support is the canonical fit. Load-balanced is better when complexity varies wildly — billing or technical support tend to need it. See <a href="#">Skill-based assignment</a> to layer skills on top.</p>`,
     settings: {
       slug: 'round-robin-vs-load-balanced-assignment',
-      tags: ['auto-assignment', 'rules'],
-      publishDate: daysAgo(3),
       seoTitle: 'Round-robin vs load-balanced auto-assignment',
-      visibility: 'public',
-      reviewerIds: ['user-aanya'],
     },
   },
   {
@@ -286,11 +254,7 @@ export const articles: Article[] = [
 <p>Beyond visual customisation, the widget has behavioural toggles for proactive messages, quiet hours, and offline-mode forms. Most teams start with all toggles off and enable them as they observe their chat traffic patterns. See <a href="#">Proactive chat playbook</a> for what to try first.</p>`,
     settings: {
       slug: 'customizing-the-chat-widget',
-      tags: ['live-chat', 'widget', 'branding'],
-      publishDate: daysAgo(4),
       seoTitle: 'Customize the Hiver chat widget',
-      visibility: 'public',
-      reviewerIds: ['user-aanya'],
     },
     aiGapsSummary:
       'Adding accessibility best-practices guidance, renaming the color picker to theme selector and removing legacy iframe embed instructions',
@@ -316,11 +280,7 @@ export const articles: Article[] = [
 <p>Inbound WhatsApp messages appear as conversations in the inbox you map them to. Agents can reply through the same composer they use for email. Outbound proactive messages need a pre-approved template per Meta's policy. See <a href="#">WhatsApp message templates</a>.</p>`,
     settings: {
       slug: 'connecting-whatsapp-business-to-hiver',
-      tags: ['whatsapp', 'multi-channel'],
-      publishDate: daysAgo(5),
       seoTitle: 'Connect WhatsApp Business to Hiver',
-      visibility: 'public',
-      reviewerIds: ['user-mira'],
     },
   },
   {
@@ -343,11 +303,7 @@ export const articles: Article[] = [
 <p>Inbound SMS to the number appears as conversations in the inbox you map. Outbound SMS uses message templates with character-aware previews — Hiver tells you when a message will split into multiple SMS segments. See <a href="#">SMS character limits</a>.</p>`,
     settings: {
       slug: 'adding-sms-as-a-support-channel',
-      tags: ['sms', 'multi-channel'],
-      publishDate: daysAgo(7),
       seoTitle: 'Add SMS support to Hiver',
-      visibility: 'public',
-      reviewerIds: ['user-aanya'],
     },
   },
   {
@@ -376,11 +332,7 @@ export const articles: Article[] = [
 <p>Once saved, send a test email from outside your team to the trigger inbox. The auto-reply should arrive within a few seconds. If it doesn't, check the rule's run log — every rule has a per-run history showing why it did or didn't fire. See <a href="#">Rule run logs</a>.</p>`,
     settings: {
       slug: 'setting-up-auto-reply-rules',
-      tags: ['automations', 'rules', 'auto-reply'],
-      publishDate: daysAgo(6),
       seoTitle: 'Set up auto-reply rules in Hiver',
-      visibility: 'public',
-      reviewerIds: ['user-mira', 'user-tarun'],
     },
     aiGapsSummary:
       'Adding timezone guidance for rule schedules, clarifying the ambiguous Recent trigger and removing the deprecated sender-domain toggle',
@@ -406,11 +358,7 @@ export const articles: Article[] = [
 <p>Hiver measures from conversation arrival to first outbound agent reply. Internal notes don't count by default; flip the toggle if you want notes to stop the clock. See <a href="#">SLA measurement details</a>.</p>`,
     settings: {
       slug: 'defining-first-response-targets',
-      tags: ['sla', 'metrics'],
-      publishDate: daysAgo(2),
       seoTitle: 'Define first-response SLA targets in Hiver',
-      visibility: 'public',
-      reviewerIds: ['user-mira'],
     },
   },
   {
@@ -434,11 +382,7 @@ export const articles: Article[] = [
 <p>For severe breaches you can chain escalations — escalate to manager at breach, then to director if still unanswered after another hour. See <a href="#">Escalation chains</a> for the full pattern.</p>`,
     settings: {
       slug: 'escalating-to-a-manager-on-sla-breach',
-      tags: ['escalations', 'sla'],
-      publishDate: daysAgo(4),
       seoTitle: 'Escalate to a manager on SLA breach',
-      visibility: 'public',
-      reviewerIds: ['user-aanya'],
     },
   },
   {
@@ -461,11 +405,7 @@ export const articles: Article[] = [
 <p>The default profile is "Browser push for assigned-to-me, hourly email digest for everything else, Slack off." Most agents leave the defaults; power users tune them aggressively. See <a href="#">Notification profiles</a> for preset bundles.</p>`,
     settings: {
       slug: 'personal-notification-preferences',
-      tags: ['notifications'],
-      publishDate: daysAgo(3),
       seoTitle: 'Personal notification preferences in Hiver',
-      visibility: 'public',
-      reviewerIds: ['user-aanya'],
     },
   },
   {
@@ -489,11 +429,7 @@ export const articles: Article[] = [
 <p>Email the report to yourself or your manager on a recurring schedule — daily, weekly, monthly. PDF and CSV both supported. See <a href="#">Report scheduling</a>.</p>`,
     settings: {
       slug: 'volume-and-response-time-reports',
-      tags: ['reports'],
-      publishDate: daysAgo(1),
       seoTitle: 'Volume and response-time reports in Hiver',
-      visibility: 'public',
-      reviewerIds: ['user-mira'],
     },
   },
   {
@@ -517,11 +453,7 @@ export const articles: Article[] = [
 <p>Custom dashboards can be private (just you), team-scoped (specific roles or agents), or public to the workspace. See <a href="#">Sharing custom dashboards</a>.</p>`,
     settings: {
       slug: 'building-your-first-custom-dashboard',
-      tags: ['dashboards', 'reports'],
-      publishDate: daysAgo(6),
       seoTitle: 'Build your first custom dashboard in Hiver',
-      visibility: 'public',
-      reviewerIds: ['user-aanya'],
     },
   },
   {
@@ -550,11 +482,7 @@ export const articles: Article[] = [
 <p>Notifications are the lightweight third primitive — no triggers, no deadlines, just per-agent preferences for what events should ping them and through which channel. Most agents tune their own notifications; managers tune team-wide defaults. Use notifications when you want awareness without action — "tell me when I'm mentioned in a note" rather than "auto-assign this to me." The three primitives compose: a rule routes a conversation, an SLA times it, and a notification pings the right agent the moment either fires.</p>`,
     settings: {
       slug: 'choosing-the-right-automation-type',
-      tags: ['automations', 'overview', 'workflows'],
-      publishDate: daysAgo(3),
       seoTitle: 'When to use rules, SLAs, and notifications in Hiver',
-      visibility: 'public',
-      reviewerIds: ['user-mira'],
     },
   },
 ];

--- a/apps/demo/src/store/reducer.ts
+++ b/apps/demo/src/store/reducer.ts
@@ -267,10 +267,6 @@ export function rootReducer(
         ...article,
         status: 'published',
         lastUpdatedAt: nowIso,
-        settings: {
-          ...article.settings,
-          publishDate: article.settings.publishDate ?? nowIso,
-        },
       };
       return {
         ...state,
@@ -293,11 +289,7 @@ export function rootReducer(
         bodyHTML: '',
         settings: {
           slug: action.newSlug,
-          tags: [],
-          publishDate: null,
           seoTitle: 'Untitled article',
-          visibility: 'public',
-          reviewerIds: [],
         },
       };
       return {
@@ -375,10 +367,6 @@ export function rootReducer(
         bodyHTML: newBody,
         status: 'published',
         lastUpdatedAt: action.now,
-        settings: {
-          ...article.settings,
-          publishDate: article.settings.publishDate ?? action.now,
-        },
       };
 
       // 4. Drop the per-article reducer slot.

--- a/apps/demo/src/store/seed.ts
+++ b/apps/demo/src/store/seed.ts
@@ -89,20 +89,10 @@ function runIntegrityAsserts(state: MockStoreState): void {
     }
   }
 
-  // Reviewer ids on article settings must resolve and must NOT include
-  // the author themselves (per TRD types comment).
-  for (const a of Object.values(state.articles)) {
-    for (const rid of a.settings.reviewerIds) {
-      if (!state.users[rid]) {
-        errors.push(`article ${a.id} → unknown reviewer ${rid}`);
-      }
-      if (rid === a.authorId) {
-        errors.push(
-          `article ${a.id} → reviewer ${rid} is also the author (forbidden)`,
-        );
-      }
-    }
-  }
+  // Reviewer ids on article settings were validated here in pre-SEO-panel
+  // chunks. Chunk 2 of the SEO panel scaffold removed reviewer/visibility/
+  // tags/publishDate fields from the store; chunk 3 will reintroduce the
+  // SEO-specific fields it needs.
 
   // Current user is a real user
   if (!state.users[state.currentUserId]) {

--- a/apps/demo/src/store/types.ts
+++ b/apps/demo/src/store/types.ts
@@ -37,17 +37,14 @@ export type Category = {
   depth: CategoryDepth;
 };
 
-export type ArticleVisibility = 'public' | 'private';
-
 export type ArticleSettings = {
   slug: string;
-  tags: string[];
-  /** ISO date string when published, null when draft. */
-  publishDate: string | null;
+  /**
+   * SEO meta title. Chunk 3 of the SEO panel build will rename this to
+   * `metaTitle` and surface it as a first-class field; for now it stays
+   * on the store so seed/fixture data round-trips intact.
+   */
   seoTitle: string;
-  visibility: ArticleVisibility;
-  /** Reviewer user IDs — never includes the article's author. */
-  reviewerIds: string[];
   /**
    * Free-text meta description (≤160 chars). Empty/undefined falls back
    * to the search-engine auto-generated snippet.

--- a/packages/kb-ui/src/components/content/ArticleSettingsPanel.review.stories.tsx
+++ b/packages/kb-ui/src/components/content/ArticleSettingsPanel.review.stories.tsx
@@ -17,51 +17,23 @@ const meta: Meta<typeof ArticleSettingsPanel> = {
 export default meta;
 
 /**
- * Figma frame `53:8384` ("settings.config - expanded") is a 452×356
- * snippet showing the panel header (settings cog + "Settings" label +
- * up chevron), the divider rule, and three populated dropdowns:
+ * Figma frame `2945:7756` is the new SEO-panel General-tab visual —
+ * header, divider, General/SEO tab switcher, then 3 populated fields:
  *   - Author (Avatar "A" + "Varun K" + chevron)
  *   - Category ("Hiver in Incognito" + chevron)
- *   - Article Slug ("article-default-slug" + "14/32" counter)
+ *   - Article Slug ("article-default-slug" + "14/32" counter, no chevron)
  *
- * The production `ArticleSettingsPanel` renders the full 8-field set
- * specified in PRD §13: author, category, slug, tags, publish date,
- * SEO title, visibility, reviewers. The 3-field Figma frame is a
- * design snippet, not a complete spec. We seed all 8 fields with
- * realistic values so the chrome (header, divider, field gap, outer
- * padding, footer) can be reviewed against Figma — the first three
- * fields will line up, the rest extend below the Figma raster.
- *
- * **Inline drift fixed in this dispatch**: production card border was
- * `#e2e8f0`; Figma ships `#f1f5f9` (`--color-border`). Aligned to
- * `#f1f5f9` to stay consistent with `ContentEditor`.
- *
- * **Deferred — flagged for follow-up**:
- *   - Figma's Author field uses an avatar with a green online-status
- *     dot at the bottom-right corner. Production `Avatar` does not
- *     render the dot in this context. Adding a status indicator would
- *     widen the avatar API; defer.
- *   - Figma's `Avatar` glyph is the lowercase letter "A" rendered in a
- *     `#525252` body color on a `#e5e5e5` chip. Production `Avatar`
- *     uses initials computed from the name plus the kb-ui slate color
- *     ramp. Visual delta is small but non-zero; needs a dedicated
- *     review pass on `Avatar` itself.
+ * Chunk 2 of the SEO panel scaffold trims the panel from 8 fields to
+ * 3 + a SEO placeholder tab. This review story seeds the 3 General-tab
+ * fields with realistic values so the chrome (header, divider, tabs,
+ * field gap, outer padding) can be reviewed against Figma.
  */
 const POPULATED_SETTINGS: ArticleSettings = {
   author: { name: 'Varun K', initials: 'VK' },
   category: 'Hiver in Incognito',
   // Trimmed to 14 chars so the counter pill reads `14/32` exactly as in
-  // Figma `53:8384` (Article Slug field).
+  // Figma `2945:7756` (Article Slug field).
   slug: 'article-defaul',
-  tags: ['Security', 'Account', 'Password'],
-  publishDate: 'Apr 12, 2026',
-  seoTitle: 'Reset Your Password — Hiver Help',
-  visibility: 'Public',
-  reviewers: [
-    { name: 'Ananya Kapoor', initials: 'AK' },
-    { name: 'Maya Rao', initials: 'MR' },
-    { name: 'Tanvi Shah', initials: 'TS' },
-  ],
 };
 
 function ArticleSettingsPanelReview() {
@@ -70,7 +42,7 @@ function ArticleSettingsPanelReview() {
       storyKey="content-article-settings-panel"
       figmaImage={articleSettingsPanelFigma}
       componentLabel="ArticleSettingsPanel"
-      frameLabel="Figma · settings.config (expanded, 3-field snippet)"
+      frameLabel="Figma · settings.config (General tab, SEO panel scaffold)"
       figmaNodeUrl={`https://www.figma.com/design/${figmaNode.fileKey}/?node-id=${figmaNode.nodeId.replace(':', '-')}`}
     >
       <div className="font-sans" style={{ width: 452 }}>

--- a/packages/kb-ui/src/components/content/ArticleSettingsPanel.stories.tsx
+++ b/packages/kb-ui/src/components/content/ArticleSettingsPanel.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Calendar, Plus } from '@untitledui/icons';
 import '../../tokens.css';
 import {
   ArticleSettingsPanel,
@@ -11,45 +10,30 @@ import {
   FieldBox,
   ChevronSuffix,
   CharCounter,
-  Placeholder,
-  TagChip,
-  AddChipButton,
 } from './ArticleSettingsPanelAtoms';
 import { Avatar } from '../primitives/Avatar';
 
 /* ─────────────────────────────────────────────────────────────
- * ArticleSettingsPanel Playground — exercises the full new
- * composition API on `ArticleSettingsPanel`:
- *   1. `sections`   — replace the 8 built-in fields with a hand-
- *                     composed list using lifted atoms (FieldBox,
- *                     ChevronSuffix, Placeholder, CharCounter,
- *                     TagChip, AddChipButton). Eight match the
- *                     built-in defaults; the ninth adds an "SEO
- *                     Description" textarea section the panel has
- *                     no built-in equivalent for.
+ * ArticleSettingsPanel Playground — exercises the composition
+ * API on `ArticleSettingsPanel`:
+ *   1. `sections`   — replace the built-in General/SEO tab content
+ *                     with a hand-composed list using lifted atoms
+ *                     (FieldBox, ChevronSuffix, CharCounter).
+ *                     Three sections mirror the General-tab default
+ *                     fields; the fourth adds an "SEO Description"
+ *                     textarea section the panel has no built-in
+ *                     equivalent for.
  *   2. `headerSlot` — a "Custom layout" pill on the right of the
  *                     panel header.
  *   3. `footerSlot` — a single muted line below the divider.
- * Multiple fields are wired to React.useState so the editing
- * affordances (slug/seoTitle counters, tag chips) are live.
+ * Slug is wired to React.useState so the counter is live.
  * ───────────────────────────────────────────────────────────── */
 
 const populatedSettings: ArticleSettings = {
   author: { name: 'Varun Kelkar', initials: 'VK' },
   category: 'Managing emails',
   slug: 'how-to-reset-your-password',
-  tags: ['Security', 'Account', 'Password'],
-  publishDate: 'Apr 12, 2026',
-  seoTitle: 'Reset Your Password — Hiver Help',
-  visibility: 'Public',
-  reviewers: [
-    { name: 'Ananya Kapoor', initials: 'AK' },
-    { name: 'Maya Rao', initials: 'MR' },
-    { name: 'Tanvi Shah', initials: 'TS' },
-  ],
 };
-
-const customSettings: ArticleSettings = populatedSettings;
 
 const meta: Meta<typeof ArticleSettingsPanel> = {
   title: 'Components/Article/Article Settings Panel',
@@ -82,12 +66,9 @@ function CustomSeoDescriptionSection({
 
 function ArticleSettingsPanelPlayground() {
   const [seoDescription, setSeoDescription] = React.useState('');
-  const [tags, setTags] = React.useState<string[]>(customSettings.tags ?? []);
-  const [slug, setSlug] = React.useState<string>(customSettings.slug ?? '');
-  const [seoTitle, setSeoTitle] = React.useState<string>(customSettings.seoTitle ?? '');
+  const [slug, setSlug] = React.useState<string>(populatedSettings.slug ?? '');
 
   const SLUG_MAX = 32;
-  const SEO_MAX = 60;
 
   const sections: ArticleSettingsSection[] = [
     {
@@ -95,17 +76,17 @@ function ArticleSettingsPanelPlayground() {
       label: 'Author',
       content: (
         <FieldBox ariaLabel="Change author">
-          {customSettings.author ? (
+          {populatedSettings.author ? (
             <>
               <Avatar
-                initials={customSettings.author.initials}
-                name={customSettings.author.name}
+                initials={populatedSettings.author.initials}
+                name={populatedSettings.author.name}
                 className="size-5 text-[10px] leading-[16px]"
               />
-              <span className="truncate">{customSettings.author.name}</span>
+              <span className="truncate">{populatedSettings.author.name}</span>
             </>
           ) : (
-            <Placeholder>Select author</Placeholder>
+            <span className="text-text-disabled">Select author</span>
           )}
           <ChevronSuffix />
         </FieldBox>
@@ -116,10 +97,10 @@ function ArticleSettingsPanelPlayground() {
       label: 'Category',
       content: (
         <FieldBox ariaLabel="Change category">
-          {customSettings.category ? (
-            <span className="truncate">{customSettings.category}</span>
+          {populatedSettings.category ? (
+            <span className="truncate">{populatedSettings.category}</span>
           ) : (
-            <Placeholder>Select category</Placeholder>
+            <span className="text-text-disabled">Select category</span>
           )}
           <ChevronSuffix />
         </FieldBox>
@@ -142,101 +123,11 @@ function ArticleSettingsPanelPlayground() {
               placeholder="article-url-slug"
               className="flex-1 bg-transparent text-[14px] leading-[20px] font-normal text-[#0f172a] placeholder:text-[#94a3b8] focus:outline-none"
             />
-            <ChevronSuffix />
           </FieldBox>
         </div>
       ),
     },
-    {
-      id: 'tags',
-      label: 'Tags',
-      content: (
-        <div className="flex w-full min-h-[40px] flex-wrap items-center gap-1.5 rounded-[8px] border border-[#e5e5e5] bg-white px-2 py-1.5">
-          {tags.length === 0 && <Placeholder>No tags yet</Placeholder>}
-          {tags.map((t, i) => (
-            <TagChip
-              key={`${t}-${i}`}
-              label={t}
-              onRemove={() => setTags(tags.filter((_, idx) => idx !== i))}
-            />
-          ))}
-          <AddChipButton onClick={() => setTags([...tags, 'New tag'])} />
-        </div>
-      ),
-    },
-    {
-      id: 'publishDate',
-      label: 'Publish date',
-      content: (
-        <FieldBox ariaLabel="Change publish date">
-          <Calendar aria-hidden="true" className="h-4 w-4 shrink-0 text-[#64748b]" />
-          {customSettings.publishDate ? (
-            <span className="truncate">{customSettings.publishDate}</span>
-          ) : (
-            <Placeholder>Pick a date</Placeholder>
-          )}
-        </FieldBox>
-      ),
-    },
-    {
-      id: 'seoTitle',
-      label: 'SEO title',
-      content: (
-        <div className="flex flex-col gap-1.5">
-          <div className="flex items-center justify-end -mt-[26px]">
-            <CharCounter count={seoTitle.length} max={SEO_MAX} />
-          </div>
-          <FieldBox as="div">
-            <input
-              type="text"
-              value={seoTitle}
-              onChange={(e) => setSeoTitle(e.target.value.slice(0, SEO_MAX))}
-              maxLength={SEO_MAX}
-              placeholder="SEO page title"
-              className="flex-1 bg-transparent text-[14px] leading-[20px] font-normal text-[#0f172a] placeholder:text-[#94a3b8] focus:outline-none"
-            />
-          </FieldBox>
-        </div>
-      ),
-    },
-    {
-      id: 'visibility',
-      label: 'Visibility',
-      content: (
-        <FieldBox ariaLabel="Change visibility">
-          {customSettings.visibility ? (
-            <span className="truncate">{customSettings.visibility}</span>
-          ) : (
-            <Placeholder>Select visibility</Placeholder>
-          )}
-          <ChevronSuffix />
-        </FieldBox>
-      ),
-    },
-    {
-      id: 'reviewers',
-      label: 'Reviewers',
-      content: (
-        <div className="flex items-center">
-          {(customSettings.reviewers ?? []).map((r, i) => (
-            <Avatar
-              key={`${r.initials}-${i}`}
-              initials={r.initials}
-              name={r.name}
-              className={`size-6 ring-2 ring-white${i > 0 ? ' -ml-2' : ''}`}
-            />
-          ))}
-          <button
-            type="button"
-            aria-label="Add reviewer"
-            className={`inline-flex size-6 items-center justify-center rounded-full border border-dashed border-[#cbd5e1] bg-white text-[#64748b] ring-2 ring-white hover:bg-[#f8fafc] focus:outline-none focus:ring-2 focus:ring-black/10${(customSettings.reviewers?.length ?? 0) > 0 ? ' -ml-2' : ''}`}
-          >
-            <Plus className="h-[14px] w-[14px]" />
-          </button>
-        </div>
-      ),
-    },
-    /* The 9th section — the new one with no built-in equivalent. */
+    /* Custom section — no built-in equivalent. */
     {
       id: 'seoDescription',
       label: 'SEO Description',
@@ -263,7 +154,7 @@ function ArticleSettingsPanelPlayground() {
 
   return (
     <ArticleSettingsPanel
-      value={customSettings}
+      value={populatedSettings}
       defaultCollapsed={false}
       sections={sections}
       headerSlot={headerPill}
@@ -274,4 +165,15 @@ function ArticleSettingsPanelPlayground() {
 
 export const Playground: StoryObj<typeof ArticleSettingsPanel> = {
   render: () => <ArticleSettingsPanelPlayground />,
+};
+
+/* ─────────────────────────────────────────────────────────────
+ * Default tabs — exercises the built-in General/SEO tab path
+ * with the trimmed 3-field General body and the SEO placeholder.
+ * ───────────────────────────────────────────────────────────── */
+
+export const DefaultTabs: StoryObj<typeof ArticleSettingsPanel> = {
+  render: () => (
+    <ArticleSettingsPanel value={populatedSettings} />
+  ),
 };

--- a/packages/kb-ui/src/components/content/ArticleSettingsPanel.tsx
+++ b/packages/kb-ui/src/components/content/ArticleSettingsPanel.tsx
@@ -1,28 +1,18 @@
 import * as React from 'react';
-import {
-  Settings01,
-  ChevronUp,
-  ChevronDown,
-  Calendar,
-  Plus,
-} from '@untitledui/icons';
+import { Settings01, ChevronUp, ChevronDown } from '@untitledui/icons';
 import { cn } from '../../utils/cn';
 import { Avatar } from '../primitives/Avatar';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../primitives';
 import {
   FieldLabel,
   FieldBox,
   ChevronSuffix,
   CharCounter,
-  Placeholder,
-  TagChip,
-  AddChipButton,
 } from './ArticleSettingsPanelAtoms';
 
 /* ─────────────────────────────────────────────────────────────
  * Types
  * ───────────────────────────────────────────────────────────── */
-
-export type ArticleVisibility = 'Public' | 'Internal' | 'Draft';
 
 export type ArticleSettingsPerson = {
   name: string;
@@ -33,18 +23,13 @@ export type ArticleSettings = {
   author?: ArticleSettingsPerson;
   category?: string;
   slug?: string;
-  tags?: string[];
-  publishDate?: string; // e.g. "Apr 12, 2026"
-  seoTitle?: string;
-  visibility?: ArticleVisibility;
-  reviewers?: ArticleSettingsPerson[];
 };
 
 /**
  * Composition entry for the `sections` prop. When supplied, the panel renders
- * one `<FieldLabel>` + `content` block per entry instead of the 8 hardcoded
- * fields. Visual chrome (outer padding, divider, vertical rhythm) is shared
- * with the default render path.
+ * one `<FieldLabel>` + `content` block per entry instead of the General-tab
+ * default fields. Visual chrome (outer padding, divider, vertical rhythm) is
+ * shared with the default render path.
  */
 export type ArticleSettingsSection = {
   id: string;
@@ -65,13 +50,16 @@ export type ArticleSettingsPanelProps = {
   compact?: boolean;
   className?: string;
   /**
-   * When supplied, the panel renders this list of sections instead of the 8
-   * built-in fields (author, category, slug, tags, publishDate, seoTitle,
-   * visibility, reviewers). Each entry's `label` becomes a `FieldLabel`; the
-   * `content` is rendered as-is. The panel chrome (header, divider, outer
-   * padding, vertical rhythm) is identical to the default render path so
-   * consumers can extend the panel without forking. When `undefined`, the
-   * default 8-field render path is preserved exactly.
+   * When supplied, the panel renders this list of sections instead of the
+   * General-tab default fields (author, category, slug). Each entry's
+   * `label` becomes a `FieldLabel`; the `content` is rendered as-is. The
+   * panel chrome (header, divider, outer padding, vertical rhythm) is
+   * identical to the default render path so consumers can extend the panel
+   * without forking. When `undefined`, the default render path is preserved
+   * exactly.
+   *
+   * Note: when `sections` is supplied, the General/SEO tabs are NOT
+   * rendered — the consumer is fully driving content.
    */
   sections?: ArticleSettingsSection[];
   /**
@@ -84,19 +72,17 @@ export type ArticleSettingsPanelProps = {
   headerSlot?: React.ReactNode;
   /**
    * Optional content rendered as the last child of the panel's main
-   * content column, after the section list (or after the 8 default
-   * fields), separated by the same divider used elsewhere in the panel.
-   * Useful for save footers or compliance notes. When `undefined`, the
-   * footer renders zero extra DOM and the default render path is
-   * preserved exactly.
+   * content column, after the section list (or after the default fields),
+   * separated by the same divider used elsewhere in the panel. Useful for
+   * save footers or compliance notes. When `undefined`, the footer renders
+   * zero extra DOM and the default render path is preserved exactly.
    */
   footerSlot?: React.ReactNode;
 };
 
 // Figma `53:8464` shows the slug counter reading `14/32` — the slug field
-// uses a 32-char max, not 60. SEO title remains 60.
+// uses a 32-char max.
 const SLUG_MAX = 32;
-const SEO_MAX = 60;
 
 /* ─────────────────────────────────────────────────────────────
  * Field: Author
@@ -123,7 +109,7 @@ function AuthorField({
             <span className="truncate">{author.name}</span>
           </>
         ) : (
-          <Placeholder>Select author</Placeholder>
+          <span className="text-text-disabled">Select author</span>
         )}
         <ChevronSuffix />
       </FieldBox>
@@ -146,7 +132,11 @@ function CategoryField({
     <div className="flex flex-col gap-1.5">
       <FieldLabel>Category</FieldLabel>
       <FieldBox onClick={onOpen} ariaLabel="Change category">
-        {category ? <span className="truncate">{category}</span> : <Placeholder>Select category</Placeholder>}
+        {category ? (
+          <span className="truncate">{category}</span>
+        ) : (
+          <span className="text-text-disabled">Select category</span>
+        )}
         <ChevronSuffix />
       </FieldBox>
     </div>
@@ -154,7 +144,7 @@ function CategoryField({
 }
 
 /* ─────────────────────────────────────────────────────────────
- * Field: Slug (with char counter)
+ * Field: Slug (with char counter, no trailing chevron — Figma 2945:7756)
  * ───────────────────────────────────────────────────────────── */
 
 function SlugField({
@@ -192,180 +182,26 @@ function SlugField({
             'placeholder:text-text-disabled focus:outline-none',
           )}
         />
-        <ChevronDown aria-hidden="true" className="h-4 w-4 shrink-0 text-text-disabled" />
       </div>
     </div>
   );
 }
 
 /* ─────────────────────────────────────────────────────────────
- * Field: Tags
- * ───────────────────────────────────────────────────────────── */
-
-function TagsField({
-  tags,
-  onChange,
-}: {
-  tags: string[];
-  onChange?: (tags: string[]) => void;
-}) {
-  const handleRemove = (idx: number) => {
-    const next = tags.filter((_, i) => i !== idx);
-    onChange?.(next);
-  };
-  const handleAdd = () => {
-    onChange?.([...tags, 'New tag']);
-  };
-  return (
-    <div className="flex flex-col gap-1.5">
-      <FieldLabel>Tags</FieldLabel>
-      <div
-        className={cn(
-          'flex w-full min-h-[40px] flex-wrap items-center gap-1.5 rounded-[8px] border border-card-border bg-white',
-          'px-2 py-1.5',
-        )}
-      >
-        {tags.length === 0 && <Placeholder>No tags yet</Placeholder>}
-        {tags.map((t, i) => (
-          <TagChip key={`${t}-${i}`} label={t} onRemove={() => handleRemove(i)} />
-        ))}
-        <AddChipButton onClick={handleAdd} />
-      </div>
-    </div>
-  );
-}
-
-/* ─────────────────────────────────────────────────────────────
- * Field: Publish date
- * ───────────────────────────────────────────────────────────── */
-
-function PublishDateField({
-  date,
-  onOpen,
-}: {
-  date?: string;
-  onOpen?: () => void;
-}) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <FieldLabel>Publish date</FieldLabel>
-      <FieldBox onClick={onOpen} ariaLabel="Change publish date">
-        <Calendar aria-hidden="true" className="h-4 w-4 shrink-0 text-text-muted" />
-        {date ? <span className="truncate">{date}</span> : <Placeholder>Pick a date</Placeholder>}
-      </FieldBox>
-    </div>
-  );
-}
-
-/* ─────────────────────────────────────────────────────────────
- * Field: SEO title (with char counter below input)
- * ───────────────────────────────────────────────────────────── */
-
-function SeoTitleField({
-  seoTitle,
-  onChange,
-}: {
-  seoTitle?: string;
-  onChange?: (v: string) => void;
-}) {
-  const count = seoTitle?.length ?? 0;
-  const inputId = React.useId();
-  return (
-    <div className="flex flex-col gap-1.5">
-      <div className="flex items-center justify-between">
-        <FieldLabel>
-          <label htmlFor={inputId}>SEO title</label>
-        </FieldLabel>
-        <CharCounter count={count} max={SEO_MAX} />
-      </div>
-      <div
-        className={cn(
-          'flex w-full min-h-[40px] items-center gap-2 rounded-[8px] border border-card-border bg-white px-3',
-          'focus-within:border-border-faint',
-        )}
-      >
-        <input
-          id={inputId}
-          type="text"
-          value={seoTitle ?? ''}
-          onChange={(e) => onChange?.(e.target.value.slice(0, SEO_MAX))}
-          maxLength={SEO_MAX}
-          placeholder="SEO page title"
-          className={cn(
-            'flex-1 bg-transparent text-[14px] leading-[20px] font-normal text-text-primary',
-            'placeholder:text-text-disabled focus:outline-none',
-          )}
-        />
-      </div>
-    </div>
-  );
-}
-
-/* ─────────────────────────────────────────────────────────────
- * Field: Visibility
- * ───────────────────────────────────────────────────────────── */
-
-function VisibilityField({
-  visibility,
-  onOpen,
-}: {
-  visibility?: ArticleVisibility;
-  onOpen?: () => void;
-}) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <FieldLabel>Visibility</FieldLabel>
-      <FieldBox onClick={onOpen} ariaLabel="Change visibility">
-        {visibility ? <span className="truncate">{visibility}</span> : <Placeholder>Select visibility</Placeholder>}
-        <ChevronSuffix />
-      </FieldBox>
-    </div>
-  );
-}
-
-/* ─────────────────────────────────────────────────────────────
- * Field: Reviewers
+ * SEO tab placeholder
  *
- * Horizontal stack: each avatar overlaps the previous by -ml-2.
- * Trailing + Add circular button with dashed border.
+ * Chunk 2 of 5 of the SEO panel scaffold — the SEO tab body is wired up
+ * but content is intentionally deferred to chunk 3. The placeholder uses
+ * the same vertical rhythm as the field stack so swapping it for real
+ * content in chunk 3 doesn't visibly shift the panel chrome.
  * ───────────────────────────────────────────────────────────── */
 
-function ReviewersField({
-  reviewers,
-  onAdd,
-}: {
-  reviewers: ArticleSettingsPerson[];
-  onAdd?: () => void;
-}) {
+function SeoTabPlaceholder() {
   return (
-    <div className="flex flex-col gap-1.5">
-      <FieldLabel>Reviewers</FieldLabel>
-      <div className="flex items-center">
-        {reviewers.map((r, i) => (
-          <Avatar
-            key={`${r.initials}-${i}`}
-            initials={r.initials}
-            name={r.name}
-            className={cn(
-              'size-6 ring-2 ring-white',
-              i > 0 && '-ml-2',
-            )}
-          />
-        ))}
-        <button
-          type="button"
-          onClick={onAdd}
-          aria-label="Add reviewer"
-          className={cn(
-            'inline-flex size-6 items-center justify-center rounded-full border border-dashed border-border-faint',
-            'bg-white text-text-muted ring-2 ring-white',
-            reviewers.length > 0 && '-ml-2',
-            'hover:bg-surface-subtle focus:outline-none focus:ring-2 focus:ring-black/10',
-          )}
-        >
-          <Plus className="h-[14px] w-[14px]" />
-        </button>
-      </div>
+    <div className="flex min-h-[120px] items-center justify-center px-2 py-6">
+      <p className="text-center text-[13px] leading-[20px] font-normal text-text-muted">
+        SEO settings will appear here in the next iteration.
+      </p>
     </div>
   );
 }
@@ -385,10 +221,12 @@ export function ArticleSettingsPanel({
   footerSlot,
 }: ArticleSettingsPanelProps) {
   const [collapsed, setCollapsed] = React.useState(defaultCollapsed);
+  // Tabs are panel-internal for now (chunk 2). If a future chunk needs
+  // controlled tabs, we'll lift this to a prop.
+  const [activeTab, setActiveTab] = React.useState<'general' | 'seo'>('general');
 
   // Treat component as controlled when `value` + `onChange` are both supplied.
-  // Keep an internal mirror so that local demo interactions (tag × and
-  // reviewer +) work without a controlling parent.
+  // Keep an internal mirror so the panel works without a controlling parent.
   const [internal, setInternal] = React.useState<ArticleSettings>(value ?? {});
 
   // Sync internal state whenever the incoming `value` prop changes identity —
@@ -413,11 +251,11 @@ export function ArticleSettingsPanel({
       data-kb-variant={compact ? 'compact' : 'default'}
       className={cn(
         // Figma `53:8384` ships card border `#f1f5f9` (color-border).
-        // Aligns with ContentEditor; replaces the prior `#e2e8f0` drift.
+        // Aligns with ContentEditor.
         'flex flex-col rounded-[12px] border border-surface-muted bg-white',
         'shadow-[0px_4px_6px_-1px_rgba(0,0,0,0.05),0px_2px_4px_-2px_rgba(0,0,0,0.10)]',
         // Width + outer padding swap on the compact variant.
-        // Default 452 / py-6 px-[22px] (24/22)  ─  Compact 380 / px-4 py-4 (16/16).
+        // Default 452 / py-6 px-[22px]  ─  Compact 380 / px-4 py-4.
         compact ? 'w-[380px] px-4 py-4' : 'w-[452px] py-6 px-[22px]',
         className,
       )}
@@ -469,69 +307,73 @@ export function ArticleSettingsPanel({
       {!collapsed && (
         <div id={panelId} className="flex flex-col">
           {/* Divider directly below header. Compact tightens the divider's
-              top spacing to match the 12-px field gap. */}
+              top spacing to match the smaller field gap. */}
           <div
             aria-hidden="true"
             className={cn('h-px w-full bg-card-border', compact ? 'mt-3' : 'mt-5')}
           />
 
-          {/* Field stack — default 20-px gap, compact 12-px gap. Field
-              heights (`min-h-[40px]`) are unchanged so click/touch
-              targets stay identical between variants.
-
-              When `sections` is supplied, we render the consumer's list
-              instead of the 8 built-in fields. Outer wrapper, gaps, and
-              divider above remain identical so chrome is shared. When
-              `sections` is undefined, the original 8-field render path
-              is preserved byte-for-byte. */}
-          <div
-            className={cn('flex flex-col', compact ? 'mt-3 gap-3' : 'mt-5 gap-5')}
-          >
-            {sections ? (
-              sections.map((s) => (
+          {sections ? (
+            /* Consumer-driven sections — no tabs, just the section list
+               using shared vertical rhythm. Preserved exactly so existing
+               composition consumers (Storybook Playground, future
+               extension callsites) keep working without churn. */
+            <div
+              className={cn(
+                'flex flex-col',
+                compact ? 'mt-3 gap-3' : 'mt-5 gap-5',
+              )}
+            >
+              {sections.map((s) => (
                 <div key={s.id} className="flex flex-col gap-1.5">
                   <FieldLabel>{s.label}</FieldLabel>
                   {s.content}
                 </div>
-              ))
-            ) : (
-              <>
+              ))}
+              {footerSlot ? (
+                <>
+                  <div aria-hidden="true" className="h-px w-full bg-card-border" />
+                  {footerSlot}
+                </>
+              ) : null}
+            </div>
+          ) : (
+            /* Default render path — General/SEO tabs above the field
+               stack. Figma `2945:7756` places the tab group below the
+               divider and above the field column. */
+            <Tabs
+              value={activeTab}
+              onValueChange={(v) => setActiveTab(v as 'general' | 'seo')}
+              className={cn(compact ? 'mt-3 gap-3' : 'mt-5 gap-5')}
+            >
+              <TabsList aria-label="Article settings tabs">
+                <TabsTrigger value="general">General</TabsTrigger>
+                <TabsTrigger value="seo">SEO</TabsTrigger>
+              </TabsList>
+
+              <TabsContent
+                value="general"
+                className={cn('flex flex-col', compact ? 'gap-3' : 'gap-5')}
+              >
                 <AuthorField author={current.author} />
                 <CategoryField category={current.category} />
                 <SlugField
                   slug={current.slug}
                   onChange={(slug) => update({ slug })}
                 />
-                <TagsField
-                  tags={current.tags ?? []}
-                  onChange={(tags) => update({ tags })}
-                />
-                <PublishDateField date={current.publishDate} />
-                <SeoTitleField
-                  seoTitle={current.seoTitle}
-                  onChange={(seoTitle) => update({ seoTitle })}
-                />
-                <VisibilityField visibility={current.visibility} />
-                <ReviewersField
-                  reviewers={current.reviewers ?? []}
-                  onAdd={() =>
-                    update({
-                      reviewers: [
-                        ...(current.reviewers ?? []),
-                        { name: 'New User', initials: 'NU' },
-                      ],
-                    })
-                  }
-                />
-              </>
-            )}
-            {footerSlot ? (
-              <>
-                <div aria-hidden="true" className="h-px w-full bg-card-border" />
-                {footerSlot}
-              </>
-            ) : null}
-          </div>
+                {footerSlot ? (
+                  <>
+                    <div aria-hidden="true" className="h-px w-full bg-card-border" />
+                    {footerSlot}
+                  </>
+                ) : null}
+              </TabsContent>
+
+              <TabsContent value="seo">
+                <SeoTabPlaceholder />
+              </TabsContent>
+            </Tabs>
+          )}
         </div>
       )}
     </section>

--- a/packages/kb-ui/src/components/content/ArticleSettingsPanelAtoms.tsx
+++ b/packages/kb-ui/src/components/content/ArticleSettingsPanelAtoms.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ChevronDown, XClose } from '@untitledui/icons';
+import { ChevronDown } from '@untitledui/icons';
 import { cn } from '../../utils/cn';
 
 /* ─────────────────────────────────────────────────────────────
@@ -7,13 +7,11 @@ import { cn } from '../../utils/cn';
  *
  * Every settings field uses a label row + 40-tall input box. The
  * input box is a div (not an <input>) because these controls are
- * demo-only for v1 — they open no real dropdown menus. See design
- * doc.
+ * demo-only for v1 — they open no real dropdown menus.
  *
  * These atoms are extracted from ArticleSettingsPanel so that
  * consumers can compose visually-correct fields outside the panel
- * without re-implementing chrome. Render output is byte-identical
- * to the previous private declarations.
+ * without re-implementing chrome.
  * ───────────────────────────────────────────────────────────── */
 
 export function FieldLabel({ children }: { children: React.ReactNode }) {
@@ -66,64 +64,5 @@ export function CharCounter({ count, max }: { count: number; max: number }) {
     <span className="text-[12px] font-normal leading-[18px] text-text-disabled tabular-nums">
       {count}/{max}
     </span>
-  );
-}
-
-export function Placeholder({ children }: { children: React.ReactNode }) {
-  return <span className="text-text-disabled">{children}</span>;
-}
-
-/* ─────────────────────────────────────────────────────────────
- * Tag chip (custom — Badge primitive is not quite right:
- * Badge is pill-y but doesn't have the × close affordance and
- * has specific variant colors. Panel tags match spec better
- * with a dedicated chip).
- * ───────────────────────────────────────────────────────────── */
-
-export type TagChipProps = {
-  label: string;
-  onRemove?: () => void;
-};
-
-export function TagChip({ label, onRemove }: TagChipProps) {
-  return (
-    <span
-      className={cn(
-        'inline-flex h-[22px] items-center gap-1.5 rounded-full bg-surface-muted pl-2 pr-1',
-        'text-[12px] font-medium leading-[18px] text-text-primary',
-      )}
-    >
-      <span>{label}</span>
-      {onRemove && (
-        <button
-          type="button"
-          onClick={onRemove}
-          aria-label={`Remove ${label}`}
-          className={cn(
-            'inline-flex h-[16px] w-[16px] items-center justify-center rounded-full',
-            'text-text-muted hover:bg-card-border hover:text-text-primary',
-            'focus:outline-none focus:ring-2 focus:ring-black/10',
-          )}
-        >
-          <XClose className="h-3 w-3" />
-        </button>
-      )}
-    </span>
-  );
-}
-
-export function AddChipButton({ onClick, label = '+ Add' }: { onClick?: () => void; label?: string }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        'inline-flex h-[22px] items-center rounded-full border border-dashed border-border-faint bg-white px-2',
-        'text-[12px] font-medium leading-[18px] text-text-meta',
-        'hover:bg-surface-subtle focus:outline-none focus:ring-2 focus:ring-black/10',
-      )}
-    >
-      {label}
-    </button>
   );
 }

--- a/packages/kb-ui/src/components/content/index.ts
+++ b/packages/kb-ui/src/components/content/index.ts
@@ -14,21 +14,14 @@ export type {
   ArticleSettingsPanelProps,
   ArticleSettingsPerson,
   ArticleSettingsSection,
-  ArticleVisibility,
 } from './ArticleSettingsPanel';
 export {
   FieldLabel,
   FieldBox,
   ChevronSuffix,
   CharCounter,
-  Placeholder,
-  TagChip,
-  AddChipButton,
 } from './ArticleSettingsPanelAtoms';
-export type {
-  FieldBoxProps,
-  TagChipProps,
-} from './ArticleSettingsPanelAtoms';
+export type { FieldBoxProps } from './ArticleSettingsPanelAtoms';
 export { SuggestionCard, DEFAULT_SUGGESTION_KINDS } from './SuggestionCard';
 export type {
   SuggestionCardProps,

--- a/packages/kb-ui/src/pages/KBAIGapsExperience.stories.tsx
+++ b/packages/kb-ui/src/pages/KBAIGapsExperience.stories.tsx
@@ -330,14 +330,6 @@ const dummySettings: ArticleSettings = {
   author: { name: 'Aileen Kelly', initials: 'AK' },
   category: 'Getting Started',
   slug: 'reset-password',
-  tags: ['password', 'security'],
-  publishDate: 'Apr 12, 2026',
-  seoTitle: 'How to reset your password — Hiver KB',
-  visibility: 'Public',
-  reviewers: [
-    { name: 'Mara Reyes', initials: 'MR' },
-    { name: 'Tom Singh', initials: 'TS' },
-  ],
 };
 
 /* ─────────────────────────────────────────────────────────────

--- a/packages/kb-ui/src/pages/KBEditorPage.stories.tsx
+++ b/packages/kb-ui/src/pages/KBEditorPage.stories.tsx
@@ -172,21 +172,9 @@ const populatedSettings: ArticleSettings = {
   author: { name: 'Varun K', initials: 'A' },
   category: 'Hiver in Incognito',
   slug: 'how-to-reset-your-password',
-  tags: ['Security', 'Account', 'Password'],
-  publishDate: 'Apr 12, 2026',
-  seoTitle: 'Reset Your Password — Hiver Help',
-  visibility: 'Public',
-  reviewers: [
-    { name: 'Aditya Kapoor', initials: 'AK' },
-    { name: 'Maya Rao', initials: 'MR' },
-    { name: 'Tanvi Shah', initials: 'TS' },
-  ],
 };
 
-const emptySettings: ArticleSettings = {
-  tags: [],
-  reviewers: [],
-};
+const emptySettings: ArticleSettings = {};
 
 /* ─────────────────────────────────────────────────────────────
  * Composition wrapper
@@ -223,7 +211,7 @@ function EditorPage({ sidebarCollapsed, populated }: EditorPageProps) {
   // Sync local state with control changes: toggling `sidebarCollapsed` or
   // `populated` from the Storybook controls panel should reset the local
   // wrapper state to match — otherwise the user's prior in-component
-  // edits (e.g. tags they added) shadow the new arg value.
+  // edits shadow the new arg value.
   React.useEffect(() => {
     setCollapsed(sidebarCollapsed);
   }, [sidebarCollapsed]);


### PR DESCRIPTION
Chunk 2 of 5 for the SEO settings panel. Adds the General/SEO tab switcher and trims the General body to the 3 fields the new design ships (Author, Category, Article Slug — no chevron on Slug). SEO tab is a placeholder; real content lands in chunk 3.

## kb-ui
- ArticleSettingsPanel: General/SEO Tabs above the field stack (Figma 2945-7756); 3-field General body; SEO tab placeholder ("SEO settings will appear here in the next iteration.")
- Drop TagsField / PublishDateField / SeoTitleField / VisibilityField / ReviewersField + ArticleVisibility type
- Strip trailing chevron from SlugField
- Atoms: drop TagChip / AddChipButton / Placeholder + their unused icon imports (Calendar, Plus, XClose)
- Stories: Playground + Review pruned; new DefaultTabs story exercising the tab path; pages stories (KBEditorPage, KBAIGapsExperience) reseeded

## apps/demo
- ArticleSettings: drop tags / publishDate / visibility / reviewerIds + ArticleVisibility export. Keep slug / seoTitle / metaDescription / canonicalUrlOverride
- Reducer: drop dropped-field branches in editor/createNew + editor/publish + aiGaps/publish
- Fixtures: prune tags/publishDate/visibility/reviewerIds across 17 articles
- EditorPage + ReviewPage: trimmed adapters (no more visibility/reviewer projection)
- seed.ts: drop reviewer integrity-check loop (the field is gone)