### PR TITLE
polish: counter position (Field hint row)

### DIFF
--- a/packages/kb-ui/src/components/primitives/Field.tsx
+++ b/packages/kb-ui/src/components/primitives/Field.tsx
@@ -80,8 +80,8 @@ export function Field({
       )}
       {children}
       {showHintRow && (
-        <div className="flex items-center justify-between gap-2 text-[12px] font-normal leading-[18px] text-text-muted">
-          <span>{hint}</span>
+        <div className="flex items-center justify-start gap-2 text-[12px] font-normal leading-[18px] text-text-muted">
+          {hint !== undefined && <span>{hint}</span>}
           {hintEnd !== undefined && <span>{hintEnd}</span>}
         </div>
       )}


### PR DESCRIPTION
Field hint row now left-aligns to match Figma node 2949-7844 — SEO meta-title counter sits on the left, not the right.