### PR TITLE
Chunk 12: modal motion under reduce-motion + emil audit (5 items)

### DIFF
--- a/packages/kb-ui/src/components/content/SeoTabBody.tsx
+++ b/packages/kb-ui/src/components/content/SeoTabBody.tsx
@@ -236,8 +236,28 @@ function CopyButton({
  * populated on mount (controlled toggle thereafter).
  * ───────────────────────────────────────────────────────────── */
 
-const DISCLOSURE_EASE_OUT = 'cubic-bezier(0.23, 1, 0.32, 1)';
+// Canonical strong ease-out — wires to `--ease-out-strong` in tokens.css.
+// Chunk 12: dropped the literal `cubic-bezier(...)` in favor of the var
+// so disclosure motion stays in lockstep with the rest of the system.
+const DISCLOSURE_EASE_OUT = 'var(--ease-out-strong)';
 const DISCLOSURE_DURATION_MS = 220;
+
+/* SerpPreview ↔ NoPreviewState crossfade transition (Section 6).
+ *
+ * Inline style instead of an arbitrary Tailwind class because
+ * `transition-property: opacity, filter` needs an explicit comma-
+ * separated list — Tailwind v4's `transition-[a,b]` arbitrary syntax
+ * is ambiguous around comma handling and underscores get rewritten
+ * to spaces, so the inline style is the most predictable surface.
+ *
+ * `motion-reduce:!transition-none` at the call site overrides this
+ * for reduce-motion users, so they get an instant swap (the content
+ * swap is a state change, not navigation — instant is the a11y default). */
+const CROSSFADE_TRANSITION_STYLE: React.CSSProperties = {
+  transitionProperty: 'opacity, filter',
+  transitionDuration: '200ms',
+  transitionTimingFunction: 'var(--ease-out-strong)',
+};
 
 function CanonicalOverrideDisclosure({
   canonicalUrl,
@@ -631,26 +651,63 @@ export function SeoTabBody({
 
       {/* ── 6. Search result live preview ────────────────────── */}
       <Field label="Search result live preview" tooltip={SEARCH_PREVIEW_TOOLTIP}>
-        {/* Keyed wrapper drives the cross-fade: when `excluded` flips,
-            Radix-style remount replays `kb-tabs-content-in` (150ms
-            opacity-only fade, strong ease-out) so the swap reads as
-            a clean fade rather than a snap. Emil's rule: occasional
-            swaps deserve a short, opacity-only animation to prevent
-            jarring changes (motion-safe-gated for a11y). */}
-        <div
-          key={excluded ? 'empty' : 'preview'}
-          className="motion-safe:animate-kb-tabs-content-in"
-        >
-          {excluded ? (
-            <NoPreviewState />
-          ) : (
+        {/* Stable-mount cross-fade between SerpPreview and NoPreviewState.
+            Chunk 12 / emil-design-eng: the previous keyed-remount pattern
+            unmounted one child and re-mounted the other on every flip —
+            which played `kb-tabs-content-in` on the incoming child but
+            left no exit animation on the outgoing one, producing a hard
+            cut from the eye's perspective even though a fade was applied
+            to one side. The textbook crossfade is BOTH children mounted
+            at the same time, with the inactive one absolutely positioned
+            and opacity-0, the active one at opacity-1, both transitioning
+            simultaneously. A `min-h` floor (88px ≈ SerpPreview's natural
+            height) prevents the wrapper from collapsing to the smaller
+            child's height mid-transition. The outgoing child gets a soft
+            `blur(2px)` for textbook crossfade quality — masks the
+            two-objects-overlapping smell without being heavy-handed.
+            All motion is `motion-safe:`-gated; reduce-motion users get
+            an instant swap (this is a content swap, not a navigation, so
+            the a11y default of "no motion" is fine here). */}
+        <div className="relative min-h-[88px]">
+          <div
+            data-kb-part="serp-preview-slot"
+            aria-hidden={excluded || undefined}
+            style={CROSSFADE_TRANSITION_STYLE}
+            className={cn(
+              // Active child takes the layout; inactive is absolute on
+              // top of the same space so they crossfade in place.
+              excluded
+                ? 'pointer-events-none absolute inset-0'
+                : 'relative',
+              'motion-reduce:!transition-none',
+              excluded
+                ? 'opacity-0 motion-safe:blur-[2px]'
+                : 'opacity-100 motion-safe:blur-0',
+            )}
+          >
             <SerpPreview
               title={value.metaTitle}
               description={value.metaDescription}
               baseUrl={value.urlBase}
               breadcrumbPath={value.categoryPath}
             />
-          )}
+          </div>
+          <div
+            data-kb-part="serp-preview-empty-slot"
+            aria-hidden={!excluded || undefined}
+            style={CROSSFADE_TRANSITION_STYLE}
+            className={cn(
+              excluded
+                ? 'relative'
+                : 'pointer-events-none absolute inset-0',
+              'motion-reduce:!transition-none',
+              excluded
+                ? 'opacity-100 motion-safe:blur-0'
+                : 'opacity-0 motion-safe:blur-[2px]',
+            )}
+          >
+            <NoPreviewState />
+          </div>
         </div>
       </Field>
     </div>

--- a/packages/kb-ui/src/components/overlays/Modal.tsx
+++ b/packages/kb-ui/src/components/overlays/Modal.tsx
@@ -254,16 +254,24 @@ export function Modal({
    * uses text-primary/40 wash + z-90 to match the existing demo
    * ConfirmDialog stacking; content sits on z-91.
    *
-   * Motion (Phase D1, emil-design-eng skill):
-   *   - Backdrop: opacity fade — 200ms enter / 140ms exit
+   * Motion (Phase D1 + Chunk 12 reduced-motion fix, emil-design-eng skill):
+   *   - Backdrop: opacity fade — 200ms enter / 140ms exit, `var(--ease-out-strong)`
    *   - Content: scale 0.96 → 1 + opacity fade — 200ms enter / 140ms exit
    *     transform-origin: center (skill confirms modals stay centered)
    *   - Exit faster than enter (close feels snappy, not draggy)
    *   - Keyframes (not transitions) so Radix can suspend unmount via
    *     `animationend` while the exit animation plays out
-   *   - `motion-safe:` gates the animation — reduced-motion users get
-   *     instant mount/unmount (Radix detects no animation and unmounts
-   *     immediately, which is the correct accessible default) */
+   *
+   *   Reduced-motion users (`prefers-reduced-motion: reduce`):
+   *     The previous version relied on `motion-safe:` alone, which suppresses
+   *     the animation entirely and made the modal "stutter into existence"
+   *     (Radix mounts instantly + no opacity fade = hard pop). Emil's rule
+   *     for reduced-motion is to drop *movement* (transforms), not all motion.
+   *     `motion-reduce:` variants apply opacity-only fades (kb-modal-*-reduced
+   *     keyframes in tokens.css) at 100ms enter / 80ms exit so the mount/
+   *     unmount still has a perceptible cushion without any scale or slide.
+   *     Radix detects an animation is running on both code paths, so
+   *     `animationend` correctly suspends unmount in either branch. */
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
@@ -273,6 +281,8 @@ export function Modal({
             'fixed inset-0 z-[90] bg-text-primary/40',
             'motion-safe:data-[state=open]:animate-kb-backdrop-in',
             'motion-safe:data-[state=closed]:animate-kb-backdrop-out',
+            'motion-reduce:data-[state=open]:animate-kb-backdrop-in-reduced',
+            'motion-reduce:data-[state=closed]:animate-kb-backdrop-out-reduced',
           )}
         />
 
@@ -287,6 +297,8 @@ export function Modal({
             'focus:outline-none',
             'motion-safe:data-[state=open]:animate-kb-modal-in',
             'motion-safe:data-[state=closed]:animate-kb-modal-out',
+            'motion-reduce:data-[state=open]:animate-kb-modal-in-reduced',
+            'motion-reduce:data-[state=closed]:animate-kb-modal-out-reduced',
             className,
           )}
           aria-describedby={undefined}

--- a/packages/kb-ui/src/components/primitives/Switch.tsx
+++ b/packages/kb-ui/src/components/primitives/Switch.tsx
@@ -35,12 +35,13 @@ import { cn } from '../../utils/cn';
  *  - Knob:      white, with a subtle shadow that doesn't bleed
  *    past the track on either edge.
  *
- * Motion (per emil-design-eng — toggle = "decisive flip"):
- *  - Knob travel: 160ms with a slight overshoot curve
- *    `cubic-bezier(0.34, 1.4, 0.64, 1)`. Snappier than the prior
- *    200ms strong ease-out, and the overshoot lands the knob
- *    against its destination edge with a confident "thunk" instead
- *    of a soft glide.
+ * Motion (per emil-design-eng — toggle motion vocabulary):
+ *  - Knob travel: 160ms with the canonical `ease-out-strong` curve
+ *    (`cubic-bezier(0.23, 1, 0.32, 1)`). Aligns with the rest of the
+ *    motion vocabulary (overlays, dropdowns, tabs) — chunk 12 dropped
+ *    the prior overshoot curve so all motion in the product speaks the
+ *    same language; the strong ease-out still feels snappy without an
+ *    overshoot-bounce that's hard to mimic across the broader system.
  *  - Track bg crossfade: 140ms strong ease-out — slightly faster
  *    than the knob travel so the destination color is ready when
  *    the knob arrives.
@@ -50,12 +51,14 @@ import { cn } from '../../utils/cn';
  *    with no transitions.
  * ───────────────────────────────────────────────────────────── */
 
+// Canonical strong ease-out curve — matches `--ease-out-strong` in
+// kb-ui's design tokens. Inlined here because the `transition` shorthand
+// is set via the `style` prop and CSS variables aren't reliably resolved
+// inline (Radix's Switch renders into a forwarded ref before style
+// computation), so we mirror the literal value to stay consistent with
+// the rest of the motion vocabulary.
 const SWITCH_EASE_OUT = 'cubic-bezier(0.23, 1, 0.32, 1)';
-// Mild overshoot curve — peaks at ~1.04 then settles. Gives the
-// knob a confident "thunk" against the destination edge instead
-// of a soft glide. Lower than a true bouncy spring so it still
-// reads as polished, not playful.
-const SWITCH_KNOB_CURVE = 'cubic-bezier(0.34, 1.4, 0.64, 1)';
+const SWITCH_KNOB_CURVE = SWITCH_EASE_OUT;
 
 export type SwitchProps = React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>;
 
@@ -86,9 +89,10 @@ export const Switch = React.forwardRef<
   >
     <SwitchPrimitive.Thumb
       style={{
-        // Knob travel uses the overshoot curve for the "decisive
-        // flip". 160ms is in emil's 150–180ms snappy band for
-        // toggles. Absolute positioning + `translate-x` keeps the
+        // Knob travel uses the canonical `ease-out-strong` curve to
+        // stay aligned with the rest of the motion vocabulary (modals,
+        // dropdowns, tabs). 160ms is in emil's 150–180ms snappy band
+        // for toggles. Absolute positioning + `translate-x` keeps the
         // knob's vertical center on a fixed `top: 2px` so flexbox
         // sub-pixel math can never push it off-axis.
         transition: `transform 160ms ${SWITCH_KNOB_CURVE}`,

--- a/packages/kb-ui/src/components/primitives/Textarea.tsx
+++ b/packages/kb-ui/src/components/primitives/Textarea.tsx
@@ -16,19 +16,34 @@ import { Skeleton } from './Skeleton';
  *                   The slot is rendered above the contents (z-index)
  *                   and dims to opacity-50 while `refining`.
  *
- * Chunk-5 refining state behaviour (per emil-design-eng motion brief):
+ * Chunk-5 refining state behaviour (per emil-design-eng motion brief
+ * + chunk-12 exit-phase fix):
  *   1. The textarea's RENDERED height is captured one render BEFORE
  *      `refining` flips true via a layout effect — Skeleton bars are
  *      sized to match so there's zero layout jump when shimmer kicks in.
- *   2. Content fade-out: 100ms opacity 1 → 0 (linear is fine; the eye
- *      barely sees it). On exit: 150ms opacity 0 → 1 with strong
- *      ease-out so the new AI text feels like it "lands".
- *   3. The Skeleton's own shimmer pseudo-element (`kb-skeleton-shimmer`,
+ *   2. Content fade-out (entering refining): 100ms opacity 1 → 0 linear.
+ *      Linear is correct here: the fade fires at the moment of click, so
+ *      the system's response should land deliberately — a fast linear
+ *      vanish doesn't compete with the upcoming skeleton mount.
+ *   3. Content fade-in (exiting refining): 150ms opacity 0 → 1 with
+ *      `var(--ease-out-strong)`. The strong ease-out lets the new AI
+ *      text feel like it "lands" instead of glides — matches the rest
+ *      of the system's overlay vocabulary.
+ *   4. Skeleton exit: when `refining` flips false, we keep the Skeleton
+ *      mounted for one short cycle (100ms) while `kb-tabs-content-out`
+ *      plays, then unmount. Without this exit phase the skeleton was
+ *      yanked from the DOM the moment refining ended, making the new
+ *      text appear to "snap in" under a still-visible (one-frame-stale)
+ *      skeleton. The crossfade window also gets a brief `blur(2px) → 0`
+ *      filter on the textarea contents so the two-objects-overlapping
+ *      smell of the crossfade is masked — Emil's standard textbook
+ *      crossfade pattern.
+ *   5. The Skeleton's own shimmer pseudo-element (`kb-skeleton-shimmer`,
  *      1.6s linear infinite) handles the in-flight loading motion.
- *   4. Textarea becomes `readOnly` while refining so the user can't
+ *   6. Textarea becomes `readOnly` while refining so the user can't
  *      race the AI service; the underlying value is preserved so an
  *      error path can restore prior text without losing edits.
- *   5. `motion-safe:` gates the fade transitions so reduced-motion
+ *   7. `motion-safe:` gates the fade transitions so reduced-motion
  *      users get instant swaps.
  * ───────────────────────────────────────────────────────────── */
 
@@ -90,6 +105,14 @@ const resizeClassMap: Record<NonNullable<TextareaProps['resize']>, string> = {
 const HIDE_NATIVE_RESIZE_GRIP_CLASS =
   '[&::-webkit-resizer]:hidden';
 
+// Skeleton-exit dwell time. Matches `kb-tabs-content-out` (100ms)
+// in tokens.css so the overlay finishes fading just as the textarea
+// reaches full opacity on its 150ms fade-in. The 50ms head-start the
+// textarea gets is deliberate — Emil's textbook crossfade has the
+// incoming object slightly ahead so the eye lands on "real text"
+// before the skeleton is fully gone.
+const SKELETON_EXIT_MS = 100;
+
 export function Textarea({
   value,
   onChange,
@@ -119,6 +142,18 @@ export function Textarea({
   );
   const wasRefiningRef = React.useRef<boolean>(refining);
 
+  /* ── Skeleton exit phase (chunk-12 emil pass) ────────────────
+   * When `refining` flips false the Skeleton overlay used to vanish
+   * the same frame the AI text re-appeared — a crossfade where one
+   * side is instant looks like a snap, even when the other side has
+   * the correct fade. We keep the Skeleton mounted for `SKELETON_EXIT_MS`
+   * after `refining` drops, running `kb-tabs-content-out` on its
+   * wrapper so it fades out on top of the textarea fading back in.
+   * Reduce-motion users skip the wait (instant unmount, matching
+   * the reduce-motion default of "no crossfade window"). */
+  const [isExitingSkeleton, setIsExitingSkeleton] = React.useState(false);
+  const exitTimerRef = React.useRef<number | null>(null);
+
   React.useLayoutEffect(() => {
     // Capture height on the render where `refining` becomes true.
     // The textarea node still exists at this point (it's just
@@ -129,9 +164,38 @@ export function Textarea({
       if (rect && rect.height > 0) {
         setMeasuredHeight(rect.height);
       }
+      // Cancel any in-flight exit (rapid retoggle) — refining is
+      // back on, so the skeleton stays visible at full opacity.
+      if (exitTimerRef.current !== null) {
+        window.clearTimeout(exitTimerRef.current);
+        exitTimerRef.current = null;
+      }
+      setIsExitingSkeleton(false);
+    }
+    // Fire the exit phase on refining true → false.
+    if (!refining && wasRefiningRef.current) {
+      setIsExitingSkeleton(true);
+      if (exitTimerRef.current !== null) {
+        window.clearTimeout(exitTimerRef.current);
+      }
+      exitTimerRef.current = window.setTimeout(() => {
+        setIsExitingSkeleton(false);
+        exitTimerRef.current = null;
+      }, SKELETON_EXIT_MS);
     }
     wasRefiningRef.current = refining;
   }, [refining]);
+
+  // Cleanup any pending timer on unmount so we don't setState on
+  // a torn-down component (which React 18 warns on in dev).
+  React.useEffect(() => {
+    return () => {
+      if (exitTimerRef.current !== null) {
+        window.clearTimeout(exitTimerRef.current);
+        exitTimerRef.current = null;
+      }
+    };
+  }, []);
 
   // Compute the Skeleton's row count + widths from the latched
   // height. Each row is 16px tall + 12px gap, so a typical 80px
@@ -187,19 +251,50 @@ export function Textarea({
           style={{
             // While refining, lock to measured height so the Skeleton
             // overlay can match exactly. Otherwise honour initialHeight.
+            //
+            // Autosize: `fieldSizing: 'content'` grows the textarea to
+            // fit content past the `minHeight` floor. CSS-native, no
+            // JS / no re-renders. Falls back gracefully to a fixed
+            // `minHeight` frame on Firefox <144 (the textarea simply
+            // stops growing — the user can still scroll). While
+            // `refining`, content is hidden (opacity-0) so field-sizing
+            // has nothing to measure and the `min-height` floor
+            // (latched to the pre-refine measured height) keeps the
+            // frame stable for the Skeleton overlay.
+            //
+            // We intentionally DO NOT transition the height change —
+            // per emil-design-eng, animating `height` is a known
+            // layout-thrash + perf hazard, AND autosize snaps are
+            // typically ≤ 20px per linebreak. With frequent typing
+            // (the common case), a height transition would constantly
+            // retarget mid-flight, producing the soft-landing-rubbery
+            // feel users describe as "laggy". The absence of a
+            // transition reads as crisp instead of jumpy.
+            //
+            // Asymmetric fade timing for the refining state (chunk 12
+            // emil pass) — refining IS where motion lives. The fade
+            // ENTERING refining is 100ms linear: a fast vanish that
+            // doesn't compete with the upcoming skeleton mount, and
+            // linear is appropriate at the trigger moment. The fade
+            // EXITING refining is 150ms with `var(--ease-out-strong)`:
+            // the new AI text gets a deliberate landing curve that
+            // matches the rest of the overlay/dropdown vocabulary.
+            // Filter blur(2px → 0) on exit masks the brief crossfade
+            // overlap with the still-fading Skeleton above.
+            //
+            // The inline style is the only reliable way to switch
+            // transition properties asymmetrically based on state —
+            // Tailwind's transition-* utilities don't compose well
+            // when both duration AND timing function flip mid-state.
             minHeight: `${
               refining && measuredHeight ? measuredHeight : initialHeight
             }px`,
-            // Autosize: grow the textarea to fit content past the
-            // `minHeight` floor. CSS-native, no JS / no re-renders.
-            // Falls back gracefully to a fixed `minHeight` frame on
-            // Firefox <144 (the textarea simply stops growing — the
-            // user can still scroll). While `refining`, content is
-            // hidden (opacity-0) so field-sizing has nothing to
-            // measure and the `min-height` floor (latched to the
-            // pre-refine measured height) keeps the frame stable for
-            // the Skeleton overlay.
             fieldSizing: 'content',
+            transitionProperty: 'opacity, filter',
+            transitionDuration: refining ? '100ms, 100ms' : '150ms, 150ms',
+            transitionTimingFunction: refining
+              ? 'linear, linear'
+              : 'var(--ease-out-strong), var(--ease-out-strong)',
           } as React.CSSProperties}
           className={cn(
             'block w-full min-w-0 flex-1 border-0 bg-transparent p-0 text-[14px] font-normal leading-5 text-text-primary outline-none placeholder:text-text-muted disabled:cursor-not-allowed',
@@ -217,32 +312,56 @@ export function Textarea({
             // the textarea flush so existing single-textarea consumers
             // (CategoryDescription, generic forms) don't grow.
             refineSlot && 'pb-12',
-            // Fade out the contents on entering refining state.
-            // 100ms opacity 1 → 0 is fast enough to read as "the
-            // text vanished" without flashing through unparsed copy.
-            refining ? 'opacity-0' : 'opacity-100',
-            'motion-safe:transition-opacity motion-safe:duration-100 motion-safe:ease-linear',
+            // Opacity + filter target state. While refining: invisible
+            // and slightly blurred (the latter masks the crossfade
+            // smell when the Skeleton overlay sits on top). On exit:
+            // opacity-100 + blur-0 — fades in over 150ms ease-out-strong
+            // via the inline transition above.
+            refining
+              ? 'opacity-0 motion-safe:blur-[2px]'
+              : 'opacity-100 motion-safe:blur-0',
+            // Reduce-motion users skip the filter transition entirely
+            // (no movement-equivalent perception cost; the swap is
+            // instant which is the a11y default for content swaps).
+            'motion-reduce:!transition-none',
             textareaClassName,
           )}
         />
 
-        {refining && (
+        {(refining || isExitingSkeleton) && (
           <div
             /* Skeleton overlay — absolutely positioned over the textarea
-               so it doesn't push layout. Fade-in mirrors the textarea's
-               fade-out: 150ms opacity 0 → 1 with strong ease-out so the
-               shimmer feels like a confident "the AI is working" state
-               rather than a sluggish reveal.
-               The wrapper has `animate-kb-tabs-content-in` (150ms
-               opacity-only fade, strong ease-out) which fires once on
-               mount when refining first kicks in. The Skeleton's own
-               kb-skeleton-shimmer animation handles the in-flight
-               loading sweep at 1.6s linear infinite. */
+               so it doesn't push layout.
+               Mount-in: `kb-tabs-content-in` (150ms opacity 0 → 1, strong
+               ease-out) fires once when `refining` first kicks in, so
+               the shimmer feels like a confident "the AI is working"
+               state rather than a sluggish reveal.
+               Exit (chunk 12 emil pass): when `refining` flips false we
+               keep the overlay mounted for SKELETON_EXIT_MS while
+               `kb-tabs-content-out` plays (100ms opacity 1 → 0, strong
+               ease-out). Without this exit phase the skeleton was yanked
+               from the DOM the moment refining ended, producing a hard
+               cut even though the textarea was fading in underneath.
+               The 50ms head-start the textarea has over the skeleton
+               (150ms fade-in vs 100ms fade-out) means the eye lands on
+               "real text" before the shimmer is fully gone — the Emil
+               textbook crossfade pattern.
+               The Skeleton's own kb-skeleton-shimmer animation handles
+               the in-flight loading sweep at 1.6s linear infinite. */
             aria-hidden="true"
             data-kb-part="textarea-refining-overlay"
             className={cn(
               'pointer-events-none absolute inset-0 flex items-start',
-              'motion-safe:animate-kb-tabs-content-in',
+              // Mount-in plays whenever the wrapper enters refining.
+              // Exit plays when the wrapper is in the `isExitingSkeleton`
+              // tail — same animation utility namespace so both classes
+              // resolve to keyframes registered in tokens.css. The exit
+              // animation uses `animation-fill-mode: forwards` so the
+              // overlay holds at opacity:0 during the unmount-timer
+              // handoff (~100ms) without a flash-back to opacity:1.
+              isExitingSkeleton
+                ? 'motion-safe:animate-kb-tabs-content-out'
+                : 'motion-safe:animate-kb-tabs-content-in',
             )}
           >
             <Skeleton

--- a/packages/kb-ui/src/tokens.css
+++ b/packages/kb-ui/src/tokens.css
@@ -248,8 +248,21 @@ html {
    * rather than snapping back to zero. */
   --animate-kb-modal-in:      kb-modal-in 200ms var(--ease-out-strong);
   --animate-kb-modal-out:     kb-modal-out 140ms var(--ease-out-strong);
-  --animate-kb-backdrop-in:   kb-backdrop-in 200ms ease;
-  --animate-kb-backdrop-out:  kb-backdrop-out 140ms ease;
+  --animate-kb-backdrop-in:   kb-backdrop-in 200ms var(--ease-out-strong);
+  --animate-kb-backdrop-out:  kb-backdrop-out 140ms var(--ease-out-strong);
+
+  /* Reduced-motion fallbacks. Modal/backdrop should NEVER hard-pop
+   * into existence even for reduce-motion users — Emil's rule:
+   * suppress *transforms* (the movement), not all motion. A short
+   * opacity-only fade is still in the a11y safe zone and prevents
+   * the "stutter into existence" jank that prompted this fix.
+   * Applied via `motion-reduce:` variants at the call site so the
+   * full-motion (transform+opacity) path is preserved for everyone
+   * who hasn't set the OS reduce-motion preference. */
+  --animate-kb-modal-in-reduced:     kb-fade-in 100ms ease-out;
+  --animate-kb-modal-out-reduced:    kb-fade-out 80ms ease-out;
+  --animate-kb-backdrop-in-reduced:  kb-fade-in 100ms ease-out;
+  --animate-kb-backdrop-out-reduced: kb-fade-out 80ms ease-out;
   --animate-kb-sheet-in-right:  kb-sheet-in-right 240ms var(--ease-out-strong);
   --animate-kb-sheet-out-right: kb-sheet-out-right 180ms var(--ease-out-strong);
 
@@ -305,6 +318,18 @@ html {
     to   { opacity: 1; }
   }
   @keyframes kb-backdrop-out {
+    from { opacity: 1; }
+    to   { opacity: 0; }
+  }
+  /* Generic opacity-only fades — used by the reduced-motion fallback
+   * animations for Modal + backdrop above. Kept generic so future
+   * reduce-motion overrides (toasts, dropdowns) can reuse them
+   * instead of redefining identical keyframes per component. */
+  @keyframes kb-fade-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+  @keyframes kb-fade-out {
     from { opacity: 1; }
     to   { opacity: 0; }
   }
@@ -392,6 +417,32 @@ html {
   }
   .animate-kb-tabs-content-in {
     animation: kb-tabs-content-in 150ms var(--ease-out-strong);
+  }
+
+  /* TabsContent fade-out — paired with kb-tabs-content-in for cases
+   * where the exit phase needs to play out before unmount (e.g. the
+   * Textarea refine flow's Skeleton overlay: when `refining` flips
+   * false, the host keeps the Skeleton mounted for one short cycle
+   * while this keyframe runs, then unmounts). 100ms is fast enough
+   * to feel like the skeleton "vanishes" the instant the new text
+   * lands but slow enough to mask the two-objects-overlapping
+   * crossfade smell. Strong ease-out matches the entrance curve. */
+  @keyframes kb-tabs-content-out {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
+  }
+  /* `animation-fill-mode: forwards` pins the final keyframe state after
+   * the animation completes — without it the overlay would briefly
+   * snap back to opacity:1 (its CSS default) before the host unmounts
+   * it, producing a visible flash. The host owns unmount on a timer
+   * sized to the animation duration, so `forwards` cleanly holds the
+   * exit pose during that handoff. */
+  .animate-kb-tabs-content-out {
+    animation: kb-tabs-content-out 100ms var(--ease-out-strong) forwards;
   }
 
   /* AI Gaps — collapsed decision chip enter.


### PR DESCRIPTION
## Summary

- **Modal motion (PRIORITY)**: under macOS Reduce Motion (`prefers-reduced-motion: reduce`) the prior `motion-safe:`-only animation chain produced a hard pop ("stutters into existence"). Adds `motion-reduce:` opacity-only fallback animations so reduced-motion users get a perceptible fade-in/out cushion without any transforms. Also aligns the backdrop curve (was `ease`) with the content curve (`var(--ease-out-strong)`).
- **Emil audit (5 items)**:
  1. **Textarea refine flow** — skeleton now gets a 100ms exit phase (new `kb-tabs-content-out` keyframe + internal `isExitingSkeleton` state); textarea fade-in bumps from 100ms linear to 150ms `var(--ease-out-strong)` with brief `blur(2px) -> 0` filter masking the crossfade.
  2. **Switch knob** — overshoot curve `cubic-bezier(0.34, 1.4, 0.64, 1)` replaced with canonical `ease-out-strong`; docblock updated to drop "decisive flip thunk" language.
  3. **SerpPreview <-> NoPreviewState** — keyed-remount swapped for stable dual-mount opacity crossfade (200ms `ease-out-strong` + outgoing-blur); `min-h-[88px]` floor prevents layout collapse.
  4. **Disclosure curve** — literal `cubic-bezier(0.23, 1, 0.32, 1)` replaced with `var(--ease-out-strong)` token.
  5. **Textarea autosize** — inline comment documents the deliberate no-animation choice for the `fieldSizing: 'content'` height changes (perf + autosize-snap granularity).

## Diagnosis (modal)

Captured the animation under both motion preferences:

- Full motion: `kb-modal-in` 200ms `cubic-bezier(0.23, 1, 0.32, 1)` — smooth opacity 0->1 + scale 0.96->1 progression. Working as designed.
- Reduced motion (before fix): `animationName: "none"`, `opacity: 1` from frame 0 — instant pop, "stutters into existence". Confirmed reproduction.
- Reduced motion (after fix): `kb-fade-in` 100ms `ease-out`, opacity smoothly progresses 0 -> 0.9 over 10 frames. No transforms (a11y-correct), but a perceptible cushion.

## Test plan

- [x] `npm run --workspace=packages/kb-ui typecheck` -> 0
- [x] `npm run --workspace=packages/kb-ui build` -> 0
- [x] `npm run --workspace=packages/kb-ui build-storybook` -> 0
- [x] `npm run --workspace=apps/demo typecheck` -> 0
- [x] `npm run --workspace=apps/demo build` -> 0
- [x] Vite caches cleared; demo dev boots clean
- [x] Modal mid-enter + at-rest screenshots captured (full motion path)
- [x] Modal reduced-motion path verified via Playwright reducedMotion: 'reduce' context — confirmed `kb-fade-in` plays
- [x] Switch ON screenshot (no overshoot)
- [x] SerpPreview <-> NoPreview mid-crossfade screenshot (both children visible, outgoing blurred)
- [x] Refine flow mid-exit screenshot (skeleton bars still visible, AI text fading in underneath)

Merge triggers Vercel auto-deploy to https://kb-demo-six.vercel.app.