### PR TITLE
SEO panel polish: 6 fixes from user review

### DIFF
--- a/packages/kb-ui/src/components/brand/CompanyLogo.tsx
+++ b/packages/kb-ui/src/components/brand/CompanyLogo.tsx
@@ -5,23 +5,33 @@ export type CompanyLogoProps = React.SVGProps<SVGSVGElement> & {
   size?: number;
   src?: string;
   glyph?: React.ReactNode;
+  /**
+   * Background color of the rounded-rect wrapper / svg fill. Defaults to
+   * `#2D2D2D` (the dark variant used in the app rail). The SERP preview
+   * uses the yellow product favicon variant (`#FEC32A`) — pass that color
+   * explicitly when rendering the Hiver favicon inline with text.
+   */
+  bgColor?: string;
 };
 
 /**
- * Hiver company mark — 24×24 dark rounded rect (#2D2D2D) with the inner
- * Hiver glyph rendered in white. Used in the SideNavRail brand slot.
+ * Hiver company mark — 24×24 rounded rect with the inner Hiver glyph rendered
+ * in white. Default bg `#2D2D2D` (dark variant used in the app rail). Pass
+ * `bgColor="#FEC32A"` to render the yellow product favicon variant used in
+ * the SERP preview (Figma 2949:8003).
  *
  * Source asset: /CompanyLogo.svg (repo root).
  *
  * Override slots (defaults preserved when both are undefined):
- * - `src`: render an <img> inside the dark rounded-rect wrapper.
- * - `glyph`: render arbitrary React content inside the dark rounded-rect wrapper.
+ * - `src`: render an <img> inside the rounded-rect wrapper.
+ * - `glyph`: render arbitrary React content inside the rounded-rect wrapper.
  */
 export function CompanyLogo({
   size = 24,
   className,
   src,
   glyph,
+  bgColor = '#2D2D2D',
   ...rest
 }: CompanyLogoProps) {
   if (typeof src === 'string' && src.length > 0) {
@@ -35,7 +45,7 @@ export function CompanyLogo({
           width: size,
           height: size,
           borderRadius: 4,
-          backgroundColor: '#2D2D2D',
+          backgroundColor: bgColor,
           overflow: 'hidden',
         }}
         aria-hidden="true"
@@ -62,7 +72,7 @@ export function CompanyLogo({
           width: size,
           height: size,
           borderRadius: 4,
-          backgroundColor: '#2D2D2D',
+          backgroundColor: bgColor,
           overflow: 'hidden',
         }}
         aria-hidden="true"
@@ -83,7 +93,7 @@ export function CompanyLogo({
       aria-hidden="true"
       {...rest}
     >
-      <rect width="24" height="24" rx="4" fill="#2D2D2D" />
+      <rect width="24" height="24" rx="4" fill={bgColor} />
       <path
         d="M12.855 11.2344C14.7431 11.2345 16.2739 12.7661 16.2739 14.6543V18.7949C14.3857 18.7949 12.8551 17.2642 12.855 15.376V11.2344ZM7.72607 5.20508C9.61434 5.20508 11.145 6.73575 11.145 8.62402V18.4346C9.25685 18.4345 7.72607 16.9038 7.72607 15.0156V5.20508Z"
         fill="white"

--- a/packages/kb-ui/src/components/content/MetaLengthMeter.tsx
+++ b/packages/kb-ui/src/components/content/MetaLengthMeter.tsx
@@ -58,9 +58,11 @@ const VERDICT_CLASS: Record<MetaLengthVerdict, string> = {
   // Reuses --color-success-text — same green as addition badges.
   optimal: 'text-success-text',
   // Amber. No `text-amber-*` token in kb-ui (token sweep candidate:
-  // promote `#d97706` to e.g. --color-warning-text when a second
-  // amber consumer lands).
-  acceptable: 'text-[#d97706]',
+  // promote `#d55206` to e.g. --color-warning-text when a second
+  // amber consumer lands). #d55206 matches Figma --text/warning/default
+  // (2949:7901). Previously #d97706 — the prior pick was visually
+  // similar but a half-step lighter than Figma.
+  acceptable: 'text-[#d55206]',
   // Reuses --color-trend-down — same red as removal/down trend.
   short: 'text-trend-down',
   long: 'text-trend-down',

--- a/packages/kb-ui/src/components/content/SeoTabBody.tsx
+++ b/packages/kb-ui/src/components/content/SeoTabBody.tsx
@@ -7,6 +7,7 @@ import { TextInput } from '../primitives/TextInput';
 import { Textarea } from '../primitives/Textarea';
 import { Switch } from '../primitives/Switch';
 import { CodeChip } from '../primitives/CodeChip';
+import { Button } from '../primitives/Button';
 import { AiIcon } from '../brand/AiIcon';
 import {
   MetaLengthMeter,
@@ -204,8 +205,11 @@ function CanonicalOverrideDisclosure({
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}
         aria-controls={panelId}
+        // Figma 2949:7932 — 13px font-medium #64758b. Sits flush against
+        // the URL input above (parent column owns the 6px gap), so no
+        // additional top padding here.
         className={cn(
-          'inline-flex items-center gap-1.5 self-start text-[13px] font-normal leading-[19px]',
+          'inline-flex items-center gap-1 self-start px-0.5 text-[13px] font-medium leading-[19px]',
           'text-text-muted hover:text-text-secondary transition-colors',
           'focus:outline-none focus-visible:ring-2 focus-visible:ring-border-faint rounded-[4px]',
         )}
@@ -244,7 +248,7 @@ function CanonicalOverrideDisclosure({
                 />
               }
             />
-            <p className="text-[12px] font-normal leading-[18px] text-text-muted">
+            <p className="text-[13px] font-normal leading-[19px] text-text-muted">
               Use this when the same content lives on another domain you own
               (e.g. a developer docs site). Leave empty to use the
               auto-generated URL.
@@ -261,26 +265,23 @@ function CanonicalOverrideDisclosure({
  * ───────────────────────────────────────────────────────────── */
 
 /* ─────────────────────────────────────────────────────────────
- * RefineWithAIButton — private to the SEO panel (no premature
- * abstraction per emil-design-eng: ship inside the consumer first
- * and extract only when a second caller materializes).
+ * RefineWithAIButton — pinned bottom-right inside the Description
+ * textarea. Built on the Button primitive's `subtle` variant per
+ * user direction so it reads as a real pressable pill (slate-100
+ * background) instead of the prior plain text+icon affordance,
+ * which visually collided with the now-hidden native resize handle.
  *
- * Visual (Figma 2949:7886 → 2949:8109):
- *   - 4-point AI sparkle (magenta→peach gradient via `AiIcon`)
- *     + "Refine with AI" text.
- *   - 12px sparkle, 13px text, weight 400, color `text-muted`
- *     (#475569). No background, no border — sits flush against
- *     the textarea body.
- *   - On `disabled`, the wrapper opacity-50s. The parent Textarea
- *     ALSO dims the slot via pointer-events-none + opacity-50, so
- *     the button can stay visually neutral while refining and we
- *     don't double-dim.
+ * Size override: the default Button is h-8 / px-3 (32×N) — too tall
+ * to sit cleanly inside the textarea's bottom-right inset. We
+ * shrink to h-7 / px-2.5 (28×N) via className so the pill nests
+ * inside the textarea's 8px inset without crowding the text rows
+ * above it. Text size + sparkle size stay on the Button's defaults
+ * so this stays close to the design system.
  *
- * Motion (per emil-design-eng — "buttons must feel responsive"):
- *   - `:active` scale-down 0.97 with a 160ms ease-out transition.
- *     Gates behind `motion-safe:`.
- *   - Color transition on hover/focus (200ms ease) for the muted
- *     → primary text crossfade.
+ * Motion: inherited from Button — `motion-safe:active:scale-[0.97]`
+ * + 120ms strong ease-out transition on transform/colors. Disabled
+ * state (during refining) is handled by Button (opacity-50 +
+ * pointer-events-none).
  * ───────────────────────────────────────────────────────────── */
 
 function RefineWithAIButton({
@@ -291,38 +292,20 @@ function RefineWithAIButton({
   disabled?: boolean;
 }) {
   return (
-    <button
-      type="button"
+    <Button
+      variant="subtle"
       onClick={onClick}
       disabled={disabled}
       aria-label="Refine description with AI"
       data-kb-part="refine-with-ai-button"
-      className={cn(
-        'inline-flex items-center gap-1 px-0 py-0.5',
-        // No background. Text reads as a muted CTA; rgb #475569
-        // matches Figma 2949:7888 (text/neutral/subtle).
-        'text-[13px] font-normal leading-[19px] text-text-secondary',
-        // Hover/focus crossfade to primary, 200ms ease (color only).
-        'hover:text-text-primary focus-visible:text-text-primary',
-        'motion-safe:transition-colors motion-safe:duration-200 motion-safe:ease-linear',
-        // Responsive press feedback. 160ms ease-out scale-down 0.97
-        // gives the CTA a tactile feel without overshooting.
-        'motion-safe:transition-transform motion-safe:duration-150 motion-safe:ease-out',
-        'active:scale-[0.97]',
-        // Focus ring — uses the same faint outline as CopyButton
-        // for visual consistency across the SEO panel.
-        'rounded-[4px] focus:outline-none focus-visible:ring-2 focus-visible:ring-border-faint',
-        // When the consumer passes `disabled`, the underlying
-        // <button> ignores clicks AND the wrapper dims. The parent
-        // Textarea ALSO dims (opacity-50 + pointer-events-none) via
-        // the `refining` flag, so visually they compose to a single
-        // dim layer (50% × 1.0 = 50%, not 25%).
-        disabled && 'cursor-default',
-      )}
+      icon={<AiIcon size={12} aria-hidden="true" />}
+      // Shrink Button's default h-8 / px-3 to h-7 / px-2.5 / text-[13px]
+      // so the pill nests neatly inside the textarea inset (Figma
+      // 2949:7886). Stays a subtle slate-100 pill on the surface.
+      className="h-7 px-2.5 text-[13px] font-medium leading-[19px]"
     >
-      <AiIcon size={12} aria-hidden="true" className="shrink-0" />
-      <span>Refine with AI</span>
-    </button>
+      Refine with AI
+    </Button>
   );
 }
 
@@ -493,7 +476,12 @@ export function SeoTabBody({
   );
 
   return (
-    <div className={cn('flex flex-col gap-5', className)}>
+    // Section-to-section rhythm: 28px (Figma --scale/space/5xl). Sections
+    // that internally span two visual rows (URL + canonical disclosure,
+    // Exclude row + helper text) collapse their internal gap to 8px so
+    // they read as a single unit; the 28px outer gap then separates them
+    // from neighbouring sections at the same beat as every other field.
+    <div className={cn('flex flex-col gap-7', className)}>
       {/* ── 1. Meta title ─────────────────────────────────────── */}
       <Field
         label="Meta title"
@@ -547,36 +535,46 @@ export function SeoTabBody({
         />
       </Field>
 
-      {/* ── 3. URL (read-only + copy) ────────────────────────── */}
-      <Field label="URL" tooltip={URL_TOOLTIP} htmlFor={urlId}>
-        <TextInput
-          id={urlId}
-          value={autoUrl}
-          readOnly
-          suffix={
-            <CopyButton
-              url={autoUrl}
-              onCopy={onCopyUrl}
-              ariaLabel="Copy URL"
-            />
-          }
+      {/* ── 3+4. URL (read-only + copy) and Advanced canonical override
+          live in one column. The disclosure trigger reads as sub-text
+          immediately under the URL input rather than as a standalone
+          section — 6px gap between the URL input and the trigger keeps
+          them visually paired. The outer column gap then separates this
+          pair from the next section at the standard 28px beat. */}
+      <div className="flex flex-col gap-1.5">
+        <Field label="URL" tooltip={URL_TOOLTIP} htmlFor={urlId}>
+          <TextInput
+            id={urlId}
+            value={autoUrl}
+            readOnly
+            suffix={
+              <CopyButton
+                url={autoUrl}
+                onCopy={onCopyUrl}
+                ariaLabel="Copy URL"
+              />
+            }
+          />
+        </Field>
+        <CanonicalOverrideDisclosure
+          canonicalUrl={value.canonicalUrl ?? ''}
+          onChange={(next) => onChange({ canonicalUrl: next })}
+          onCopy={onCopyCanonical}
         />
-      </Field>
-
-      {/* ── 4. Advanced : override canonical URL ─────────────── */}
-      <CanonicalOverrideDisclosure
-        canonicalUrl={value.canonicalUrl ?? ''}
-        onChange={(next) => onChange({ canonicalUrl: next })}
-        onCopy={onCopyCanonical}
-      />
+      </div>
 
       {/* ── 5. Exclude from search engines ───────────────────── */}
-      <div className="flex flex-col gap-2">
+      {/* Inner gap matches every other section's label-to-content beat
+          (Field uses gap-1.5 / 6px). The helper paragraph reads at
+          13px so the inline CodeChips (which are 13px medium) match
+          the surrounding text weight — without this match, the chips
+          look visually larger than their wrapping copy. */}
+      <div className="flex flex-col gap-1.5">
         <ExcludeFromSearchRow
           checked={excluded}
           onChange={(next) => onChange({ excludeFromSearch: next })}
         />
-        <p className="text-[12px] font-normal leading-[18px] text-text-muted">
+        <p className="text-[13px] font-normal leading-[19px] text-text-muted">
           When enabled, this article will include{' '}
           <CodeChip>noindex</CodeChip> and <CodeChip>nofollow</CodeChip> and
           will not appear in Google, Bing, or other search results.

--- a/packages/kb-ui/src/components/content/SerpPreview.tsx
+++ b/packages/kb-ui/src/components/content/SerpPreview.tsx
@@ -49,9 +49,12 @@ export type SerpPreviewProps = {
 };
 
 /* ─────────────────────────────────────────────────────────────
- * Multi-color Google "G" mark — inlined SVG rather than CDN-loaded.
- * Sized 14px to match the Figma header glyph (14×14 outer, 12×12
- * inner). Standard 4-color brand swatches.
+ * Multi-color Google "G" mark — inlined SVG with the full
+ * 0–48 viewBox so all four color quadrants render without edge-
+ * cropping. Default size 14 matches the Figma header glyph
+ * (2949:7984). The previous version used a 0–18 viewBox that
+ * clipped against the path geometry at small sizes, producing a
+ * visibly chopped "G". Standard 4-color brand swatches.
  * ───────────────────────────────────────────────────────────── */
 
 function GoogleGMark({ size = 14 }: { size?: number }) {
@@ -59,26 +62,26 @@ function GoogleGMark({ size = 14 }: { size?: number }) {
     <svg
       width={size}
       height={size}
-      viewBox="0 0 18 18"
+      viewBox="0 0 48 48"
       xmlns="http://www.w3.org/2000/svg"
       aria-hidden="true"
-      style={{ flexShrink: 0 }}
+      style={{ flexShrink: 0, display: 'block' }}
     >
       <path
-        d="M17.64 9.205c0-.639-.057-1.252-.164-1.841H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615Z"
-        fill="#4285F4"
+        fill="#FFC107"
+        d="M43.611 20.083H42V20H24v8h11.303c-1.649 4.657-6.08 8-11.303 8c-6.627 0-12-5.373-12-12s5.373-12 12-12c3.059 0 5.842 1.154 7.961 3.039l5.657-5.657C34.046 6.053 29.268 4 24 4C12.955 4 4 12.955 4 24s8.955 20 20 20s20-8.955 20-20c0-1.341-.138-2.65-.389-3.917z"
       />
       <path
-        d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18Z"
-        fill="#34A853"
+        fill="#FF3D00"
+        d="m6.306 14.691l6.571 4.819C14.655 15.108 18.961 12 24 12c3.059 0 5.842 1.154 7.961 3.039l5.657-5.657C34.046 6.053 29.268 4 24 4C16.318 4 9.656 8.337 6.306 14.691z"
       />
       <path
-        d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332Z"
-        fill="#FBBC05"
+        fill="#4CAF50"
+        d="M24 44c5.166 0 9.86-1.977 13.409-5.192l-6.19-5.238C29.211 35.091 26.715 36 24 36c-5.202 0-9.619-3.317-11.283-7.946l-6.522 5.025C9.505 39.556 16.227 44 24 44z"
       />
       <path
-        d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58Z"
-        fill="#EA4335"
+        fill="#1976D2"
+        d="M43.611 20.083H42V20H24v8h11.303c-.792 2.237-2.231 4.166-4.087 5.571l.003-.002l6.19 5.238C36.971 39.205 44 34 44 24c0-1.341-.138-2.65-.389-3.917z"
       />
     </svg>
   );
@@ -148,8 +151,11 @@ export function SerpPreview({
       <div className="flex w-full flex-col gap-1.5">
         {/* Favicon + breadcrumb URL row */}
         <div className="flex w-full items-center gap-1.5">
-          {/* Hiver's own favicon — 14px to match Figma 2949:8003 */}
-          <CompanyLogo size={14} className="shrink-0" />
+          {/* Hiver's own favicon — yellow product variant `#FEC32A` to match
+              Figma 2949:8003 (which uses `imgHiverLogo`, not the dark app-rail
+              variant). 14×14 wrapper, 14×14 svg — same dimensions as the
+              Google G glyph above so the two icons read at identical weight. */}
+          <CompanyLogo size={14} bgColor="#FEC32A" className="shrink-0" />
           {/* Crumb stack — flex-1 so it can truncate; title-as-crumb
               is the only flex-grow element. */}
           <div className="flex min-w-0 flex-1 items-center gap-0.5">

--- a/packages/kb-ui/src/components/primitives/Textarea.tsx
+++ b/packages/kb-ui/src/components/primitives/Textarea.tsx
@@ -81,6 +81,15 @@ const resizeClassMap: Record<NonNullable<TextareaProps['resize']>, string> = {
   none: 'resize-none',
 };
 
+/* Always hide the native browser resize handle (the diagonal grip at the
+ * bottom-right). The `resize` prop controls user-resize behaviour via the
+ * resize-* utility above; when `resize='vertical'` users can still drag the
+ * textarea taller, the grip just isn't drawn. Removing the grip is critical
+ * inside the SEO panel where it visually collides with the pinned
+ * `refineSlot` button (Figma 2949:7844). */
+const HIDE_NATIVE_RESIZE_GRIP_CLASS =
+  '[&::-webkit-resizer]:hidden';
+
 export function Textarea({
   value,
   onChange,
@@ -185,6 +194,10 @@ export function Textarea({
           className={cn(
             'block w-full min-w-0 flex-1 border-0 bg-transparent p-0 text-[14px] font-normal leading-5 text-text-primary outline-none placeholder:text-text-muted disabled:cursor-not-allowed',
             resizeClassMap[resize],
+            // Hide the native diagonal resize grip (WebKit/Blink).
+            // Drag-to-resize via `resize-y` still works; only the
+            // grip glyph is suppressed. See HIDE_NATIVE_RESIZE_GRIP_CLASS.
+            HIDE_NATIVE_RESIZE_GRIP_CLASS,
             // Fade out the contents on entering refining state.
             // 100ms opacity 1 → 0 is fast enough to read as "the
             // text vanished" without flashing through unparsed copy.


### PR DESCRIPTION
Six concrete defects flagged by the user during localhost review of the merged SEO panel (PRs #108-#112). Single PR, all six fixes verified against Figma 2949:7844.

1. Refine-with-AI affordance rebuilt on the Button primitive (subtle slate pill, h-7); native textarea resize handle hidden via [&::-webkit-resizer]:hidden.
2. Vertical rhythm normalised to 28px between sections (gap-7 — Figma --scale/space/5xl); per-section gaps unified at 6px (Field's gap-1.5).
3. Advanced canonical disclosure now tucks 6px under URL input as a single column, reads as sub-text not a standalone section.
4. Exclude helper paragraph + canonical-disclosure helper bumped from 12px to 13px so inline CodeChips (13px medium) no longer look visually larger than the wrapping text.
5. Google G mark switched from 0-18 to 0-48 viewBox (full multi-color, no edge clipping at 14px); SERP favicon switched to the yellow #FEC32A product variant via new optional bgColor prop on CompanyLogo.
6. Acceptable verdict color aligned from #d97706 to Figma's #d55206.

## Test plan

- [x] tsc clean (kb-ui + demo)
- [x] kb-ui build, demo build, Storybook build-storybook all clean
- [x] Playwright captures: full panel + zoom-in on refine pill, canonical, exclude/helper, SERP icons, refining state mid-flow
- [x] Refine click triggers skeleton overlay (no regression on chunk-5 flow)
- [x] Exclude toggle cross-fades preview to empty state
- [x] Hard-cap (>70) flips meta title border to #dc2626 + "Too long" verdict

Caches cleared before dev-server verification per the per-workspace rule.