### PR TITLE
feat(kb-ui): Refine-with-AI affordance + skeleton motion (chunk 5/5 of SEO panel)

### DIFF
--- a/apps/demo/src/lib/refineDescriptionMock.ts
+++ b/apps/demo/src/lib/refineDescriptionMock.ts
@@ -1,0 +1,44 @@
+// Phase 7.5 chunk-5 — Mock AI service for the SEO panel's
+// "✦ Refine with AI" affordance on the description textarea.
+//
+// The real product wires `onRefineDescription` to a remote LLM call;
+// the demo ships a deterministic mock that:
+//   - Waits 1500ms to feel like a real network round-trip
+//   - Returns one of a handful of Hiver-flavoured copy variants
+//   - Picks the variant deterministically off the input string's
+//     length, so refreshing on localhost yields the same output
+//     for the same input (no flicker / no demo-day surprises).
+//
+// Used by `apps/demo/src/routes/kb/EditorPage.tsx` via
+// `<ArticleSettingsPanel onRefineDescription={refineDescription}>`.
+
+const CANNED_REFINEMENT_TEMPLATES: ReadonlyArray<string> = [
+  'Step-by-step guide to setting up shared inboxes in Hiver — invite teammates, configure routing rules, and resolve common access issues.',
+  'Configure Hiver to handle support inboxes shared across your team. Covers permissions, routing, and access management for shared mailboxes.',
+  'Set up your first Hiver shared inbox in under five minutes. Walkthrough covers team invites, assignments, and access-error troubleshooting.',
+  'Get your team collaborating in shared Gmail inboxes with Hiver. Includes onboarding, routing rules, and resolving permission errors quickly.',
+  'Onboard your team to shared inboxes in Hiver — from invites to assignment routing — with answers to the access errors that come up first.',
+] as const;
+
+/** Simulated network latency in milliseconds. Tuned to feel like a
+ *  real LLM call without making the demo feel sluggish. */
+const REFINE_LATENCY_MS = 1500;
+
+/**
+ * Pretend to refine the description via an AI service. Resolves to
+ * one of the canned variants after a 1500ms delay. The variant choice
+ * is deterministic on input length so refreshing on localhost yields
+ * the same result for the same input.
+ *
+ * The chunk-5 contract:
+ *   - Always resolves (no rejections from this mock — the SEO panel's
+ *     error path is wired but not demoed here).
+ *   - The resolved string is shorter than 160 chars, so it lands in
+ *     the Optimal verdict band given the aiRefinedAt bump.
+ */
+export async function refineDescription(current: string): Promise<string> {
+  await new Promise((resolve) => setTimeout(resolve, REFINE_LATENCY_MS));
+  const len = current?.length ?? 0;
+  const idx = len % CANNED_REFINEMENT_TEMPLATES.length;
+  return CANNED_REFINEMENT_TEMPLATES[idx];
+}

--- a/apps/demo/src/routes/kb/EditorPage.tsx
+++ b/apps/demo/src/routes/kb/EditorPage.tsx
@@ -58,6 +58,7 @@ import {
 import { useUnsavedChangesGuard } from '../../hooks/useUnsavedChangesGuard';
 import { useToast } from '../../components/Toast';
 import { ConfirmDialog } from '@test-kb-ui/kb-ui';
+import { refineDescription } from '../../lib/refineDescriptionMock';
 
 /* ─────────────────────────────────────────────────────────────
  * Constants
@@ -361,6 +362,14 @@ function EditorPageBody({ article }: { article: Article }) {
     [showToast],
   );
 
+  // Toast wiring for the SEO panel's Refine-with-AI failure path.
+  // The mock service never rejects, but a real backend will — this
+  // is the error sink for that case.
+  const handleRefineError = useCallback(
+    (message: string) => showToast(message, 'error'),
+    [showToast],
+  );
+
   const handleSaveAsDraft = useCallback(() => {
     justSavedRef.current = true;
     dispatch({
@@ -565,6 +574,8 @@ function EditorPageBody({ article }: { article: Article }) {
             onChange={handleSettingsChange}
             onCopyUrl={handleCopyUrl}
             onCopyCanonical={handleCopyUrl}
+            onRefineDescription={refineDescription}
+            onToastError={handleRefineError}
             compact
           />
         </div>

--- a/packages/kb-ui/src/components/content/ArticleSettingsPanel.tsx
+++ b/packages/kb-ui/src/components/content/ArticleSettingsPanel.tsx
@@ -113,6 +113,23 @@ export type ArticleSettingsPanelProps = {
    * Same as `onCopyUrl`, but for the canonical-URL override field.
    */
   onCopyCanonical?: (url: string) => void;
+  /**
+   * Optional async hook to "refine" the SEO description via an AI
+   * service. When supplied, the SEO tab renders a "✦ Refine with AI"
+   * affordance pinned to the bottom-right of the Description textarea.
+   * Clicking it disables the CTA, replaces the textarea with a
+   * shimmer skeleton, and on resolve patches `metaDescription` +
+   * `aiRefinedAt`. Errors are surfaced via `onToastError`.
+   *
+   * Forwarded as-is to `<SeoTabBody>`.
+   */
+  onRefineDescription?: (currentDescription: string) => Promise<string>;
+  /**
+   * Optional error toast hook for the Refine-with-AI flow. kb-ui
+   * ships no toast primitive, so the demo wires this to its own
+   * toast system.
+   */
+  onToastError?: (message: string) => void;
 };
 
 // Figma `53:8464` shows the slug counter reading `14/32` — the slug field
