### PR TITLE
fix(demo): editor landing routes to first folder

### DIFF
--- a/apps/demo/src/routes/RedirectToDefault.tsx
+++ b/apps/demo/src/routes/RedirectToDefault.tsx
@@ -1,20 +1,34 @@
 // Phase 7.5.3 — `/` redirector.
 //
 // PRD §4.1 / §6 Journey A step 1: landing on `/` redirects to the
-// default KB category. Use `<Navigate replace>` so the back button
-// doesn't return to a blank `/`.
+// default KB category — the FIRST top-level folder in the explorer
+// tree. We derive the slug from `selectFirstCategorySlug(state)` so
+// this redirect agrees by construction with the FileExplorerNav's own
+// ordering. Use `<Navigate replace>` so the back button doesn't return
+// to a blank `/`.
+//
+// Defensive: if the store somehow has zero folders, render nothing
+// (no crash, no infinite redirect). The mock store always has folders
+// in practice.
 
 import { Navigate, useLocation } from 'react-router-dom';
-import { DEFAULT_KB_CATEGORY_SLUG, routes } from '../lib/routes';
+import { useMockStore } from '../store/MockStoreContext';
+import { selectFirstCategorySlug } from '../store/selectors';
+import { routes } from '../lib/routes';
 
 export default function RedirectToDefault() {
   const { search } = useLocation();
+  const { state } = useMockStore();
+  const slug = selectFirstCategorySlug(state);
+
+  if (!slug) return null;
+
   // Preserve the query string through the redirect so feature flags
   // like `?welcome=1` (the welcome-tour reset) reach the destination
   // route where the provider lives.
   return (
     <Navigate
-      to={{ pathname: routes.kb.category(DEFAULT_KB_CATEGORY_SLUG), search }}
+      to={{ pathname: routes.kb.category(slug), search }}
       replace
     />
   );

--- a/apps/demo/src/routes/WelcomeRedirect.tsx
+++ b/apps/demo/src/routes/WelcomeRedirect.tsx
@@ -8,10 +8,16 @@
 //
 // Use the `replace` navigation so the back button doesn't return to
 // `/welcome` — that would just re-trigger the tour again.
+//
+// Landing slug is derived from the store's first folder via
+// `selectFirstCategorySlug` so it stays in lockstep with
+// RedirectToDefault and the AppRail Editor click target.
 
 import { useEffect, useRef } from 'react';
 import { Navigate } from 'react-router-dom';
-import { DEFAULT_KB_CATEGORY_SLUG, routes } from '../lib/routes';
+import { useMockStore } from '../store/MockStoreContext';
+import { selectFirstCategorySlug } from '../store/selectors';
+import { routes } from '../lib/routes';
 import { HIVER_TOUR_STORAGE_KEY } from '../components/welcome-tour-config';
 
 export default function WelcomeRedirect() {
@@ -29,10 +35,15 @@ export default function WelcomeRedirect() {
     }
   }, []);
 
