### PR TITLE
polish: kb-ui field labels 14px → 13px medium (global rule)

### DIFF
--- a/packages/kb-ui/src/components/content/ArticleSettingsPanelAtoms.tsx
+++ b/packages/kb-ui/src/components/content/ArticleSettingsPanelAtoms.tsx
@@ -16,7 +16,7 @@ import { cn } from '../../utils/cn';
 
 export function FieldLabel({ children }: { children: React.ReactNode }) {
   return (
-    <label className="text-[14px] font-medium leading-[20px] text-text-primary">
+    <label className="text-[13px] font-medium leading-[19px] text-text-primary">
       {children}
     </label>
   );

--- a/packages/kb-ui/src/components/content/SeoTabBody.tsx
+++ b/packages/kb-ui/src/components/content/SeoTabBody.tsx
@@ -659,7 +659,7 @@ function ExcludeFromSearchRow({
       <div className="flex items-center gap-1">
         <label
           htmlFor={id}
-          className="text-[14px] font-medium leading-5 text-text-primary"
+          className="text-[13px] font-medium leading-[19px] text-text-primary"
         >
           Exclude from search engines
         </label>

--- a/packages/kb-ui/src/components/primitives/Dropdown.tsx
+++ b/packages/kb-ui/src/components/primitives/Dropdown.tsx
@@ -19,7 +19,7 @@ export function Dropdown({
 }: DropdownProps) {
   const trigger = (
     <div className={cn('flex flex-col gap-2', className)}>
-      <label className="text-[14px] font-medium leading-5 text-text-primary">{label}</label>
+      <label className="text-[13px] font-medium leading-[19px] text-text-primary">{label}</label>
       <TextInput
         {...inputProps}
         suffix={<ChevronDown size={14} className="text-text-meta" />}

--- a/packages/kb-ui/src/components/primitives/Field.tsx
+++ b/packages/kb-ui/src/components/primitives/Field.tsx
@@ -41,7 +41,7 @@ export function Field({
           {label !== undefined && (
             <label
               htmlFor={htmlFor}
-              className="text-[14px] font-medium leading-5 text-text-primary"
+              className="text-[13px] font-medium leading-[19px] text-text-primary"
             >
               {label}
               {required && (


### PR DESCRIPTION
## Summary

Global typography rule for field labels: 14px medium → **13px medium / 19px line-height**. This is the kb-ui-only half; demo + Storybook story sweep is a follow-up chunk.

## Files

- `Field.tsx` — primitive Field label
- `Dropdown.tsx` — Dropdown trigger label
- `ArticleSettingsPanelAtoms.tsx` — `FieldLabel` atom (Author/Category/Slug)
- `SeoTabBody.tsx` — `ExcludeFromSearchRow` manual label cluster

Input CONTENT was audited (TextInput, Textarea) and is already 14px regular — no change needed.

## Verification

- `typecheck` 0
- `build` 0
- `build-storybook` 0
- Demo at `/articles/:slug/edit` — General + SEO tabs Playwright-captured; `getComputedStyle()` reports `fontSize: 13px / fontWeight: 500 / lineHeight: 19px` for Author, Category, Meta title, Description, URL, Exclude from search engines

🤖 Generated with [Claude Code](https://claude.com/claude-code)