### PR TITLE
feat(kb-ui): SEO tab static fields + Switch refit + emil motion pass (chunk 3/5 of SEO panel)

### DIFF
--- a/apps/demo/src/routes/kb/EditorPage.tsx
+++ b/apps/demo/src/routes/kb/EditorPage.tsx
@@ -83,25 +83,40 @@ function toPerson(user: User | undefined): ArticleSettingsPerson | undefined {
   return { name: user.name, initials: user.initials };
 }
 
+/** Hardcoded SEO base — the demo's articles all live under help.hiverhq.com. */
+const DEMO_URL_BASE = 'help.hiverhq.com';
+
 function adaptStoreToKbSettings(
   article: Article,
   category: Category | undefined,
+  ancestors: Category[],
   users: Record<string, User>,
   storeSettings: StoreArticleSettings,
 ): KbUiArticleSettings {
   const author = users[article.authorId];
+  // Build the URL path crumbs from the article's category ancestry,
+  // top-down. The SEO panel renders these as `base/crumb1/crumb2/slug`.
+  const categoryPath = ancestors.map((c) => c.slug);
   return {
     author: toPerson(author),
     category: category?.title,
     slug: storeSettings.slug,
+    metaTitle: storeSettings.metaTitle,
+    metaDescription: storeSettings.metaDescription,
+    urlBase: DEMO_URL_BASE,
+    categoryPath,
+    canonicalUrl: storeSettings.canonicalUrlOverride,
+    excludeFromSearch: storeSettings.excludeFromSearch,
+    aiRefinedAt: storeSettings.aiRefinedAt,
   };
 }
 
 /**
  * Project edits made inside the kb-ui ArticleSettingsPanel back into the
- * store's settings shape. Only the fields the panel can actually mutate
- * (slug, post-chunk-2) are written; author / category stay frozen —
- * those are surfaced as read-only dropdowns in v1.
+ * store's settings shape. SEO field edits flow through here too — each
+ * one becomes a targeted reducer action in EditorPageBody via the panel's
+ * onChange callback (we don't write directly to the store in this adapter;
+ * the caller dispatches per-field).
  */
 function adaptKbToStoreSettings(
   prev: StoreArticleSettings,
@@ -110,6 +125,12 @@ function adaptKbToStoreSettings(
   return {
     ...prev,
     slug: next.slug ?? prev.slug,
+    metaTitle: next.metaTitle ?? prev.metaTitle,
+    metaDescription: next.metaDescription ?? prev.metaDescription,
+    canonicalUrlOverride: next.canonicalUrl ?? prev.canonicalUrlOverride,
+    excludeFromSearch:
+      next.excludeFromSearch ?? prev.excludeFromSearch ?? false,
+    aiRefinedAt: next.aiRefinedAt ?? prev.aiRefinedAt,
   };
 }
 
@@ -284,8 +305,14 @@ function EditorPageBody({ article }: { article: Article }) {
    */
   const kbSettings = useMemo<KbUiArticleSettings>(
     () =>
-      adaptStoreToKbSettings(article, category, state.users, storeSettings),
-    [article, category, state.users, storeSettings],
+      adaptStoreToKbSettings(
+        article,
+        category,
+        ancestors,
+        state.users,
+        storeSettings,
+      ),
+    [article, category, ancestors, state.users, storeSettings],
   );
 
   /* ── Handlers ──────────────────────────────────────────────── */
@@ -310,10 +337,28 @@ function EditorPageBody({ article }: { article: Article }) {
 
   const handleSettingsChange = useCallback(
     (next: KbUiArticleSettings) => {
+      // The panel emits the FULL merged shape; we project back into the
+      // store's settings shape via the adapter. The dirty flag flips on
+      // any settings mutation (matches General-tab behaviour pre-chunk-3).
+      //
+      // We intentionally write through `setStoreSettings` rather than
+      // dispatching per-field actions — keeping a single source of truth
+      // for the panel's value (local state, mirrored to the store via
+      // the debounced saveDraft path). Per-field reducer actions exist
+      // for direct callers (e.g. tests, future automations) but the live
+      // panel does not need them.
       setStoreSettings((prev) => adaptKbToStoreSettings(prev, next));
       setDirty(true);
     },
     [],
+  );
+
+  // Toast wiring for the SEO panel's URL / canonical copy buttons.
+  // navigator.clipboard is already invoked inside the SEO panel; this
+  // callback just surfaces the visual confirmation.
+  const handleCopyUrl = useCallback(
+    () => showToast('URL copied to clipboard.', 'success'),
+    [showToast],
   );
 
   const handleSaveAsDraft = useCallback(() => {
@@ -518,6 +563,8 @@ function EditorPageBody({ article }: { article: Article }) {
           <ArticleSettingsPanel
             value={kbSettings}
             onChange={handleSettingsChange}
+            onCopyUrl={handleCopyUrl}
+            onCopyCanonical={handleCopyUrl}
             compact
           />
         </div>

--- a/apps/demo/src/store/fixtures/articles.ts
+++ b/apps/demo/src/store/fixtures/articles.ts
@@ -60,7 +60,8 @@ export const articles: Article[] = [
 <p>Once Hiver is loaded, you'll see the shared-inbox list under your personal labels. If the rail is missing, disable and re-enable the extension from <code>chrome://extensions</code>, then refresh Gmail. Most install issues come from a stale Gmail tab — closing every Gmail tab and re-opening one fresh resolves them.</p>`,
     settings: {
       slug: 'installing-the-hiver-chrome-extension',
-      seoTitle: 'How to install the Hiver Chrome extension',
+      metaTitle: 'How to install the Hiver Chrome extension',
+      excludeFromSearch: false,
     },
   },
   {
@@ -83,7 +84,8 @@ export const articles: Article[] = [
 <p>The invitee receives an email with a one-click link that drops them straight into the Hiver onboarding flow. Once they accept, they'll appear in the agent list with a green "Online" dot the next time they open Gmail. For tips on a smooth first day, read <a href="#">Onboarding new agents</a>.</p>`,
     settings: {
       slug: 'inviting-your-first-teammate',
-      seoTitle: 'How to invite your first teammate to Hiver',
+      metaTitle: 'How to invite your first teammate to Hiver',
+      excludeFromSearch: false,
     },
   },
   {
@@ -106,7 +108,8 @@ export const articles: Article[] = [
 <p>If the connection appears successful but no conversations sync, check your tenant's conditional access rules — Hiver's IP range needs to be allowlisted on tenants that block "third-party connectors." See <a href="#">Microsoft 365 conditional access</a> for the IP list.</p>`,
     settings: {
       slug: 'connecting-an-outlook-mailbox',
-      seoTitle: 'Connect an Outlook mailbox to Hiver',
+      metaTitle: 'Connect an Outlook mailbox to Hiver',
+      excludeFromSearch: false,
     },
   },
   {
@@ -130,7 +133,8 @@ export const articles: Article[] = [
 <p>The first new email to that address shows up as a Hiver conversation within 30 seconds. If you don't see one within five minutes, double-check the alias is forwarding correctly. See <a href="#">Diagnosing a quiet inbox</a>.</p>`,
     settings: {
       slug: 'creating-your-first-shared-inbox',
-      seoTitle: 'Create your first shared inbox in Hiver',
+      metaTitle: 'Create your first shared inbox in Hiver',
+      excludeFromSearch: false,
     },
   },
   {
@@ -156,7 +160,8 @@ export const articles: Article[] = [
 <p>If you don't receive the email within five minutes, the most likely cause is that your team's mail server is quarantining no-reply addresses. Ask your IT admin to allowlist <code>noreply@hiverhq.com</code>. For more help, see <a href="#">Login troubleshooting</a>.</p>`,
     settings: {
       slug: 'how-to-reset-your-password',
-      seoTitle: 'How to reset your Hiver password',
+      metaTitle: 'How to reset your Hiver password',
+      excludeFromSearch: false,
     },
     aiGapsSummary:
       'Refining the article with updated instruction set, updating link and by removing legacy instructions',
@@ -181,7 +186,8 @@ export const articles: Article[] = [
 <p>Every add/remove on a restricted inbox writes an entry to the audit log under <strong>Settings → Audit log</strong>. Filter by inbox ID to review the full access history. See <a href="#">Audit log filters</a> for advanced queries.</p>`,
     settings: {
       slug: 'restricting-an-inbox-to-specific-agents',
-      seoTitle: 'Restrict a Hiver inbox to specific agents',
+      metaTitle: 'Restrict a Hiver inbox to specific agents',
+      excludeFromSearch: false,
     },
   },
   {
@@ -204,7 +210,8 @@ export const articles: Article[] = [
 <p>By default templates are scoped to the inbox they were created in. Move a template to the workspace-level <em>Shared</em> folder to make it available everywhere. See <a href="#">Template variables reference</a> for the full placeholder list.</p>`,
     settings: {
       slug: 'creating-a-shared-template-library',
-      seoTitle: 'Build a shared template library in Hiver',
+      metaTitle: 'Build a shared template library in Hiver',
+      excludeFromSearch: false,
     },
   },
   {
@@ -227,7 +234,8 @@ export const articles: Article[] = [
 <p>Round-robin works for teams where every conversation takes roughly the same time — high-volume tier-1 support is the canonical fit. Load-balanced is better when complexity varies wildly — billing or technical support tend to need it. See <a href="#">Skill-based assignment</a> to layer skills on top.</p>`,
     settings: {
       slug: 'round-robin-vs-load-balanced-assignment',
-      seoTitle: 'Round-robin vs load-balanced auto-assignment',
+      metaTitle: 'Round-robin vs load-balanced auto-assignment',
+      excludeFromSearch: false,
     },
   },
   {
@@ -254,7 +262,8 @@ export const articles: Article[] = [
 <p>Beyond visual customisation, the widget has behavioural toggles for proactive messages, quiet hours, and offline-mode forms. Most teams start with all toggles off and enable them as they observe their chat traffic patterns. See <a href="#">Proactive chat playbook</a> for what to try first.</p>`,
     settings: {
       slug: 'customizing-the-chat-widget',
-      seoTitle: 'Customize the Hiver chat widget',
+      metaTitle: 'Customize the Hiver chat widget',
+      excludeFromSearch: false,
     },
     aiGapsSummary:
       'Adding accessibility best-practices guidance, renaming the color picker to theme selector and removing legacy iframe embed instructions',
@@ -280,7 +289,8 @@ export const articles: Article[] = [
 <p>Inbound WhatsApp messages appear as conversations in the inbox you map them to. Agents can reply through the same composer they use for email. Outbound proactive messages need a pre-approved template per Meta's policy. See <a href="#">WhatsApp message templates</a>.</p>`,
     settings: {
       slug: 'connecting-whatsapp-business-to-hiver',
-      seoTitle: 'Connect WhatsApp Business to Hiver',
+      metaTitle: 'Connect WhatsApp Business to Hiver',
+      excludeFromSearch: false,
     },
   },
   {
@@ -303,7 +313,8 @@ export const articles: Article[] = [
 <p>Inbound SMS to the number appears as conversations in the inbox you map. Outbound SMS uses message templates with character-aware previews — Hiver tells you when a message will split into multiple SMS segments. See <a href="#">SMS character limits</a>.</p>`,
     settings: {
       slug: 'adding-sms-as-a-support-channel',
-      seoTitle: 'Add SMS support to Hiver',
+      metaTitle: 'Add SMS support to Hiver',
+      excludeFromSearch: false,
     },
   },
   {
@@ -332,7 +343,8 @@ export const articles: Article[] = [
 <p>Once saved, send a test email from outside your team to the trigger inbox. The auto-reply should arrive within a few seconds. If it doesn't, check the rule's run log — every rule has a per-run history showing why it did or didn't fire. See <a href="#">Rule run logs</a>.</p>`,
     settings: {
       slug: 'setting-up-auto-reply-rules',
-      seoTitle: 'Set up auto-reply rules in Hiver',
+      metaTitle: 'Set up auto-reply rules in Hiver',
+      excludeFromSearch: false,
     },
     aiGapsSummary:
       'Adding timezone guidance for rule schedules, clarifying the ambiguous Recent trigger and removing the deprecated sender-domain toggle',
@@ -358,7 +370,8 @@ export const articles: Article[] = [
 <p>Hiver measures from conversation arrival to first outbound agent reply. Internal notes don't count by default; flip the toggle if you want notes to stop the clock. See <a href="#">SLA measurement details</a>.</p>`,
     settings: {
       slug: 'defining-first-response-targets',
-      seoTitle: 'Define first-response SLA targets in Hiver',
+      metaTitle: 'Define first-response SLA targets in Hiver',
+      excludeFromSearch: false,
     },
   },
   {
@@ -382,7 +395,8 @@ export const articles: Article[] = [
 <p>For severe breaches you can chain escalations — escalate to manager at breach, then to director if still unanswered after another hour. See <a href="#">Escalation chains</a> for the full pattern.</p>`,
     settings: {
       slug: 'escalating-to-a-manager-on-sla-breach',
-      seoTitle: 'Escalate to a manager on SLA breach',
+      metaTitle: 'Escalate to a manager on SLA breach',
+      excludeFromSearch: false,
     },
   },
   {
@@ -405,7 +419,8 @@ export const articles: Article[] = [
 <p>The default profile is "Browser push for assigned-to-me, hourly email digest for everything else, Slack off." Most agents leave the defaults; power users tune them aggressively. See <a href="#">Notification profiles</a> for preset bundles.</p>`,
     settings: {
       slug: 'personal-notification-preferences',
-      seoTitle: 'Personal notification preferences in Hiver',
+      metaTitle: 'Personal notification preferences in Hiver',
+      excludeFromSearch: false,
     },
   },
   {
@@ -429,7 +444,8 @@ export const articles: Article[] = [
 <p>Email the report to yourself or your manager on a recurring schedule — daily, weekly, monthly. PDF and CSV both supported. See <a href="#">Report scheduling</a>.</p>`,
     settings: {
       slug: 'volume-and-response-time-reports',
-      seoTitle: 'Volume and response-time reports in Hiver',
+      metaTitle: 'Volume and response-time reports in Hiver',
+      excludeFromSearch: false,
     },
   },
   {
@@ -453,7 +469,8 @@ export const articles: Article[] = [
 <p>Custom dashboards can be private (just you), team-scoped (specific roles or agents), or public to the workspace. See <a href="#">Sharing custom dashboards</a>.</p>`,
     settings: {
       slug: 'building-your-first-custom-dashboard',
-      seoTitle: 'Build your first custom dashboard in Hiver',
+      metaTitle: 'Build your first custom dashboard in Hiver',
+      excludeFromSearch: false,
     },
   },
   {
@@ -482,7 +499,8 @@ export const articles: Article[] = [
 <p>Notifications are the lightweight third primitive — no triggers, no deadlines, just per-agent preferences for what events should ping them and through which channel. Most agents tune their own notifications; managers tune team-wide defaults. Use notifications when you want awareness without action — "tell me when I'm mentioned in a note" rather than "auto-assign this to me." The three primitives compose: a rule routes a conversation, an SLA times it, and a notification pings the right agent the moment either fires.</p>`,
     settings: {
       slug: 'choosing-the-right-automation-type',
-      seoTitle: 'When to use rules, SLAs, and notifications in Hiver',
+      metaTitle: 'When to use rules, SLAs, and notifications in Hiver',
+      excludeFromSearch: false,
     },
   },
 ];

--- a/apps/demo/src/store/reducer.ts
+++ b/apps/demo/src/store/reducer.ts
@@ -32,6 +32,23 @@ export type StoreAction =
     }
   | { type: 'editor/publish'; articleId: string }
   | { type: 'editor/setTitle'; articleId: string; title: string }
+  | { type: 'editor/setMetaTitle'; articleId: string; metaTitle: string }
+  | {
+      type: 'editor/setMetaDescription';
+      articleId: string;
+      metaDescription: string;
+    }
+  | {
+      type: 'editor/setCanonicalOverride';
+      articleId: string;
+      canonicalUrlOverride: string;
+    }
+  | {
+      type: 'editor/setExcludeFromSearch';
+      articleId: string;
+      excludeFromSearch: boolean;
+    }
+  | { type: 'editor/markAiRefined'; articleId: string; at: number }
   | {
       type: 'editor/createNew';
       categoryId: string;
@@ -259,6 +276,92 @@ export function rootReducer(
       };
     }
 
+    case 'editor/setMetaTitle': {
+      const article = state.articles[action.articleId];
+      if (!article) return state;
+      if (article.settings.metaTitle === action.metaTitle) return state;
+      const next: Article = {
+        ...article,
+        settings: { ...article.settings, metaTitle: action.metaTitle },
+      };
+      return {
+        ...state,
+        articles: { ...state.articles, [action.articleId]: next },
+      };
+    }
+
+    case 'editor/setMetaDescription': {
+      const article = state.articles[action.articleId];
+      if (!article) return state;
+      if (article.settings.metaDescription === action.metaDescription) {
+        return state;
+      }
+      const next: Article = {
+        ...article,
+        settings: {
+          ...article.settings,
+          metaDescription: action.metaDescription,
+        },
+      };
+      return {
+        ...state,
+        articles: { ...state.articles, [action.articleId]: next },
+      };
+    }
+
+    case 'editor/setCanonicalOverride': {
+      const article = state.articles[action.articleId];
+      if (!article) return state;
+      if (
+        article.settings.canonicalUrlOverride === action.canonicalUrlOverride
+      ) {
+        return state;
+      }
+      const next: Article = {
+        ...article,
+        settings: {
+          ...article.settings,
+          canonicalUrlOverride: action.canonicalUrlOverride,
+        },
+      };
+      return {
+        ...state,
+        articles: { ...state.articles, [action.articleId]: next },
+      };
+    }
+
+    case 'editor/setExcludeFromSearch': {
+      const article = state.articles[action.articleId];
+      if (!article) return state;
+      if (article.settings.excludeFromSearch === action.excludeFromSearch) {
+        return state;
+      }
+      const next: Article = {
+        ...article,
+        settings: {
+          ...article.settings,
+          excludeFromSearch: action.excludeFromSearch,
+        },
+      };
+      return {
+        ...state,
+        articles: { ...state.articles, [action.articleId]: next },
+      };
+    }
+
+    case 'editor/markAiRefined': {
+      const article = state.articles[action.articleId];
+      if (!article) return state;
+      const next: Article = {
+        ...article,
+        settings: { ...article.settings, aiRefinedAt: action.at },
+      };
+      return {
+        ...state,
+        articles: { ...state.articles, [action.articleId]: next },
+      };
+    }
+
     case 'editor/publish': {
       const article = state.articles[action.articleId];
       if (!article) return state;
@@ -289,7 +392,8 @@ export function rootReducer(
         bodyHTML: '',
         settings: {
           slug: action.newSlug,
-          seoTitle: 'Untitled article',
+          metaTitle: 'Untitled article',
+          excludeFromSearch: false,
         },
       };
       return {

--- a/apps/demo/src/store/types.ts
+++ b/apps/demo/src/store/types.ts
@@ -40,11 +40,10 @@ export type Category = {
 export type ArticleSettings = {
   slug: string;
   /**
-   * SEO meta title. Chunk 3 of the SEO panel build will rename this to
-   * `metaTitle` and surface it as a first-class field; for now it stays
-   * on the store so seed/fixture data round-trips intact.
+   * SEO meta title (renamed from `seoTitle` in chunk 3 of the SEO panel
+   * build). Shown in search engine results + browser tabs.
    */
-  seoTitle: string;
+  metaTitle: string;
   /**
    * Free-text meta description (≤160 chars). Empty/undefined falls back
    * to the search-engine auto-generated snippet.
@@ -55,6 +54,17 @@ export type ArticleSettings = {
    * canonical URL is auto-generated from the primary domain + slug.
    */
   canonicalUrlOverride?: string;
+  /**
+   * When `true`, the article emits `noindex` / `nofollow` meta tags and
+   * is excluded from search-engine indexing. Default `false`.
+   */
+  excludeFromSearch: boolean;
+  /**
+   * Ms timestamp of the last AI refine on the meta title / description.
+   * Drives the SEO panel's verdict-bump behaviour while staleness is
+   * tracked client-side. Unset until the first refine fires.
+   */
+  aiRefinedAt?: number;
 };
 
 export type ArticleStatus = 'draft' | 'published';

--- a/packages/kb-ui/src/components/content/ArticleSettingsPanel.stories.tsx
+++ b/packages/kb-ui/src/components/content/ArticleSettingsPanel.stories.tsx
@@ -33,6 +33,15 @@ const populatedSettings: ArticleSettings = {
   author: { name: 'Varun Kelkar', initials: 'VK' },
   category: 'Managing emails',
   slug: 'how-to-reset-your-password',
+  // SEO seeds — verdict-locked to Optimal green for both meters per
+  // the chunk-3 brief.
+  metaTitle: 'How to reset your Hiver password — quick step-by-step',
+  metaDescription:
+    'Reset your Hiver password from the sign-in page in under a minute. Email or SMS verification supported with one-time codes.',
+  urlBase: 'help.hiverhq.com',
+  categoryPath: ['managing-emails'],
+  canonicalUrl: '',
+  excludeFromSearch: false,
 };
 
 const meta: Meta<typeof ArticleSettingsPanel> = {

--- a/packages/kb-ui/src/components/content/ArticleSettingsPanel.tsx
+++ b/packages/kb-ui/src/components/content/ArticleSettingsPanel.tsx
@@ -9,6 +9,7 @@ import {
   ChevronSuffix,
   CharCounter,
 } from './ArticleSettingsPanelAtoms';
+import { SeoTabBody, type SeoTabBodyValue } from './SeoTabBody';
 
 /* ─────────────────────────────────────────────────────────────
  * Types
@@ -23,6 +24,29 @@ export type ArticleSettings = {
   author?: ArticleSettingsPerson;
   category?: string;
   slug?: string;
+  /* ── SEO tab fields (chunk 3) ─────────────────────────────── */
+  /** Meta title displayed in search results / browser tab. ≤70 chars
+   *  for the verdict to stay out of the hard-cap red state. */
+  metaTitle?: string;
+  /** Meta description shown in the search snippet. ≤160 chars. */
+  metaDescription?: string;
+  /** Base URL used for the auto-generated URL field — e.g.
+   *  `"help.hiverhq.com"`. The full URL becomes
+   *  `${urlBase}/${categoryPath.join('/')}/${slug}`. */
+  urlBase?: string;
+  /** Category-path crumbs that appear between the base and the slug
+   *  in the auto-URL. */
+  categoryPath?: string[];
+  /** Admin-only override for the canonical URL. When non-empty, the
+   *  disclosure opens automatically. */
+  canonicalUrl?: string;
+  /** When true, the article emits `noindex` / `nofollow` meta tags
+   *  and the SERP preview is suppressed. */
+  excludeFromSearch?: boolean;
+  /** Ms timestamp of the last AI refine on the meta title /
+   *  description. Drives the SEO panel's verdict-bump behaviour
+   *  while staleness is true. */
+  aiRefinedAt?: number;
 };
 
 /**
@@ -78,6 +102,17 @@ export type ArticleSettingsPanelProps = {
    * zero extra DOM and the default render path is preserved exactly.
    */
   footerSlot?: React.ReactNode;
+  /**
+   * Optional callback fired when the SEO tab's URL copy button is
+   * clicked. The component already writes to `navigator.clipboard` —
+   * this is for downstream toast wiring. Receives the URL that was
+   * copied.
+   */
+  onCopyUrl?: (url: string) => void;
+  /**
+   * Same as `onCopyUrl`, but for the canonical-URL override field.
+   */
+  onCopyCanonical?: (url: string) => void;
 };
 
 // Figma `53:8464` shows the slug counter reading `14/32` — the slug field
@@ -188,22 +223,21 @@ function SlugField({
 }
 
 /* ─────────────────────────────────────────────────────────────
- * SEO tab placeholder
- *
- * Chunk 2 of 5 of the SEO panel scaffold — the SEO tab body is wired up
- * but content is intentionally deferred to chunk 3. The placeholder uses
- * the same vertical rhythm as the field stack so swapping it for real
- * content in chunk 3 doesn't visibly shift the panel chrome.
+ * Adapt the panel's ArticleSettings value to SeoTabBody's value
+ * shape. Only the SEO-relevant fields flow through.
  * ───────────────────────────────────────────────────────────── */
 
-function SeoTabPlaceholder() {
-  return (
-    <div className="flex min-h-[120px] items-center justify-center px-2 py-6">
-      <p className="text-center text-[13px] leading-[20px] font-normal text-text-muted">
-        SEO settings will appear here in the next iteration.
-      </p>
-    </div>
-  );
+function toSeoTabValue(s: ArticleSettings): SeoTabBodyValue {
+  return {
+    metaTitle: s.metaTitle,
+    metaDescription: s.metaDescription,
+    urlBase: s.urlBase,
+    slug: s.slug,
+    categoryPath: s.categoryPath,
+    canonicalUrl: s.canonicalUrl,
+    excludeFromSearch: s.excludeFromSearch,
+    aiRefinedAt: s.aiRefinedAt,
+  };
 }
 
 /* ─────────────────────────────────────────────────────────────
@@ -219,6 +253,8 @@ export function ArticleSettingsPanel({
   sections,
   headerSlot,
   footerSlot,
+  onCopyUrl,
+  onCopyCanonical,
 }: ArticleSettingsPanelProps) {
   const [collapsed, setCollapsed] = React.useState(defaultCollapsed);
   // Tabs are panel-internal for now (chunk 2). If a future chunk needs
@@ -370,7 +406,12 @@ export function ArticleSettingsPanel({
               </TabsContent>
 
               <TabsContent value="seo">
-                <SeoTabPlaceholder />
+                <SeoTabBody
+                  value={toSeoTabValue(current)}
+                  onChange={(patch) => update(patch)}
+                  onCopyUrl={onCopyUrl}
+                  onCopyCanonical={onCopyCanonical}
+                />
               </TabsContent>
             </Tabs>
           )}

--- a/packages/kb-ui/src/components/content/ArticleSettingsPanel.tsx
+++ b/packages/kb-ui/src/components/content/ArticleSettingsPanel.tsx
@@ -387,9 +387,23 @@ export function ArticleSettingsPanel({
                 <TabsTrigger value="seo">SEO</TabsTrigger>
               </TabsList>
 
+              {/* TabsContent mount fade: per emil-design-eng, content
+                  swap without transition reads as a hard snap. Radix
+                  unmounts the inactive panel on every state flip, so
+                  a CSS transition between data-states won't fire (the
+                  outgoing element is removed from the DOM before any
+                  transition can complete). Instead, we use a 150ms
+                  ease-out keyframe (`animate-kb-tabs-content-in`) that
+                  runs once on mount of the newly-active panel.
+                  `motion-safe:` gates the animation; reduced-motion
+                  users get an instant swap. */}
               <TabsContent
                 value="general"
-                className={cn('flex flex-col', compact ? 'gap-3' : 'gap-5')}
+                className={cn(
+                  'flex flex-col',
+                  compact ? 'gap-3' : 'gap-5',
+                  'motion-safe:animate-kb-tabs-content-in',
+                )}
               >
                 <AuthorField author={current.author} />
                 <CategoryField category={current.category} />
@@ -405,7 +419,10 @@ export function ArticleSettingsPanel({
                 ) : null}
               </TabsContent>
 
-              <TabsContent value="seo">
+              <TabsContent
+                value="seo"
+                className="motion-safe:animate-kb-tabs-content-in"
+              >
                 <SeoTabBody
                   value={toSeoTabValue(current)}
                   onChange={(patch) => update(patch)}

--- a/packages/kb-ui/src/components/content/MetaLengthMeter.stories.tsx
+++ b/packages/kb-ui/src/components/content/MetaLengthMeter.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../tokens.css';
+import { MetaLengthMeter, type MetaLengthVerdict } from './MetaLengthMeter';
+
+/* MetaLengthMeter Playground — iterates every verdict state at the
+ * thresholds that flip the verdict (per the locked algorithm in
+ * MetaLengthMeter.tsx). Meta title (max 70) on the left, description
+ * (max 160) on the right. */
+
+const meta: Meta<typeof MetaLengthMeter> = {
+  title: 'Components/Article/Meta Length Meter',
+  component: MetaLengthMeter,
+  parameters: { layout: 'padded' },
+  globals: { backgrounds: { value: 'white' } },
+};
+export default meta;
+
+type Row = { count: number; verdict: MetaLengthVerdict };
+
+const TITLE_ROWS: Row[] = [
+  { count: 12, verdict: 'short' },
+  { count: 42, verdict: 'acceptable' },
+  { count: 55, verdict: 'optimal' },
+  { count: 64, verdict: 'long' },
+  { count: 78, verdict: 'hard-cap' },
+];
+
+const DESC_ROWS: Row[] = [
+  { count: 40, verdict: 'short' },
+  { count: 112, verdict: 'acceptable' },
+  { count: 142, verdict: 'optimal' },
+  { count: 158, verdict: 'long' },
+  { count: 188, verdict: 'hard-cap' },
+];
+
+function MetaLengthMeterPlayground() {
+  return (
+    <div className="flex flex-col gap-6 font-sans" style={{ maxWidth: 480 }}>
+      <section className="flex flex-col gap-2">
+        <h3 className="text-[13px] font-semibold leading-[19px] text-text-primary">
+          Meta title (max 70)
+        </h3>
+        {TITLE_ROWS.map((r) => (
+          <div key={r.verdict} className="flex items-center justify-between gap-3">
+            <span className="text-[12px] font-medium leading-[18px] text-text-muted">
+              {r.verdict}
+            </span>
+            <MetaLengthMeter count={r.count} max={70} verdict={r.verdict} />
+          </div>
+        ))}
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <h3 className="text-[13px] font-semibold leading-[19px] text-text-primary">
+          Description (max 160)
+        </h3>
+        {DESC_ROWS.map((r) => (
+          <div key={r.verdict} className="flex items-center justify-between gap-3">
+            <span className="text-[12px] font-medium leading-[18px] text-text-muted">
+              {r.verdict}
+            </span>
+            <MetaLengthMeter count={r.count} max={160} verdict={r.verdict} />
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}
+
+export const Playground: StoryObj<typeof MetaLengthMeter> = {
+  render: () => <MetaLengthMeterPlayground />,
+};

--- a/packages/kb-ui/src/components/content/MetaLengthMeter.tsx
+++ b/packages/kb-ui/src/components/content/MetaLengthMeter.tsx
@@ -1,0 +1,152 @@
+import * as React from 'react';
+import { cn } from '../../utils/cn';
+
+/* ─────────────────────────────────────────────────────────────
+ * MetaLengthMeter — pure presentational length+verdict pill for
+ * the SEO panel's Meta title / Description fields.
+ *
+ * Renders inline: `{count} / {max}  ·  {Verdict label}` where the
+ * verdict label takes a verdict-keyed color and the rest is muted.
+ *
+ * Verdict computation lives in the consumer (SeoTabBody) — this
+ * component just renders the prop. The locked algorithm (Meta
+ * title 70 / Description 160 thresholds; +1 AI bump) is documented
+ * in the SeoTabBody source.
+ *
+ * Color palette (Figma 2949:7844):
+ *   - optimal       → --color-success-text (#086e3f) — green
+ *   - acceptable    → #d97706 — amber. NO kb-ui token for amber
+ *                     (token sweep candidate; see code comment).
+ *   - short/long/   → --color-trend-down (#d52c1f) — red
+ *     hard-cap
+ *
+ * Static — no motion, no internal state.
+ * ───────────────────────────────────────────────────────────── */
+
+export type MetaLengthVerdict =
+  | 'short'
+  | 'acceptable'
+  | 'optimal'
+  | 'long'
+  | 'hard-cap';
+
+export type MetaLengthMeterProps = {
+  count: number;
+  max: number;
+  verdict: MetaLengthVerdict;
+  className?: string;
+};
+
+const VERDICT_LABEL: Record<MetaLengthVerdict, string> = {
+  short: 'Short',
+  acceptable: 'Acceptable',
+  optimal: 'Optimal',
+  long: 'Long',
+  // Hard-cap visually reads as "Too long" — distinct from soft "Long"
+  // so users know overflow is genuinely problematic.
+  'hard-cap': 'Too long',
+};
+
+const VERDICT_CLASS: Record<MetaLengthVerdict, string> = {
+  // Reuses --color-success-text — same green as addition badges.
+  optimal: 'text-success-text',
+  // Amber. No `text-amber-*` token in kb-ui (token sweep candidate:
+  // promote `#d97706` to e.g. --color-warning-text when a second
+  // amber consumer lands).
+  acceptable: 'text-[#d97706]',
+  // Reuses --color-trend-down — same red as removal/down trend.
+  short: 'text-trend-down',
+  long: 'text-trend-down',
+  'hard-cap': 'text-trend-down',
+};
+
+export function MetaLengthMeter({
+  count,
+  max,
+  verdict,
+  className,
+}: MetaLengthMeterProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 text-[12px] font-normal leading-[18px] tabular-nums',
+        className,
+      )}
+      aria-live="polite"
+    >
+      <span className="text-text-muted">
+        {count} / {max}
+      </span>
+      <span className="text-text-muted" aria-hidden="true">
+        ·
+      </span>
+      <span className={VERDICT_CLASS[verdict]}>{VERDICT_LABEL[verdict]}</span>
+    </span>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * computeMetaLengthVerdict — shared helper for callers that want
+ * the locked verdict algorithm without re-implementing it.
+ *
+ * Algorithm (locked — see chunk-3 brief):
+ *   META TITLE (max 70):
+ *     0–29:   short
+ *     30–49:  acceptable
+ *     50–60:  optimal
+ *     61–70:  long
+ *     >70:    hard-cap
+ *
+ *   DESCRIPTION (max 160):
+ *     0–99:   short
+ *     100–119: acceptable
+ *     120–155: optimal
+ *     156–160: long
+ *     >160:   hard-cap
+ *
+ *   AI bump: when `aiRefinedAt` is set AND the user hasn't typed
+ *   since (caller passes `bumpToOptimal=true`), bump the verdict
+ *   one step towards optimal:
+ *     acceptable → optimal
+ *     short → acceptable
+ *     long → acceptable
+ *     hard-cap → long
+ *     optimal stays optimal
+ *
+ * The caller decides whether the bump is active. We don't take
+ * `aiRefinedAt` directly because the staleness check (did the user
+ * type after the refine?) is store-state, not derivable from this
+ * pure function.
+ * ───────────────────────────────────────────────────────────── */
+
+export function computeMetaLengthVerdict({
+  count,
+  field,
+  aiBumpActive = false,
+}: {
+  count: number;
+  field: 'metaTitle' | 'description';
+  aiBumpActive?: boolean;
+}): MetaLengthVerdict {
+  let v: MetaLengthVerdict;
+  if (field === 'metaTitle') {
+    if (count <= 29) v = 'short';
+    else if (count <= 49) v = 'acceptable';
+    else if (count <= 60) v = 'optimal';
+    else if (count <= 70) v = 'long';
+    else v = 'hard-cap';
+  } else {
+    if (count <= 99) v = 'short';
+    else if (count <= 119) v = 'acceptable';
+    else if (count <= 155) v = 'optimal';
+    else if (count <= 160) v = 'long';
+    else v = 'hard-cap';
+  }
+  if (!aiBumpActive) return v;
+  // Single-step bump towards optimal.
+  if (v === 'acceptable') return 'optimal';
+  if (v === 'short') return 'acceptable';
+  if (v === 'long') return 'acceptable';
+  if (v === 'hard-cap') return 'long';
+  return v;
+}

--- a/packages/kb-ui/src/components/content/MetaLengthMeter.tsx
+++ b/packages/kb-ui/src/components/content/MetaLengthMeter.tsx
@@ -20,7 +20,14 @@ import { cn } from '../../utils/cn';
  *   - short/long/   → --color-trend-down (#d52c1f) — red
  *     hard-cap
  *
- * Static — no motion, no internal state.
+ * Motion (per emil-design-eng — "prevent jarring changes"):
+ *   - The verdict word color transitions over 200ms ease-out so
+ *     that rapid typing across threshold boundaries doesn't strobe
+ *     red → amber → green. The 200ms duration is slow enough to
+ *     read as a smooth gradient between adjacent verdicts, fast
+ *     enough not to lag behind the typist's next keystroke.
+ *   - `motion-safe`-gated. Reduced-motion users see instant
+ *     color swaps (which is the prior behavior).
  * ───────────────────────────────────────────────────────────── */
 
 export type MetaLengthVerdict =
@@ -80,7 +87,17 @@ export function MetaLengthMeter({
       <span className="text-text-muted" aria-hidden="true">
         ·
       </span>
-      <span className={VERDICT_CLASS[verdict]}>{VERDICT_LABEL[verdict]}</span>
+      <span
+        className={cn(
+          VERDICT_CLASS[verdict],
+          // 200ms ease-out color crossfade. The verdict word reads
+          // as a smooth fade between adjacent states rather than a
+          // hard snap as the user types across thresholds.
+          'motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-out',
+        )}
+      >
+        {VERDICT_LABEL[verdict]}
+      </span>
     </span>
   );
 }

--- a/packages/kb-ui/src/components/content/SeoTabBody.tsx
+++ b/packages/kb-ui/src/components/content/SeoTabBody.tsx
@@ -1,0 +1,446 @@
+import * as React from 'react';
+import * as Tooltip from '@radix-ui/react-tooltip';
+import { ChevronDown, ChevronUp, Copy01, InfoCircle } from '@untitledui/icons';
+import { cn } from '../../utils/cn';
+import { Field } from '../primitives/Field';
+import { TextInput } from '../primitives/TextInput';
+import { Textarea } from '../primitives/Textarea';
+import { Switch } from '../primitives/Switch';
+import { CodeChip } from '../primitives/CodeChip';
+import {
+  MetaLengthMeter,
+  computeMetaLengthVerdict,
+  type MetaLengthVerdict,
+} from './MetaLengthMeter';
+
+/* ─────────────────────────────────────────────────────────────
+ * SeoTabBody — the SEO tab body of `ArticleSettingsPanel`.
+ *
+ * Renders the 5 SEO sections in order:
+ *   1. Meta title          (TextInput + MetaLengthMeter, max 70)
+ *   2. Description         (Textarea + MetaLengthMeter, max 160)
+ *   3. URL                 (read-only TextInput + copy button)
+ *   4. Advanced disclosure (collapsible canonical URL override)
+ *   5. Exclude toggle      (Switch + helper paragraph w/ CodeChips)
+ *
+ * Figma references:
+ *   - 2949:7844 — default state
+ *   - 2949:8306 — canonical URL disclosure expanded
+ *   - 2949:9407 — exclude toggle ON
+ *
+ * Chunk 3 scope: static fields only. The "✦ Refine with AI"
+ * affordance on Description (chunk 5) and the Google SERP preview
+ * card (chunk 4) are intentionally NOT rendered here.
+ *
+ * Verdict algorithm + AI bump logic lives in `MetaLengthMeter.ts`
+ * (`computeMetaLengthVerdict`). This component owns the "is the AI
+ * bump still active?" staleness check via a ref-tracked
+ * `aiRefinedAt` watermark: the bump applies while
+ * `aiRefinedAt === lastSeenAiRefinedAt` (no keystrokes since the
+ * refine landed). The next keystroke advances the watermark and
+ * clears the bump.
+ *
+ * The component is fully controlled — every field flows through
+ * `onChange`. Parents adapt store actions to the patch shape.
+ * ───────────────────────────────────────────────────────────── */
+
+export type SeoTabBodyValue = {
+  metaTitle?: string;
+  metaDescription?: string;
+  /** Base URL, e.g. "help.hiverhq.com". Drives the auto-generated
+   *  URL field. */
+  urlBase?: string;
+  /** Article slug — appears at the end of the auto-URL. */
+  slug?: string;
+  /** Category path crumbs — e.g. ["getting-started"]. Appear
+   *  between urlBase and slug in the auto-URL. */
+  categoryPath?: string[];
+  /** When non-empty, the canonical override card is opened by
+   *  default. */
+  canonicalUrl?: string;
+  excludeFromSearch?: boolean;
+  /** Ms timestamp of the last AI refine. When set AND the user has
+   *  not typed since (this component tracks staleness internally),
+   *  the verdict gets a +1 bump towards optimal. */
+  aiRefinedAt?: number;
+};
+
+export type SeoTabBodyProps = {
+  value: SeoTabBodyValue;
+  onChange: (patch: Partial<SeoTabBodyValue>) => void;
+  /** Optional callback when the URL copy button is clicked. Demo
+   *  shells dispatch a toast here. */
+  onCopyUrl?: (url: string) => void;
+  /** Optional callback when the canonical-override copy button is
+   *  clicked. */
+  onCopyCanonical?: (url: string) => void;
+  className?: string;
+};
+
+const META_TITLE_MAX = 70;
+const META_DESC_MAX = 160;
+
+const META_TITLE_TOOLTIP =
+  'The title that appears in search engine results and browser tabs. Aim for 50–60 characters.';
+const META_DESC_TOOLTIP =
+  'A short summary shown under the title in search results. Aim for 120–155 characters.';
+const URL_TOOLTIP =
+  'The web address where this article will be published, derived from your article slug.';
+const EXCLUDE_TOOLTIP =
+  'When enabled, this article won\'t appear in Google, Bing, or other search results.';
+
+/* ─────────────────────────────────────────────────────────────
+ * Helpers
+ * ───────────────────────────────────────────────────────────── */
+
+function buildAutoUrl(value: SeoTabBodyValue): string {
+  const base = value.urlBase?.trim() ?? '';
+  const path = (value.categoryPath ?? []).filter(Boolean).join('/');
+  const slug = value.slug?.trim() ?? '';
+  const parts = [base, path, slug].filter(Boolean);
+  return parts.join('/');
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Copy-suffix button — reused by the URL field + canonical
+ * override field.
+ * ───────────────────────────────────────────────────────────── */
+
+function CopyButton({
+  url,
+  onCopy,
+  ariaLabel,
+}: {
+  url: string;
+  onCopy?: (url: string) => void;
+  ariaLabel: string;
+}) {
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      navigator.clipboard.writeText(url).catch(() => {
+        /* clipboard errors are non-fatal here — demo still shows the
+           toast via the callback. */
+      });
+    }
+    onCopy?.(url);
+  };
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label={ariaLabel}
+      className={cn(
+        'inline-flex h-6 w-6 items-center justify-center rounded-[4px]',
+        'text-text-muted hover:text-text-primary hover:bg-surface-muted',
+        'transition-colors',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-border-faint',
+      )}
+    >
+      <Copy01 size={14} aria-hidden="true" />
+    </button>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Advanced disclosure — collapsible canonical URL override.
+ *
+ * Reveal motion: 220ms `grid-template-rows: 0fr → 1fr` per the
+ * FileExplorerNav pattern. `motion-reduce:transition-none` for
+ * a11y. The disclosure auto-opens when `canonicalUrl` is already
+ * populated on mount (controlled toggle thereafter).
+ * ───────────────────────────────────────────────────────────── */
+
+const DISCLOSURE_EASE_OUT = 'cubic-bezier(0.23, 1, 0.32, 1)';
+const DISCLOSURE_DURATION_MS = 220;
+
+function CanonicalOverrideDisclosure({
+  canonicalUrl,
+  onChange,
+  onCopy,
+}: {
+  canonicalUrl: string;
+  onChange: (next: string) => void;
+  onCopy?: (url: string) => void;
+}) {
+  // Auto-open if already populated; otherwise default closed.
+  const [open, setOpen] = React.useState(() => canonicalUrl.trim() !== '');
+  const inputId = React.useId();
+  const panelId = React.useId();
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-controls={panelId}
+        className={cn(
+          'inline-flex items-center gap-1.5 self-start text-[13px] font-normal leading-[19px]',
+          'text-text-muted hover:text-text-secondary transition-colors',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-border-faint rounded-[4px]',
+        )}
+      >
+        <span>Advanced : override canonical URL</span>
+        {open ? (
+          <ChevronUp size={14} aria-hidden="true" className="text-text-muted" />
+        ) : (
+          <ChevronDown size={14} aria-hidden="true" className="text-text-muted" />
+        )}
+      </button>
+
+      <div
+        id={panelId}
+        style={{
+          display: 'grid',
+          gridTemplateRows: open ? '1fr' : '0fr',
+          transition: `grid-template-rows ${DISCLOSURE_DURATION_MS}ms ${DISCLOSURE_EASE_OUT}`,
+        }}
+        className="motion-reduce:transition-none"
+      >
+        <div style={{ overflow: 'hidden', minHeight: 0 }}>
+          {/* Inset sub-surface — lighter bg + slate border + 12px radius.
+              Padding consistent w/ the panel's 14px field rhythm. */}
+          <div className="flex flex-col gap-2 rounded-[12px] border border-card-border bg-[#fcfcfc] p-3">
+            <TextInput
+              id={inputId}
+              value={canonicalUrl}
+              onChange={(e) => onChange(e.target.value)}
+              placeholder="https://example.com/canonical-url"
+              suffix={
+                <CopyButton
+                  url={canonicalUrl}
+                  onCopy={onCopy}
+                  ariaLabel="Copy canonical URL"
+                />
+              }
+            />
+            <p className="text-[12px] font-normal leading-[18px] text-text-muted">
+              Use this when the same content lives on another domain you own
+              (e.g. a developer docs site). Leave empty to use the
+              auto-generated URL.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Main component
+ * ───────────────────────────────────────────────────────────── */
+
+export function SeoTabBody({
+  value,
+  onChange,
+  onCopyUrl,
+  onCopyCanonical,
+  className,
+}: SeoTabBodyProps) {
+  const metaTitle = value.metaTitle ?? '';
+  const metaDescription = value.metaDescription ?? '';
+  const autoUrl = buildAutoUrl(value);
+  const excluded = value.excludeFromSearch ?? false;
+
+  // AI bump staleness watermark. The bump is active as long as the
+  // user has not typed since the refine landed — i.e. the current
+  // `aiRefinedAt` matches our tracked watermark. Any onChange call
+  // advances the watermark (set during the update flow below), which
+  // clears the bump until the next refine.
+  //
+  // We use a ref + state so the bump's visual effect re-renders when
+  // the watermark changes, while the watermark itself doesn't trigger
+  // its own update.
+  const [aiBumpStaleAt, setAiBumpStaleAt] = React.useState<number | undefined>(
+    undefined,
+  );
+  const aiBumpActive =
+    value.aiRefinedAt !== undefined && value.aiRefinedAt !== aiBumpStaleAt;
+
+  // Patches that mutate the user-edited text fields invalidate the AI
+  // bump. Patches that don't (e.g. excludeFromSearch toggle) leave it
+  // alone.
+  const handlePatchWithBumpInvalidation = (patch: Partial<SeoTabBodyValue>) => {
+    if (
+      Object.prototype.hasOwnProperty.call(patch, 'metaTitle') ||
+      Object.prototype.hasOwnProperty.call(patch, 'metaDescription')
+    ) {
+      // Mark current refine timestamp stale — subsequent renders will
+      // see aiBumpActive === false until a fresh refine comes in.
+      if (value.aiRefinedAt !== undefined && value.aiRefinedAt !== aiBumpStaleAt) {
+        setAiBumpStaleAt(value.aiRefinedAt);
+      }
+    }
+    onChange(patch);
+  };
+
+  const titleVerdict: MetaLengthVerdict = computeMetaLengthVerdict({
+    count: metaTitle.length,
+    field: 'metaTitle',
+    aiBumpActive,
+  });
+  const descVerdict: MetaLengthVerdict = computeMetaLengthVerdict({
+    count: metaDescription.length,
+    field: 'description',
+    aiBumpActive,
+  });
+
+  const titleHardCap = metaTitle.length > META_TITLE_MAX;
+  const descHardCap = metaDescription.length > META_DESC_MAX;
+
+  const metaTitleId = React.useId();
+  const metaDescId = React.useId();
+  const urlId = React.useId();
+
+  return (
+    <div className={cn('flex flex-col gap-5', className)}>
+      {/* ── 1. Meta title ─────────────────────────────────────── */}
+      <Field
+        label="Meta title"
+        tooltip={META_TITLE_TOOLTIP}
+        htmlFor={metaTitleId}
+        hintEnd={
+          <MetaLengthMeter
+            count={metaTitle.length}
+            max={META_TITLE_MAX}
+            verdict={titleVerdict}
+          />
+        }
+      >
+        <TextInput
+          id={metaTitleId}
+          value={metaTitle}
+          onChange={(e) =>
+            handlePatchWithBumpInvalidation({ metaTitle: e.target.value })
+          }
+          placeholder="Search, filter, and create email views"
+          error={titleHardCap}
+        />
+      </Field>
+
+      {/* ── 2. Description ───────────────────────────────────── */}
+      <Field
+        label="Description"
+        tooltip={META_DESC_TOOLTIP}
+        htmlFor={metaDescId}
+        hintEnd={
+          <MetaLengthMeter
+            count={metaDescription.length}
+            max={META_DESC_MAX}
+            verdict={descVerdict}
+          />
+        }
+      >
+        <Textarea
+          id={metaDescId}
+          value={metaDescription}
+          onChange={(e) =>
+            handlePatchWithBumpInvalidation({ metaDescription: e.target.value })
+          }
+          placeholder="Brief description of this article (shown in search results)"
+          error={descHardCap}
+          initialHeight={80}
+          resize="vertical"
+        />
+      </Field>
+
+      {/* ── 3. URL (read-only + copy) ────────────────────────── */}
+      <Field label="URL" tooltip={URL_TOOLTIP} htmlFor={urlId}>
+        <TextInput
+          id={urlId}
+          value={autoUrl}
+          readOnly
+          suffix={
+            <CopyButton
+              url={autoUrl}
+              onCopy={onCopyUrl}
+              ariaLabel="Copy URL"
+            />
+          }
+        />
+      </Field>
+
+      {/* ── 4. Advanced : override canonical URL ─────────────── */}
+      <CanonicalOverrideDisclosure
+        canonicalUrl={value.canonicalUrl ?? ''}
+        onChange={(next) => onChange({ canonicalUrl: next })}
+        onCopy={onCopyCanonical}
+      />
+
+      {/* ── 5. Exclude from search engines ───────────────────── */}
+      <div className="flex flex-col gap-2">
+        <ExcludeFromSearchRow
+          checked={excluded}
+          onChange={(next) => onChange({ excludeFromSearch: next })}
+        />
+        <p className="text-[12px] font-normal leading-[18px] text-text-muted">
+          When enabled, this article will include{' '}
+          <CodeChip>noindex</CodeChip> and <CodeChip>nofollow</CodeChip> and
+          will not appear in Google, Bing, or other search results.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * ExcludeFromSearchRow — label-on-left + tooltip + Switch-on-right.
+ *
+ * The Field primitive renders label+input vertically with the
+ * tooltip in a separate row, so we re-implement the label+tooltip
+ * cluster here to keep label and Switch on the same horizontal
+ * row. Visual chrome is byte-identical to Field's label cluster
+ * (same font sizes, same InfoCircle button, same tooltip portal).
+ * ───────────────────────────────────────────────────────────── */
+
+function ExcludeFromSearchRow({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  const id = React.useId();
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <div className="flex items-center gap-1">
+        <label
+          htmlFor={id}
+          className="text-[14px] font-medium leading-5 text-text-primary"
+        >
+          Exclude from search engines
+        </label>
+        <Tooltip.Provider delayDuration={150}>
+          <Tooltip.Root>
+            <Tooltip.Trigger asChild>
+              <button
+                type="button"
+                aria-label="More information"
+                className="inline-flex items-center text-text-disabled outline-none focus-visible:text-text-meta"
+              >
+                <InfoCircle size={14} aria-hidden="true" />
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content
+                side="top"
+                sideOffset={6}
+                className="z-50 max-w-xs rounded-md bg-text-primary px-2 py-1 text-[12px] leading-[18px] text-white shadow-md"
+              >
+                {EXCLUDE_TOOLTIP}
+                <Tooltip.Arrow className="fill-text-primary" />
+              </Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        </Tooltip.Provider>
+      </div>
+      <Switch
+        id={id}
+        checked={checked}
+        onCheckedChange={onChange}
+        aria-label="Exclude from search engines"
+      />
+    </div>
+  );
+}

--- a/packages/kb-ui/src/components/content/index.ts
+++ b/packages/kb-ui/src/components/content/index.ts
@@ -15,6 +15,16 @@ export type {
   ArticleSettingsPerson,
   ArticleSettingsSection,
 } from './ArticleSettingsPanel';
+export { SeoTabBody } from './SeoTabBody';
+export type { SeoTabBodyProps, SeoTabBodyValue } from './SeoTabBody';
+export {
+  MetaLengthMeter,
+  computeMetaLengthVerdict,
+} from './MetaLengthMeter';
+export type {
+  MetaLengthMeterProps,
+  MetaLengthVerdict,
+} from './MetaLengthMeter';
 export {
   FieldLabel,
   FieldBox,

--- a/packages/kb-ui/src/components/primitives/Switch.tsx
+++ b/packages/kb-ui/src/components/primitives/Switch.tsx
@@ -10,25 +10,52 @@ import { cn } from '../../utils/cn';
  * Built on @radix-ui/react-switch for keyboard + ARIA semantics
  * (role="switch", aria-checked, Space/Enter toggles).
  *
- * Sizing (measured from Figma):
+ * Sizing (re-measured from synced Figma 32×16 PNG, both states):
  *  - Track: 32 × 16, fully rounded (radius 8px = half-height)
- *  - Knob:  12 × 12, ~2px inset
- *  - Travel: ~16px (left:2.4 → left:17.8)
+ *  - Knob:  12 × 12
+ *  - Inset: 2px top, 2px bottom, ~2.2px right (ON), ~2.4px left (OFF)
+ *  - Travel: 15.4px (left:2.4 → left:17.8). Rounded to 15px for
+ *    crisp sub-pixel rendering — at 1×, 15.4px translates to a
+ *    fractional offset that browsers smooth with anti-aliasing
+ *    and reads slightly mushy. 15px lands the knob inside Figma's
+ *    2.2px right inset (32 - 15 - 12 = 5 ≠ 2.2 — wait, that's
+ *    wrong; the travel of 15px puts the right edge of the knob
+ *    at 2+15+12=29, inset 3px). Going with 16px to match Figma
+ *    more faithfully (right inset 2 = 32 - (2+16+12)).
+ *  - Knob position is set via absolute `left` so it's independent
+ *    of the track's flex centering (which Radix's `items-center`
+ *    would otherwise apply). We use `top: 2px` to match Figma
+ *    exactly and avoid sub-pixel float from flexbox math.
  *
- * Colors:
- *  - Off track: #edf1f6 (background/neutral/default in Figma).
- *    The closest kb-ui token is --color-border-faint (#cbd5e1)
- *    which reads too dark — we use an inline color to match.
- *    A token sweep could later promote #edf1f6 to a named token
- *    if more components need it.
- *  - On track: black (--color-btn-primary)
- *  - Knob: white
+ * Colors (from Figma `background/neutral/default` + `background/black/adaptive`):
+ *  - Off track: #edf1f6 (Figma's `--background/neutral/default`).
+ *    No exact match in kb-ui's color tokens — kept inline; a token
+ *    sweep could promote it later.
+ *  - On track:  black (matches Figma `--background/black/adaptive`).
+ *  - Knob:      white, with a subtle shadow that doesn't bleed
+ *    past the track on either edge.
  *
- * Motion: 200ms bg-color + transform with the strong ease-out
- * curve, `motion-safe`-gated. Press feedback via
- * `motion-safe:active:scale-[0.97]` on the track, mirroring
- * Button's :active behavior.
+ * Motion (per emil-design-eng — toggle = "decisive flip"):
+ *  - Knob travel: 160ms with a slight overshoot curve
+ *    `cubic-bezier(0.34, 1.4, 0.64, 1)`. Snappier than the prior
+ *    200ms strong ease-out, and the overshoot lands the knob
+ *    against its destination edge with a confident "thunk" instead
+ *    of a soft glide.
+ *  - Track bg crossfade: 140ms strong ease-out — slightly faster
+ *    than the knob travel so the destination color is ready when
+ *    the knob arrives.
+ *  - Press feedback: `active:scale-[0.97]` over 100ms — instant
+ *    enough to feel like the UI heard the click.
+ *  - All `motion-safe`-gated; reduced-motion users get end-state
+ *    with no transitions.
  * ───────────────────────────────────────────────────────────── */
+
+const SWITCH_EASE_OUT = 'cubic-bezier(0.23, 1, 0.32, 1)';
+// Mild overshoot curve — peaks at ~1.04 then settles. Gives the
+// knob a confident "thunk" against the destination edge instead
+// of a soft glide. Lower than a true bouncy spring so it still
+// reads as polished, not playful.
+const SWITCH_KNOB_CURVE = 'cubic-bezier(0.34, 1.4, 0.64, 1)';
 
 export type SwitchProps = React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>;
 
@@ -40,12 +67,15 @@ export const Switch = React.forwardRef<
     ref={ref}
     disabled={disabled}
     style={{
-      transition:
-        'background-color 200ms cubic-bezier(0.23, 1, 0.32, 1), transform 120ms cubic-bezier(0.23, 1, 0.32, 1)',
+      // bg crossfade lands slightly ahead of the knob travel (140
+      // vs 160ms) so the destination color is ready when the knob
+      // arrives. Press scale is 100ms — instant-feeling.
+      transition: `background-color 140ms ${SWITCH_EASE_OUT}, transform 100ms ${SWITCH_EASE_OUT}`,
     }}
     className={cn(
-      // Track. Figma: 32×16, rounded-full, off bg #edf1f6, on bg black.
-      'relative inline-flex h-4 w-8 shrink-0 cursor-pointer items-center rounded-full',
+      // Track. Figma: 32×16, rounded-full. Off bg #edf1f6 (Figma
+      // `--background/neutral/default`); on bg black.
+      'relative inline-block h-4 w-8 shrink-0 cursor-pointer rounded-full',
       'bg-[#edf1f6] data-[state=checked]:bg-black',
       'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-faint focus-visible:ring-offset-1',
       !disabled && 'motion-safe:active:scale-[0.97]',
@@ -56,13 +86,19 @@ export const Switch = React.forwardRef<
   >
     <SwitchPrimitive.Thumb
       style={{
-        transition: 'transform 200ms cubic-bezier(0.23, 1, 0.32, 1)',
+        // Knob travel uses the overshoot curve for the "decisive
+        // flip". 160ms is in emil's 150–180ms snappy band for
+        // toggles. Absolute positioning + `translate-x` keeps the
+        // knob's vertical center on a fixed `top: 2px` so flexbox
+        // sub-pixel math can never push it off-axis.
+        transition: `transform 160ms ${SWITCH_KNOB_CURVE}`,
       }}
       className={cn(
-        // Knob. Figma: 12×12, white, soft shadow, sits 2px from
-        // edges. Translate to ~16px on checked (32 - 12 - 2*2 = 16).
-        'pointer-events-none block size-3 rounded-full bg-white shadow-sm',
-        'translate-x-0.5 data-[state=checked]:translate-x-[18px]',
+        // Knob: 12×12, absolute-positioned at `left: 2px, top: 2px`
+        // (matches Figma's OFF state). On checked: translate-x 16px
+        // lands the knob with a 2px right inset (32 - 2 - 16 - 12 = 2).
+        'pointer-events-none absolute left-[2px] top-[2px] block size-3 rounded-full bg-white shadow-sm',
+        'translate-x-0 data-[state=checked]:translate-x-4',
       )}
     />
   </SwitchPrimitive.Root>

--- a/packages/kb-ui/src/components/primitives/Tabs.tsx
+++ b/packages/kb-ui/src/components/primitives/Tabs.tsx
@@ -12,13 +12,15 @@ import { cn } from '../../utils/cn';
  * with white "lifted" active trigger — radix exposes
  * `data-state="active|inactive"` which we style against.
  *
- * Motion: the active trigger crossfades its bg/shadow over 150ms
- * with the strong ease-out curve (matches Button's transition
- * vocabulary). Transform isn't animated — Radix mounts each
- * trigger statically, so a CSS sliding "indicator" would require
- * a measured-rect approach that's out of scope for chunk 1.
- * `motion-safe:` gates the transition; reduced-motion users get
- * an instant state swap.
+ * Motion (per emil-design-eng audit): the active trigger
+ * crossfades bg/shadow over 150ms with the strong ease-out curve.
+ * Considered a measured-rect sliding indicator (Vercel/Linear
+ * style) but for a 2-tab pill, the crossfade reads as restrained
+ * and consistent with the rest of the kb-ui motion vocabulary
+ * (Button, Switch). A sliding indicator would also add a measure
+ * pass + ResizeObserver per consumer — overkill for the SEO
+ * panel's single use. `motion-safe:` gates the transition;
+ * reduced-motion users get an instant state swap.
  * ───────────────────────────────────────────────────────────── */
 
 export type TabsProps = React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root>;

--- a/packages/kb-ui/src/components/primitives/TextInput.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/TextInput.stories.tsx
@@ -12,15 +12,42 @@ const meta: Meta<typeof TextInput> = {
 export default meta;
 
 function TextInputPlayground() {
-  const [value, setValue] = useState('');
+  const [a, setA] = useState('');
+  const [b, setB] = useState('Search, filter, and create email views & other things');
 
   return (
-    <div className="w-80 font-sans">
-      <TextInput
-        placeholder="Enter value..."
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-      />
+    <div className="flex flex-col gap-4 font-sans w-80">
+      <div className="flex flex-col gap-1">
+        <span className="text-[13px] font-medium leading-[19px] text-text-primary">
+          Default
+        </span>
+        <TextInput
+          placeholder="Enter value..."
+          value={a}
+          onChange={(e) => setA(e.target.value)}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <span className="text-[13px] font-medium leading-[19px] text-text-primary">
+          Error variant — border flips to red (#dc2626)
+        </span>
+        <TextInput
+          value={b}
+          onChange={(e) => setB(e.target.value)}
+          error
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <span className="text-[13px] font-medium leading-[19px] text-text-primary">
+          Read-only — used by the SEO panel's URL field
+        </span>
+        <TextInput
+          value="help.hiverhq.com/getting-started/setting-up-shared-inboxes"
+          readOnly
+        />
+      </div>
     </div>
   );
 }

--- a/packages/kb-ui/src/components/primitives/TextInput.tsx
+++ b/packages/kb-ui/src/components/primitives/TextInput.tsx
@@ -8,6 +8,13 @@ export type TextInputProps = {
   suffix?: React.ReactNode;
   charCount?: { current: number; max: number };
   disabled?: boolean;
+  /** When true the input renders read-only (no focus border on click,
+   *  not user-editable). Used by the SEO panel's URL field. */
+  readOnly?: boolean;
+  /** When true the input border flips to red. Used by the SEO panel
+   *  when the meta-title/description exceeds its hard cap (Honey-DS
+   *  6322:25311). Default false. */
+  error?: boolean;
   id?: string;
   name?: string;
   className?: string;
@@ -25,6 +32,8 @@ export function TextInput({
   suffix,
   charCount,
   disabled,
+  readOnly,
+  error,
   id,
   name,
   className,
@@ -33,7 +42,10 @@ export function TextInput({
   return (
     <div
       className={cn(
-        'flex h-10 items-center gap-1.5 overflow-hidden rounded-lg border border-[#e5e5e5] bg-white px-3 py-2',
+        'flex h-10 items-center gap-1.5 overflow-hidden rounded-lg border bg-white px-3 py-2',
+        // Border swaps to red on error (Honey-DS 6322:25311 — #dc2626).
+        // Default neutral border (#e5e5e5) preserved when error is false.
+        error ? 'border-[#dc2626]' : 'border-[#e5e5e5]',
         disabled && 'opacity-50 cursor-not-allowed',
         className,
       )}
@@ -47,8 +59,11 @@ export function TextInput({
         onChange={onChange}
         placeholder={placeholder}
         disabled={disabled}
+        readOnly={readOnly}
+        aria-invalid={error || undefined}
         className={cn(
           'min-w-0 flex-1 border-0 bg-transparent p-0 text-[14px] font-normal leading-5 text-text-primary outline-none placeholder:text-text-disabled disabled:cursor-not-allowed',
+          readOnly && 'cursor-default',
           inputClassName,
         )}
       />

--- a/packages/kb-ui/src/components/primitives/Textarea.tsx
+++ b/packages/kb-ui/src/components/primitives/Textarea.tsx
@@ -6,6 +6,9 @@ export type TextareaProps = {
   placeholder?: string;
   charCount?: { current: number; max: number };
   disabled?: boolean;
+  /** When true the textarea border flips to red. Same pattern as
+   *  TextInput.error (Honey-DS 6322:25311 — #dc2626). */
+  error?: boolean;
   id?: string;
   name?: string;
   /** Initial height in pixels. Default 80. */
@@ -15,6 +18,9 @@ export type TextareaProps = {
   className?: string;
   /** Override classes applied to the inner <textarea>. */
   textareaClassName?: string;
+  /** Optional slot rendered at the bottom-right inside the textarea
+   *  shell (e.g. the SEO panel's "✦ Refine with AI" affordance). */
+  footerEnd?: React.ReactNode;
 };
 
 const resizeClassMap: Record<NonNullable<TextareaProps['resize']>, string> = {
@@ -30,17 +36,20 @@ export function Textarea({
   placeholder,
   charCount,
   disabled,
+  error,
   id,
   name,
   initialHeight = 80,
   resize = 'vertical',
   className,
   textareaClassName,
+  footerEnd,
 }: TextareaProps) {
   return (
     <div
       className={cn(
-        'flex flex-col gap-1.5 overflow-hidden rounded-lg border border-[#e2e8f0] bg-white px-3 py-2',
+        'flex flex-col gap-1.5 overflow-hidden rounded-lg border bg-white px-3 py-2',
+        error ? 'border-[#dc2626]' : 'border-[#e2e8f0]',
         disabled && 'opacity-50 cursor-not-allowed',
         className,
       )}
@@ -52,6 +61,7 @@ export function Textarea({
         onChange={onChange}
         placeholder={placeholder}
         disabled={disabled}
+        aria-invalid={error || undefined}
         style={{ minHeight: `${initialHeight}px` }}
         className={cn(
           'min-w-0 flex-1 border-0 bg-transparent p-0 text-[14px] font-normal leading-5 text-text-primary outline-none placeholder:text-text-muted disabled:cursor-not-allowed',
@@ -59,11 +69,14 @@ export function Textarea({
           textareaClassName,
         )}
       />
-      {charCount && (
-        <div className="flex justify-end">
-          <span className="shrink-0 text-[12px] font-normal leading-[18px] text-text-muted tabular-nums">
-            {charCount.current}/{charCount.max}
-          </span>
+      {(charCount || footerEnd) && (
+        <div className="flex items-center justify-end gap-2">
+          {charCount && (
+            <span className="shrink-0 text-[12px] font-normal leading-[18px] text-text-muted tabular-nums">
+              {charCount.current}/{charCount.max}
+            </span>
+          )}
+          {footerEnd}
         </div>
       )}
     </div>

--- a/packages/kb-ui/src/tokens.css
+++ b/packages/kb-ui/src/tokens.css
@@ -377,6 +377,23 @@ html {
     animation: kb-suggestion-mount 220ms var(--ease-out-strong);
   }
 
+  /* TabsContent mount-in — fires when Radix mounts the newly-active
+   * TabsContent panel (Radix unmounts inactive panels by default, so
+   * the panel is fresh on every state flip). 150ms opacity-only fade
+   * prevents the hard snap without slowing perceived speed. Strong
+   * ease-out curve; gated by `motion-safe:` at call site. */
+  @keyframes kb-tabs-content-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  .animate-kb-tabs-content-in {
+    animation: kb-tabs-content-in 150ms var(--ease-out-strong);
+  }
+
   /* AI Gaps — collapsed decision chip enter.
    * Fires when an AIGapSuggestionCard flips into its `accepted` or
    * `dismissed` chip after the user's decision. Gentle "settle" —


### PR DESCRIPTION
Chunk 3 of 5 — SEO static fields. No AI refine affordance, no SERP preview yet (chunks 4 + 5).

## What's new
- `MetaLengthMeter` + `computeMetaLengthVerdict` — locked algorithm (title 50-60 = Optimal, desc 120-155 = Optimal, +1 AI bump that clears on next keystroke).
- `TextInput` / `Textarea`: `error` prop (red border, `#dc2626` per Honey-DS `6322:25311`); `TextInput.readOnly` for the URL field.
- `SeoTabBody` composes the 5 SEO sections — Meta title / Description / URL (read-only + copy) / Advanced canonical disclosure (220ms grid-template-rows reveal) / Exclude toggle with `noindex`/`nofollow` CodeChips.
- `ArticleSettingsPanel`: SEO tab wired; `ArticleSettings` extended with the 7 new SEO fields; `onCopyUrl` / `onCopyCanonical` callbacks for demo toast wiring.
- Demo: `seoTitle → metaTitle` rename across types + 18 fixtures; `excludeFromSearch: false` seeded everywhere; new reducer cases; `EditorPage` adapter builds `categoryPath` from ancestors and hardcodes `urlBase: help.hiverhq.com`.

## Verification
- `npm run --workspace=packages/kb-ui typecheck` → 0
- `npm run --workspace=packages/kb-ui build` → 0
- `npm run --workspace=packages/kb-ui build-storybook` → 0
- `npm run --workspace=apps/demo typecheck` → 0
- `npm run --workspace=apps/demo build` → 0
- Demo dev boot OK; Playwright captured 4 screenshots (default / canonical open / exclude ON / hard-cap red).

## Out of scope (next chunks)
- Chunk 4: Google SERP preview card + "no preview available" empty state.
- Chunk 5: `✦ Refine with AI` affordance inside the Description textarea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)