@@ -255,6 +272,8 @@ export function ArticleSettingsPanel({
   footerSlot,
   onCopyUrl,
   onCopyCanonical,
+  onRefineDescription,
+  onToastError,
 }: ArticleSettingsPanelProps) {
   const [collapsed, setCollapsed] = React.useState(defaultCollapsed);
   // Tabs are panel-internal for now (chunk 2). If a future chunk needs
@@ -428,6 +447,8 @@ export function ArticleSettingsPanel({
                   onChange={(patch) => update(patch)}
                   onCopyUrl={onCopyUrl}
                   onCopyCanonical={onCopyCanonical}
+                  onRefineDescription={onRefineDescription}
+                  onToastError={onToastError}
                 />
               </TabsContent>
             </Tabs>

--- a/packages/kb-ui/src/components/content/SeoTabBody.tsx
+++ b/packages/kb-ui/src/components/content/SeoTabBody.tsx
@@ -376,10 +376,14 @@ export function SeoTabBody({
     onChange(patch);
   };
 
+  // Only Description has a Refine-with-AI path, so only its verdict
+  // is eligible for the +1 bump. The Meta title's verdict ignores
+  // `aiBumpActive` — otherwise refining the description would also
+  // bump the title's verdict, which is a scope leak across fields.
   const titleVerdict: MetaLengthVerdict = computeMetaLengthVerdict({
     count: metaTitle.length,
     field: 'metaTitle',
-    aiBumpActive,
+    aiBumpActive: false,
   });
   const descVerdict: MetaLengthVerdict = computeMetaLengthVerdict({
     count: metaDescription.length,

--- a/packages/kb-ui/src/components/content/SeoTabBody.tsx
+++ b/packages/kb-ui/src/components/content/SeoTabBody.tsx
@@ -7,6 +7,7 @@ import { TextInput } from '../primitives/TextInput';
 import { Textarea } from '../primitives/Textarea';
 import { Switch } from '../primitives/Switch';
 import { CodeChip } from '../primitives/CodeChip';
+import { AiIcon } from '../brand/AiIcon';
 import {
   MetaLengthMeter,
   computeMetaLengthVerdict,
@@ -78,6 +79,28 @@ export type SeoTabBodyProps = {
   /** Optional callback when the canonical-override copy button is
    *  clicked. */
   onCopyCanonical?: (url: string) => void;
+  /**
+   * Optional async hook to "refine" the description via an AI service.
+   * The current description is passed in; the resolved string replaces
+   * the description and a fresh `aiRefinedAt` timestamp is written via
+   * `onChange` (which bumps the verdict +1 toward optimal until the
+   * user types again).
+   *
+   * When this prop is undefined the "✦ Refine with AI" CTA is not
+   * rendered — the description renders as a plain Textarea. Consumers
+   * (e.g. apps/demo) supply this via a mock or real service.
+   *
+   * Errors thrown from the promise are surfaced via `onToastError` if
+   * provided; otherwise they are logged via `console.warn` and the
+   * description is left untouched.
+   */
+  onRefineDescription?: (currentDescription: string) => Promise<string>;
+  /**
+   * Optional error toast hook. Used when `onRefineDescription` rejects.
+   * kb-ui ships no toast primitive, so this is the demo's wiring seam.
+   * The implementation receives a short user-facing message.
+   */
+  onToastError?: (message: string) => void;
   className?: string;
 };
 
@@ -237,11 +260,83 @@ function CanonicalOverrideDisclosure({
  * Main component
  * ───────────────────────────────────────────────────────────── */
 
+/* ─────────────────────────────────────────────────────────────
+ * RefineWithAIButton — private to the SEO panel (no premature
+ * abstraction per emil-design-eng: ship inside the consumer first
+ * and extract only when a second caller materializes).
+ *
+ * Visual (Figma 2949:7886 → 2949:8109):
+ *   - 4-point AI sparkle (magenta→peach gradient via `AiIcon`)
+ *     + "Refine with AI" text.
+ *   - 12px sparkle, 13px text, weight 400, color `text-muted`
+ *     (#475569). No background, no border — sits flush against
+ *     the textarea body.
+ *   - On `disabled`, the wrapper opacity-50s. The parent Textarea
+ *     ALSO dims the slot via pointer-events-none + opacity-50, so
+ *     the button can stay visually neutral while refining and we
+ *     don't double-dim.
+ *
+ * Motion (per emil-design-eng — "buttons must feel responsive"):
+ *   - `:active` scale-down 0.97 with a 160ms ease-out transition.
+ *     Gates behind `motion-safe:`.
+ *   - Color transition on hover/focus (200ms ease) for the muted
+ *     → primary text crossfade.
+ * ───────────────────────────────────────────────────────────── */
+
+function RefineWithAIButton({
+  onClick,
+  disabled,
+}: {
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label="Refine description with AI"
+      data-kb-part="refine-with-ai-button"
+      className={cn(
+        'inline-flex items-center gap-1 px-0 py-0.5',
+        // No background. Text reads as a muted CTA; rgb #475569
+        // matches Figma 2949:7888 (text/neutral/subtle).
+        'text-[13px] font-normal leading-[19px] text-text-secondary',
+        // Hover/focus crossfade to primary, 200ms ease (color only).
+        'hover:text-text-primary focus-visible:text-text-primary',
+        'motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-linear',
+        // Responsive press feedback. 160ms ease-out scale-down 0.97
+        // gives the CTA a tactile feel without overshooting.
+        'motion-safe:transition-transform motion-safe:duration-150 motion-safe:ease-out',
+        'active:scale-[0.97]',
+        // Focus ring — uses the same faint outline as CopyButton
+        // for visual consistency across the SEO panel.
+        'rounded-[4px] focus:outline-none focus-visible:ring-2 focus-visible:ring-border-faint',
+        // When the consumer passes `disabled`, the underlying
+        // <button> ignores clicks AND the wrapper dims. The parent
+        // Textarea ALSO dims (opacity-50 + pointer-events-none) via
+        // the `refining` flag, so visually they compose to a single
+        // dim layer (50% × 1.0 = 50%, not 25%).
+        disabled && 'cursor-default',
+      )}
+    >
+      <AiIcon size={12} aria-hidden="true" className="shrink-0" />
+      <span>Refine with AI</span>
+    </button>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Main component
+ * ───────────────────────────────────────────────────────────── */
+
 export function SeoTabBody({
   value,
   onChange,
   onCopyUrl,
   onCopyCanonical,
+  onRefineDescription,
+  onToastError,
   className,
 }: SeoTabBodyProps) {
   const metaTitle = value.metaTitle ?? '';
@@ -299,6 +394,100 @@ export function SeoTabBody({
   const metaDescId = React.useId();
   const urlId = React.useId();
 
+  /* ── Refine-with-AI in-flight state ─────────────────────────
+   * Local: tracks whether `onRefineDescription` is currently
+   * resolving. Drives:
+   *   - Textarea `refining` (Skeleton overlay + readOnly)
+   *   - RefineWithAIButton disabled (prevents re-fire)
+   *   - MetaLengthMeter freeze (renders last-known count+verdict,
+   *     does NOT recompute while the content is shimmering)
+   *
+   * The freeze is critical for perceived correctness: if the meter
+   * recomputed against the live `value.metaDescription` (which is
+   * stale during the refine — we haven't called onChange yet) the
+   * user would see the verdict jiggle as the skeleton shimmers.
+   * Worse: if a parent prematurely cleared the description while
+   * refining was true, the meter would flash to "Short / red" mid-
+   * flight, then snap back to a fresh verdict when the AI lands.
+   *
+   * `frozenMeterRef` captures the count+verdict snapshot at the
+   * moment refining flips true. We render the snapshot via the
+   * `hintEnd` slot while refining; once refining flips false we
+   * resume rendering live values (which now reflect the AI patch).
+   */
+  const [refining, setRefining] = React.useState(false);
+  const frozenMeterRef = React.useRef<{
+    count: number;
+    verdict: MetaLengthVerdict;
+  } | null>(null);
+
+  // Capture the snapshot one render BEFORE the Textarea starts
+  // showing the Skeleton. We do this synchronously inside the
+  // handleRefine callback so the snapshot reflects the pre-click
+  // state, not whatever React might land on the next render.
+  const handleRefine = React.useCallback(async () => {
+    if (!onRefineDescription || refining) return;
+    // Freeze the meter at the pre-refine state so it doesn't
+    // recompute while the Skeleton is animating.
+    frozenMeterRef.current = {
+      count: metaDescription.length,
+      verdict: descVerdict,
+    };
+    setRefining(true);
+    try {
+      const newText = await onRefineDescription(metaDescription);
+      // Land the new text + bump the verdict via `aiRefinedAt`.
+      // We bypass `handlePatchWithBumpInvalidation` here — that
+      // helper clears the AI bump on metaDescription patches, but
+      // THIS patch is the bump itself. Reset the staleness
+      // watermark so `aiBumpActive` evaluates to true on the very
+      // next render.
+      setAiBumpStaleAt(undefined);
+      onChange({ metaDescription: newText, aiRefinedAt: Date.now() });
+    } catch (err) {
+      // Surface the error to the demo's toast layer if wired;
+      // otherwise log + keep the original text in place.
+      const message = "Couldn't refine. Try again.";
+      if (onToastError) {
+        onToastError(message);
+      } else if (typeof console !== 'undefined' && console.warn) {
+        console.warn('[SeoTabBody] refineDescription failed:', err);
+      }
+    } finally {
+      // Clear refining + drop the snapshot. The hintEnd slot
+      // re-renders against fresh live values on the next render.
+      setRefining(false);
+      frozenMeterRef.current = null;
+    }
+  }, [
+    onRefineDescription,
+    refining,
+    metaDescription,
+    descVerdict,
+    onChange,
+    onToastError,
+  ]);
+
+  // While refining, the meter renders the snapshot. Otherwise it
+  // renders live values. This is a pure render-time switch — no
+  // extra state.
+  const liveDescMeter = (
+    <MetaLengthMeter
+      count={metaDescription.length}
+      max={META_DESC_MAX}
+      verdict={descVerdict}
+    />
+  );
+  const frozenDescMeter = frozenMeterRef.current ? (
+    <MetaLengthMeter
+      count={frozenMeterRef.current.count}
+      max={META_DESC_MAX}
+      verdict={frozenMeterRef.current.verdict}
+    />
+  ) : (
+    liveDescMeter
+  );
+
   return (
     <div className={cn('flex flex-col gap-5', className)}>
       {/* ── 1. Meta title ─────────────────────────────────────── */}
@@ -330,13 +519,7 @@ export function SeoTabBody({
         label="Description"
         tooltip={META_DESC_TOOLTIP}
         htmlFor={metaDescId}
-        hintEnd={
-          <MetaLengthMeter
-            count={metaDescription.length}
-            max={META_DESC_MAX}
-            verdict={descVerdict}
-          />
-        }
+        hintEnd={refining ? frozenDescMeter : liveDescMeter}
       >
         <Textarea
           id={metaDescId}
@@ -348,6 +531,15 @@ export function SeoTabBody({
           error={descHardCap}
           initialHeight={80}
           resize="vertical"
+          refining={refining}
+          refineSlot={
+            onRefineDescription ? (
+              <RefineWithAIButton
+                onClick={handleRefine}
+                disabled={refining}
+              />
+            ) : undefined
+          }
         />
       </Field>
 

--- a/packages/kb-ui/src/components/primitives/Textarea.stories.tsx
+++ b/packages/kb-ui/src/components/primitives/Textarea.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import '../../tokens.css';
 import { Textarea } from './Textarea';
+import { AiIcon } from '../brand/AiIcon';
 
 const meta: Meta<typeof Textarea> = {
   title: 'Components/Primitives/Textarea',
@@ -40,10 +41,113 @@ function TextareaWithoutCounter() {
   );
 }
 
+/* ─────────────────────────────────────────────────────────────
+ * Chunk-5 stories — the SEO panel's Refine-with-AI affordance
+ * lives on top of these two Textarea features:
+ *
+ *   1. `refining`   — content fades out, content-aware Skeleton
+ *                     overlay fades in (matches the textarea's
+ *                     last-measured height — no layout jump).
+ *   2. `refineSlot` — pinned bottom-right CTA inside the textarea
+ *                     frame. Dims to opacity-50 while refining.
+ * ───────────────────────────────────────────────────────────── */
+
+function RefineCTA({ onClick, disabled }: { onClick: () => void; disabled?: boolean }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="inline-flex items-center gap-1 rounded-[4px] px-0 py-0.5 text-[13px] font-normal leading-[19px] text-text-secondary hover:text-text-primary focus-visible:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-border-faint motion-safe:transition-transform motion-safe:duration-150 motion-safe:ease-out active:scale-[0.97]"
+      aria-label="Refine with AI"
+    >
+      <AiIcon size={12} aria-hidden="true" className="shrink-0" />
+      <span>Refine with AI</span>
+    </button>
+  );
+}
+
+function TextareaWithRefineSlot() {
+  const [value, setValue] = useState(
+    'default description filled by defaults and is default due to default reasons',
+  );
+  return (
+    <div className="w-96 font-sans">
+      <Textarea
+        placeholder="Brief description of this article (shown in search results)"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        refineSlot={<RefineCTA onClick={() => undefined} />}
+      />
+    </div>
+  );
+}
+
+function TextareaRefining() {
+  // Refining is forced on; the slot dims, the Skeleton overlay
+  // shimmers, the textarea contents are hidden.
+  return (
+    <div className="w-96 font-sans">
+      <Textarea
+        placeholder="Brief description of this article (shown in search results)"
+        value={'default description filled by defaults and is default due to default reasons'}
+        refining
+        refineSlot={<RefineCTA onClick={() => undefined} disabled />}
+      />
+    </div>
+  );
+}
+
+function TextareaRefiningRoundtrip() {
+  // End-to-end demo: click the CTA, wait 1500ms, contents swap.
+  const [value, setValue] = useState(
+    'default description filled by defaults and is default due to default reasons',
+  );
+  const [refining, setRefining] = useState(false);
+
+  const handleRefine = () => {
+    if (refining) return;
+    setRefining(true);
+    window.setTimeout(() => {
+      setValue(
+        'Step-by-step guide to setting up shared inboxes in Hiver — invite teammates, configure routing rules, and resolve common access issues.',
+      );
+      setRefining(false);
+    }, 1500);
+  };
+
+  return (
+    <div className="flex w-96 flex-col gap-2 font-sans">
+      <Textarea
+        placeholder="Brief description of this article (shown in search results)"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        refining={refining}
+        refineSlot={<RefineCTA onClick={handleRefine} disabled={refining} />}
+      />
+      <p className="text-[12px] leading-[18px] text-text-muted">
+        Click "Refine with AI" — wait 1500ms — new copy lands with a soft fade.
+      </p>
+    </div>
+  );
+}
+
 export const Playground: StoryObj<typeof Textarea> = {
   render: () => <TextareaPlayground />,
 };
 
 export const WithoutCounter: StoryObj<typeof Textarea> = {
   render: () => <TextareaWithoutCounter />,
+};
+
+export const WithRefineSlot: StoryObj<typeof Textarea> = {
+  render: () => <TextareaWithRefineSlot />,
+};
+
+export const Refining: StoryObj<typeof Textarea> = {
+  render: () => <TextareaRefining />,
+};
+
+export const RefineRoundtrip: StoryObj<typeof Textarea> = {
+  render: () => <TextareaRefiningRoundtrip />,
 };

--- a/packages/kb-ui/src/components/primitives/Textarea.tsx
+++ b/packages/kb-ui/src/components/primitives/Textarea.tsx
@@ -1,4 +1,36 @@
+import * as React from 'react';
 import { cn } from '../../utils/cn';
+import { Skeleton } from './Skeleton';
+
+/* ─────────────────────────────────────────────────────────────
+ * Textarea — single-line + multi-line text field used across the
+ * SEO panel, category-description editor, and a few generic forms.
+ *
+ * Public surface (chunks 1-5):
+ *   - value / onChange / placeholder / charCount / disabled / error
+ *   - id / name / initialHeight / resize / className / textareaClassName
+ *   - footerEnd   → bottom row slot rendered alongside charCount.
+ *   - refining    → switches the textarea contents to a content-aware
+ *                   shimmer Skeleton overlay (chunk 5).
+ *   - refineSlot  → pinned bottom-right CTA inside the textarea frame.
+ *                   The slot is rendered above the contents (z-index)
+ *                   and dims to opacity-50 while `refining`.
+ *
+ * Chunk-5 refining state behaviour (per emil-design-eng motion brief):
+ *   1. The textarea's RENDERED height is captured one render BEFORE
+ *      `refining` flips true via a layout effect — Skeleton bars are
+ *      sized to match so there's zero layout jump when shimmer kicks in.
+ *   2. Content fade-out: 100ms opacity 1 → 0 (linear is fine; the eye
+ *      barely sees it). On exit: 150ms opacity 0 → 1 with strong
+ *      ease-out so the new AI text feels like it "lands".
+ *   3. The Skeleton's own shimmer pseudo-element (`kb-skeleton-shimmer`,
+ *      1.6s linear infinite) handles the in-flight loading motion.
+ *   4. Textarea becomes `readOnly` while refining so the user can't
+ *      race the AI service; the underlying value is preserved so an
+ *      error path can restore prior text without losing edits.
+ *   5. `motion-safe:` gates the fade transitions so reduced-motion
+ *      users get instant swaps.
+ * ───────────────────────────────────────────────────────────── */
 
 export type TextareaProps = {
   value?: string;
@@ -21,6 +53,25 @@ export type TextareaProps = {
   /** Optional slot rendered at the bottom-right inside the textarea
    *  shell (e.g. the SEO panel's "✦ Refine with AI" affordance). */
   footerEnd?: React.ReactNode;
+  /**
+   * When true the textarea contents are visually hidden and replaced
+   * with a content-aware shimmer Skeleton overlay. Used by the SEO
+   * panel's "Refine with AI" affordance. While `refining` is true:
+   *   - The native textarea becomes `readOnly` (value is preserved).
+   *   - Contents fade out (100ms) then the Skeleton overlay appears
+   *     sized to the textarea's last-measured height.
+   *   - The slot rendered via `refineSlot` is dimmed to opacity-50
+   *     and made `pointer-events-none` so it can't re-fire.
+   */
+  refining?: boolean;
+  /**
+   * Optional slot pinned at the bottom-right corner INSIDE the
+   * textarea frame (e.g. the SEO panel's "✦ Refine with AI" CTA).
+   * Distinct from `footerEnd` which lives in the bottom-row beneath
+   * the textarea body. Visually anchored via absolute positioning so
+   * it overlays text without consuming layout space.
+   */
+  refineSlot?: React.ReactNode;
 };
 
 const resizeClassMap: Record<NonNullable<TextareaProps['resize']>, string> = {
@@ -44,31 +95,156 @@ export function Textarea({
   className,
   textareaClassName,
   footerEnd,
+  refining = false,
+  refineSlot,
 }: TextareaProps) {
+  /* ── Height measurement ──────────────────────────────────────
+   * We capture the textarea's rendered height the moment BEFORE
+   * `refining` flips true so the Skeleton overlay can match it
+   * exactly. After that we keep the measured height latched until
+   * `refining` flips false — preventing any height jump when the
+   * Skeleton replaces real text. */
+  const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
+  const [measuredHeight, setMeasuredHeight] = React.useState<number | null>(
+    null,
+  );
+  const wasRefiningRef = React.useRef<boolean>(refining);
+
+  React.useLayoutEffect(() => {
+    // Capture height on the render where `refining` becomes true.
+    // The textarea node still exists at this point (it's just
+    // readOnly + opacity-0), so getBoundingClientRect().height
+    // returns its actual visible size.
+    if (refining && !wasRefiningRef.current) {
+      const rect = textareaRef.current?.getBoundingClientRect();
+      if (rect && rect.height > 0) {
+        setMeasuredHeight(rect.height);
+      }
+    }
+    wasRefiningRef.current = refining;
+  }, [refining]);
+
+  // Compute the Skeleton's row count + widths from the latched
+  // height. Each row is 16px tall + 12px gap, so a typical 80px
+  // textarea fits 3 rows (16 + 12 + 16 + 12 + 16 = 72px). For taller
+  // textareas we add more rows up to a sensible cap; for shorter
+  // ones we drop to 2 rows. Last row clamps to 45% to feel naturalistic.
+  const skeletonProps = React.useMemo(() => {
+    const h = measuredHeight ?? initialHeight;
+    // Row pattern: 16px rows + 12px gap. Aim to fill ~85% of the
+    // available height so the bars don't crowd the top/bottom edge.
+    const usable = Math.max(0, h - 8); // leave 8px of breathing room
+    const rowH = 16;
+    const gap = 12;
+    // rows: solve rowH * n + gap * (n - 1) <= usable
+    //   → n <= (usable + gap) / (rowH + gap)
+    const n = Math.max(2, Math.min(4, Math.floor((usable + gap) / (rowH + gap))));
+    const widths: Array<number | string> = [];
+    for (let i = 0; i < n; i++) {
+      widths.push(i === n - 1 ? '45%' : '100%');
+    }
+    return { rows: n, widths, gap, height: rowH };
+  }, [measuredHeight, initialHeight]);
+
   return (
     <div
       className={cn(
-        'flex flex-col gap-1.5 overflow-hidden rounded-lg border bg-white px-3 py-2',
+        // `relative` so the absolute `refineSlot` anchors inside the
+        // outer shell. `overflow-hidden` keeps the shimmer pseudo-
+        // element clipped to the rounded border.
+        'relative flex flex-col gap-1.5 overflow-hidden rounded-lg border bg-white px-3 py-2',
         error ? 'border-[#dc2626]' : 'border-[#e2e8f0]',
         disabled && 'opacity-50 cursor-not-allowed',
         className,
       )}
     >
-      <textarea
-        id={id}
-        name={name}
-        value={value}
-        onChange={onChange}
-        placeholder={placeholder}
-        disabled={disabled}
-        aria-invalid={error || undefined}
-        style={{ minHeight: `${initialHeight}px` }}
-        className={cn(
-          'min-w-0 flex-1 border-0 bg-transparent p-0 text-[14px] font-normal leading-5 text-text-primary outline-none placeholder:text-text-muted disabled:cursor-not-allowed',
-          resizeClassMap[resize],
-          textareaClassName,
+      {/* Stack: the native textarea + the Skeleton overlay sit in the
+          same flex slot. While refining, the textarea fades to 0 and
+          the Skeleton fades in. We DO NOT toggle `display: none` so
+          the textarea retains its layout box (height stays steady). */}
+      <div className="relative min-h-0 flex-1">
+        <textarea
+          ref={textareaRef}
+          id={id}
+          name={name}
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          disabled={disabled}
+          readOnly={refining}
+          aria-invalid={error || undefined}
+          aria-busy={refining || undefined}
+          tabIndex={refining ? -1 : undefined}
+          style={{
+            // While refining, lock to measured height so the Skeleton
+            // overlay can match exactly. Otherwise honour initialHeight.
+            minHeight: `${
+              refining && measuredHeight ? measuredHeight : initialHeight
+            }px`,
+          }}
+          className={cn(
+            'block w-full min-w-0 flex-1 border-0 bg-transparent p-0 text-[14px] font-normal leading-5 text-text-primary outline-none placeholder:text-text-muted disabled:cursor-not-allowed',
+            resizeClassMap[resize],
+            // Fade out the contents on entering refining state.
+            // 100ms opacity 1 → 0 is fast enough to read as "the
+            // text vanished" without flashing through unparsed copy.
+            refining ? 'opacity-0' : 'opacity-100',
+            'motion-safe:transition-opacity motion-safe:duration-100 motion-safe:ease-linear',
+            textareaClassName,
+          )}
+        />
+
+        {refining && (
+          <div
+            /* Skeleton overlay — absolutely positioned over the textarea
+               so it doesn't push layout. Fade-in mirrors the textarea's
+               fade-out: 150ms opacity 0 → 1 with strong ease-out so the
+               shimmer feels like a confident "the AI is working" state
+               rather than a sluggish reveal.
+               The wrapper has `animate-kb-tabs-content-in` (150ms
+               opacity-only fade, strong ease-out) which fires once on
+               mount when refining first kicks in. The Skeleton's own
+               kb-skeleton-shimmer animation handles the in-flight
+               loading sweep at 1.6s linear infinite. */
+            aria-hidden="true"
+            data-kb-part="textarea-refining-overlay"
+            className={cn(
+              'pointer-events-none absolute inset-0 flex items-start',
+              'motion-safe:animate-kb-tabs-content-in',
+            )}
+          >
+            <Skeleton
+              rows={skeletonProps.rows}
+              widths={skeletonProps.widths}
+              gap={skeletonProps.gap}
+              height={skeletonProps.height}
+              radius={4}
+            />
+          </div>
         )}
-      />
+      </div>
+
+      {/* refineSlot — absolutely pinned at the bottom-right corner of
+          the textarea frame. Sits ABOVE the Skeleton overlay (z-10) so
+          it stays interactive (or visibly dimmed) while refining.
+          The 8px inset matches the Figma `#2949:7886` placement. */}
+      {refineSlot && (
+        <div
+          className={cn(
+            'absolute bottom-2 right-2 z-10',
+            // Dim + freeze the slot while refining so the user can't
+            // re-fire the action mid-flight. The slot is responsible
+            // for its own visual treatment; we add a global dim hook
+            // so consumers who don't dim themselves still get the
+            // correct affordance.
+            refining && 'pointer-events-none opacity-50',
+            'motion-safe:transition-opacity motion-safe:duration-150 motion-safe:ease-out',
+          )}
+        >
+          {refineSlot}
+        </div>
+      )}
+
       {(charCount || footerEnd) && (
         <div className="flex items-center justify-end gap-2">
           {charCount && (


### PR DESCRIPTION
## Summary
Chunk 5/5 of the SEO panel build wires the `Refine with AI` affordance on the Description textarea: pinned bottom-right CTA, content-aware skeleton overlay during in-flight refine, frozen length meter while shimmering, and a deterministic mock service in the demo. Description text fades out, Skeleton bars sized to the textarea's measured height shimmer for 1500ms, then the new AI copy fades in. `aiRefinedAt` is set so the meter bumps +1 toward Optimal; the bump clears on the next keystroke.

## Changes
- `Textarea` primitive — new `refining` + `refineSlot` props; height measured one render before refining flips true so the Skeleton overlay matches; 100ms content fade-out, 150ms ease-out fade-in
- `SeoTabBody` — new `onRefineDescription` / `onToastError` props; private `RefineWithAIButton` (AiIcon gradient + muted text + active:scale-[0.97]); MetaLengthMeter freezes against a pre-refine snapshot while refining
- `ArticleSettingsPanel` — forwards the two new props through to `SeoTabBody`
- `apps/demo/src/lib/refineDescriptionMock.ts` — 1500ms async resolver with five Hiver-flavoured canned variants, picked deterministically off input length
- `EditorPage` — wires `refineDescription` + `handleRefineError` (toast variant `'error'`) to the panel
- `Textarea.stories` — `WithRefineSlot`, `Refining`, and `RefineRoundtrip` variants

## Test plan
- [x] `npm run --workspace=packages/kb-ui typecheck` → 0
- [x] `npm run --workspace=packages/kb-ui build` → 0
- [x] `npm run --workspace=packages/kb-ui build-storybook` → 0
- [x] `npm run --workspace=apps/demo typecheck` → 0
- [x] `npm run --workspace=apps/demo build` → 0
- [x] Demo dev boot + Playwright capture of 4 states: idle / refining / refined / bump-cleared

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>