+  const { state } = useMockStore();
+  const slug = selectFirstCategorySlug(state);
+
+  if (!slug) return null;
+
   return (
     <Navigate
       to={{
-        pathname: routes.kb.category(DEFAULT_KB_CATEGORY_SLUG),
+        pathname: routes.kb.category(slug),
         search: '?welcome=1',
       }}
       replace

--- a/apps/demo/src/shell/AppRail.tsx
+++ b/apps/demo/src/shell/AppRail.tsx
@@ -20,7 +20,10 @@ import {
   type NavRailItem,
 } from '@test-kb-ui/kb-ui';
 import { useMockStore } from '../store/MockStoreContext';
-import { selectCurrentUser } from '../store/selectors';
+import {
+  selectCurrentUser,
+  selectFirstCategorySlug,
+} from '../store/selectors';
 import { DEFAULT_KB_CATEGORY_SLUG, routes } from '../lib/routes';
 
 /** Stable rail-item ids — used for active comparison and click routing. */
@@ -47,8 +50,18 @@ function activeSectionForPath(pathname: string): RailSection {
   return 'editor';
 }
 
-/** Click destination per rail icon (PRD §7.1 persistent shell table). */
-function destinationForSection(section: RailSection): string {
+/**
+ * Click destination per rail icon (PRD §7.1 persistent shell table).
+ *
+ * The Editor target is derived from `selectFirstCategorySlug(state)` so
+ * the rail click always lands on the SAME folder the FileExplorerNav
+ * highlights as first. `DEFAULT_KB_CATEGORY_SLUG` stays as a defensive
+ * fallback for the (impossible-in-practice) zero-folders state.
+ */
+function destinationForSection(
+  section: RailSection,
+  editorLandingSlug: string,
+): string {
   switch (section) {
     case 'ai':
       return routes.aiOptimise.hub();
@@ -57,7 +70,7 @@ function destinationForSection(section: RailSection): string {
     case 'settings':
       return routes.settings();
     case 'editor':
-      return routes.kb.category(DEFAULT_KB_CATEGORY_SLUG);
+      return routes.kb.category(editorLandingSlug);
   }
 }
 
@@ -67,6 +80,8 @@ export function AppRail() {
   const { state } = useMockStore();
   const currentUser = selectCurrentUser(state);
   const activeId = activeSectionForPath(pathname);
+  const editorLandingSlug =
+    selectFirstCategorySlug(state) ?? DEFAULT_KB_CATEGORY_SLUG;
 
   return (
     <SideNavRail
@@ -76,7 +91,7 @@ export function AppRail() {
       bottomSlot={<Avatar initials={currentUser?.initials ?? 'A'} />}
       onItemClick={(id) => {
         const section = id as RailSection;
-        navigate(destinationForSection(section));
+        navigate(destinationForSection(section, editorLandingSlug));
       }}
     />
   );

--- a/apps/demo/src/store/selectors.ts
+++ b/apps/demo/src/store/selectors.ts
@@ -205,6 +205,26 @@ export function selectExplorerTree(state: MockStoreState): NavItem[] {
 }
 
 /**
+ * Slug of the first top-level folder in the explorer tree. Drives the
+ * "land on first folder" routing contract — used by `RedirectToDefault`,
+ * `WelcomeRedirect`, and the Editor rail icon's click target. Returns
+ * `undefined` when the store has zero top-level categories (defensive;
+ * the demo's mock store always has at least one).
+ *
+ * Derived from the SAME `selectExplorerTree` ordering the FileExplorerNav
+ * renders, so "first folder" stays consistent across the redirect and
+ * the explorer's visual highlight/expand state.
+ */
+export function selectFirstCategorySlug(
+  state: MockStoreState,
+): string | undefined {
+  const tree = selectExplorerTree(state);
+  const firstFolder = tree.find((item) => item.type === 'folder');
+  if (!firstFolder) return undefined;
+  return state.categories[firstFolder.id]?.slug;
+}
+
+/**
  * Flat 3-item list consumed by `FileExplorerNav variant="flat"` for
  * the Analytics sub-nav. Hard-coded ids align with the routes built
  * in Phase 7.5.3.


### PR DESCRIPTION
## Summary
- The Editor landing (`/`, `/welcome`, side-rail Editor click) was hardcoded to `getting-started`. Explorer order is by id, so the first folder is actually `automations-workflows` — user always landed on the 2nd folder.
- Adds `selectFirstCategorySlug(state)` and uses it across `RedirectToDefault`, `WelcomeRedirect`, and `AppRail`. Hardcoded constant stays as defensive fallback only.

## Test plan
- [ ] Open `https://kb-demo-six.vercel.app/` → redirects to `/kb/automations-workflows`.
- [ ] Hard refresh on `/` → same target, no flash.
- [ ] Click Editor side-rail item from another surface → same target.
- [ ] Click "Getting Started" in explorer → routes to `/kb/getting-started`; redirect doesn't fight it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)