### PR TITLE
feat(demo): per-row dropdown content (Preview/Copy/Delete + Edit/New/Delete)

### DIFF
--- a/apps/demo/src/routes/kb/CategoryPage.tsx
+++ b/apps/demo/src/routes/kb/CategoryPage.tsx
@@ -20,10 +20,13 @@ import * as RxDropdownMenu from '@radix-ui/react-dropdown-menu';
 import {
   BookOpen01,
   ChevronRight,
+  Copy01,
   DotsVertical,
   File02,
   Folder,
+  LinkExternal01,
   Plus,
+  Trash01,
 } from '@untitledui/icons';
 import {
   Avatar,
@@ -128,6 +131,98 @@ const subCategoryColumns: DataTableColumn<SubCategoryRow>[] = [
   },
 ];
 
+/* ─────────────────────────────────────────────────────────────
+ * ArticleRowKebab — per-row 3-dot menu inside the Articles table.
+ *
+ * Mirrors EditorExplorer's article-row menu (Preview / Copy link /
+ * Delete Article, danger tone on the last). Same Figma source
+ * (1958:34638) — keeping the two surfaces identical avoids muscle-
+ * memory mismatch when the user toggles between the explorer and the
+ * category page.
+ *
+ * Lives in the component layer (not module-level) so it can pull the
+ * article slug from the store via `useMockStore`. The trigger button
+ * preserves the previous inert kebab's chrome (h-6/w-6, slate hover bg,
+ * focus ring) so DataTable row geometry doesn't shift.
+ *
+ * Delete is a console-log TODO — `articles/delete` doesn't exist in the
+ * demo reducer yet (see EditorExplorer for the same pattern).
+ * ───────────────────────────────────────────────────────────── */
+
+function ArticleRowKebab({
+  articleId,
+  title,
+}: {
+  articleId: string;
+  title: string;
+}) {
+  const { state } = useMockStore();
+  const article = state.articles[articleId];
+
+  const onPreview = () => {
+    if (!article) return;
+    window.open(routes.article(article.slug), '_blank', 'noopener,noreferrer');
+  };
+  const onCopyLink = () => {
+    if (!article) return;
+    const url = window.location.origin + routes.article(article.slug);
+    try {
+      void navigator.clipboard?.writeText(url);
+    } catch {
+      // Swallow — clipboard API throws in non-HTTPS / sandboxed envs.
+    }
+  };
+  const onDelete = () => {
+    // eslint-disable-next-line no-console
+    console.log('TODO: delete article', articleId);
+  };
+
+  return (
+    <div className="flex items-center justify-center">
+      <RxDropdownMenu.Root>
+        <RxDropdownMenu.Trigger asChild>
+          <button
+            type="button"
+            aria-label={`More actions for ${title}`}
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+            className={cn(
+              'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-text-disabled',
+              'hover:bg-surface-subtle focus:bg-surface-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-border-faint',
+            )}
+          >
+            <DotsVertical size={16} aria-hidden="true" />
+          </button>
+        </RxDropdownMenu.Trigger>
+        <RxDropdownMenu.Portal>
+          <RxDropdownMenu.Content
+            align="end"
+            sideOffset={4}
+            className={DROPDOWN_CONTENT_CLASSES}
+          >
+            <DropdownMenuItem
+              label="Preview"
+              icon={<LinkExternal01 aria-hidden="true" />}
+              onSelect={onPreview}
+            />
+            <DropdownMenuItem
+              label="Copy link"
+              icon={<Copy01 aria-hidden="true" />}
+              onSelect={onCopyLink}
+            />
+            <DropdownMenuItem
+              label="Delete Article"
+              icon={<Trash01 aria-hidden="true" />}
+              onSelect={onDelete}
+              tone="danger"
+            />
+          </RxDropdownMenu.Content>
+        </RxDropdownMenu.Portal>
+      </RxDropdownMenu.Root>
+    </div>
+  );
+}
+
 const articleColumns: DataTableColumn<ArticleRow>[] = [
   {
     id: 'title',
@@ -160,21 +255,7 @@ const articleColumns: DataTableColumn<ArticleRow>[] = [
     width: 48,
     headerClassName: 'px-0 py-0',
     className: 'px-0',
-    render: (a) => (
-      <div className="flex items-center justify-center">
-        <button
-          type="button"
-          aria-label={`More actions for ${a.title}`}
-          onClick={(e) => e.stopPropagation()}
-          className={cn(
-            'flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] text-text-disabled',
-            'hover:bg-surface-subtle focus:bg-surface-subtle focus:outline-none focus-visible:ring-2 focus-visible:ring-border-faint',
-          )}
-        >
-          <DotsVertical size={16} aria-hidden="true" />
-        </button>
-      </div>
-    ),
+    render: (a) => <ArticleRowKebab articleId={a.id} title={a.title} />,
   },
   {
     id: 'status',

--- a/apps/demo/src/shell/DropdownMenuItem.tsx
+++ b/apps/demo/src/shell/DropdownMenuItem.tsx
@@ -2,35 +2,55 @@
 //
 // Used by both:
 //   - `EditorExplorer` — the per-row 3-dot menu surfaced via
-//     `FileExplorerNav.renderRowAction`.
+//     `FileExplorerNav.renderRowAction` (Preview / Copy link / Delete on
+//     article rows; Edit / New article / Delete on folder rows).
 //   - `CategoryPage`   — the PageHeader "+ New" dropdown with
 //     "Folder" / "Article" items.
 //
 // Container: white bg, 1px #e2e8f0 border, 8px radius, py-2 px-1,
 //            two-layer shadow per Figma `Shadows/md`.
 // Item:      flex w/ 16px icon + 14px label, p-2, 6px radius, slate-100
-//            hover bg, destructive variant uses ai-removal red.
+//            hover bg (neutral tone) or --color-btn-danger-bg #feeeec
+//            (danger tone). Both tones use a 150ms ease-out bg transition
+//            so the wash arrives without a hard pop (emil: "make hover
+//            intentional, not jarring").
 //
 // Composes Radix DropdownMenu primitives so we keep keyboard a11y,
 // portal positioning, and focus management for free.
+//
+// Danger token choice:
+//   - text + icon color  → var(--color-ai-removal)     (#d52c1f — Figma
+//                          text/danger/default + icon/danger/default)
+//   - hover bg           → var(--color-btn-danger-bg)  (#feeeec — Figma
+//                          dismiss/delete button background)
+//   Both vars are already defined in packages/kb-ui/src/tokens.css; no
+//   new tokens introduced.
 
 import * as React from 'react';
 import * as RxDropdownMenu from '@radix-ui/react-dropdown-menu';
 import { cn } from '@test-kb-ui/kb-ui';
 
+export type DropdownItemTone = 'neutral' | 'danger';
+
 export type DropdownItemProps = {
   label: string;
   icon: React.ReactNode;
   onSelect: () => void;
-  destructive?: boolean;
+  /**
+   * `'neutral'` (default) — slate text + slate hover wash.
+   * `'danger'`            — red text/icon + light-red hover wash. Use
+   *                         for destructive items like Delete.
+   */
+  tone?: DropdownItemTone;
 };
 
 export function DropdownMenuItem({
   label,
   icon,
   onSelect,
-  destructive,
+  tone = 'neutral',
 }: DropdownItemProps) {
+  const isDanger = tone === 'danger';
   return (
     <RxDropdownMenu.Item
       onSelect={(e) => {
@@ -43,8 +63,13 @@ export function DropdownMenuItem({
       className={cn(
         'flex items-center gap-2 p-2 rounded-[6px]',
         'text-[14px] leading-5 cursor-pointer outline-none select-none',
-        'data-[highlighted]:bg-[#f1f5f9] data-[disabled]:opacity-50',
-        destructive ? 'text-[#d52c1f]' : 'text-text-primary',
+        // Emil — explicit property + ease-out + 150ms so the wash arrives
+        // without a hard pop. Never `transition: all`.
+        'transition-colors duration-150 ease-out',
+        'data-[disabled]:opacity-50',
+        isDanger
+          ? 'text-[var(--color-ai-removal)] data-[highlighted]:bg-[var(--color-btn-danger-bg)]'
+          : 'text-text-primary data-[highlighted]:bg-[#f1f5f9]',
       )}
     >
       <span
@@ -52,7 +77,7 @@ export function DropdownMenuItem({
         className={cn(
           'flex size-4 shrink-0 items-center justify-center',
           '[&>svg]:w-4 [&>svg]:h-4',
-          destructive ? 'text-[#d52c1f]' : 'text-text-meta',
+          isDanger ? 'text-[var(--color-ai-removal)]' : 'text-text-meta',
         )}
       >
         {icon}

--- a/apps/demo/src/shell/EditorExplorer.tsx
+++ b/apps/demo/src/shell/EditorExplorer.tsx
@@ -15,11 +15,17 @@
 //     category, navigate to its category page.
 //   - Article click → navigate to the editor URL for that article slug.
 //
-// Per-row actions (2026-05-14 — dispatch B + C):
-//   - `renderRowAction` → per-row 3-dot trigger + "Edit" item. On a
-//     folder row Edit opens NewCategoryModal in `edit` mode pre-filled
-//     from the matching category; on an article row Edit navigates to the
-//     article's editor URL.
+// Per-row actions (Figma node 1958:34638 article menu):
+//   - `renderRowAction` → per-row 3-dot trigger + tone-aware menu.
+//       Folder rows:  Edit / New article / Delete (danger).
+//       Article rows: Preview / Copy link / Delete Article (danger).
+//   - "Edit" (folder) opens NewCategoryModal in `edit` mode pre-filled
+//     from the matching category. "New article" and both "Delete" items
+//     stub via console.log — no `articles/create`, `articles/delete`,
+//     `categories/delete` actions exist in the demo store yet.
+//   - "Preview" opens the live editor URL in a new tab. "Copy link" writes
+//     the absolute article URL to the clipboard (try/catch — clipboard
+//     API throws in non-HTTPS contexts and some sandboxes).
 //   - Modal is edit-mode only here. The create-mode entry-point lives in
 //     CategoryPage's PageHeader "+ New" dropdown — see CategoryPage.tsx.
 //   - The dropdown chrome (container + item) is shared from
@@ -29,7 +35,14 @@
 import { useCallback, useMemo, useState } from 'react';
 import * as RxDropdownMenu from '@radix-ui/react-dropdown-menu';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { DotsVertical, Pencil02 } from '@untitledui/icons';
+import {
+  Copy01,
+  DotsVertical,
+  LinkExternal01,
+  Pencil02,
+  Plus,
+  Trash01,
+} from '@untitledui/icons';
 import {
   FileExplorerNav,
   NewCategoryModal,
@@ -217,15 +230,64 @@ export function EditorExplorer() {
 
   const renderRowAction = useCallback(
     (item: NavItem) => {
-      const onEdit = () => {
-        if (item.type === 'folder') {
-          openEditFolderModal(item.id);
-        } else {
-          // Article: navigate to its editor URL.
-          const article = state.articles[item.id];
-          if (article) navigate(routes.article(article.slug));
+      // Folder menu — Edit / New article / Delete (danger).
+      // Article menu — Preview / Copy link / Delete Article (danger).
+      // Item set matches Figma node 1958:34638 (article rows) and the
+      // spec call-out for folder rows. Destructive items lean on
+      // DropdownMenuItem's `tone="danger"` (red text + #feeeec hover wash).
+      //
+      // Wire-up notes:
+      //   - "Edit" (folder)        → preserves existing NewCategoryModal
+      //                              edit-mode behavior.
+      //   - "New article" (folder) → no `articles/create` action exists
+      //                              in the demo store; log TODO so the
+      //                              wire-up is obvious to reviewers.
+      //   - "Delete" (both rows)   → same — no delete action exists; log
+      //                              TODO. Faking a state mutation here
+      //                              would mask the missing reducer path.
+      //   - "Preview" (article)    → opens the live editor URL in a new
+      //                              tab. Folder rows have no Preview.
+      //   - "Copy link" (article)  → clipboard.writeText with try/catch;
+      //                              the API throws in non-HTTPS contexts
+      //                              and silently fails in some sandboxes.
+      const isFolder = item.type === 'folder';
+
+      const onEditFolder = () => openEditFolderModal(item.id);
+      const onNewArticle = () => {
+        // eslint-disable-next-line no-console
+        console.log('TODO: create article in', item.id);
+      };
+      const onDeleteFolder = () => {
+        // eslint-disable-next-line no-console
+        console.log('TODO: delete category', item.id);
+      };
+
+      const onPreviewArticle = () => {
+        const article = state.articles[item.id];
+        if (!article) return;
+        window.open(
+          routes.article(article.slug),
+          '_blank',
+          'noopener,noreferrer',
+        );
+      };
+      const onCopyArticleLink = () => {
+        const article = state.articles[item.id];
+        if (!article) return;
+        const url = window.location.origin + routes.article(article.slug);
+        try {
+          // navigator.clipboard is gated behind secure contexts and may
+          // be undefined in older test envs.
+          void navigator.clipboard?.writeText(url);
+        } catch {
+          // Swallow — TODO surface as toast once we wire toasts up here.
         }
       };
+      const onDeleteArticle = () => {
+        // eslint-disable-next-line no-console
+        console.log('TODO: delete article', item.id);
+      };
+
       return (
         <RxDropdownMenu.Root>
           <RxDropdownMenu.Trigger asChild>
@@ -251,17 +313,51 @@ export function EditorExplorer() {
               sideOffset={4}
               className={DROPDOWN_CONTENT_CLASSES}
             >
-              <DropdownMenuItem
-                label="Edit"
-                icon={<Pencil02 aria-hidden="true" />}
-                onSelect={onEdit}
-              />
+              {isFolder ? (
+                <>
+                  <DropdownMenuItem
+                    label="Edit"
+                    icon={<Pencil02 aria-hidden="true" />}
+                    onSelect={onEditFolder}
+                  />
+                  <DropdownMenuItem
+                    label="New article"
+                    icon={<Plus aria-hidden="true" />}
+                    onSelect={onNewArticle}
+                  />
+                  <DropdownMenuItem
+                    label="Delete"
+                    icon={<Trash01 aria-hidden="true" />}
+                    onSelect={onDeleteFolder}
+                    tone="danger"
+                  />
+                </>
+              ) : (
+                <>
+                  <DropdownMenuItem
+                    label="Preview"
+                    icon={<LinkExternal01 aria-hidden="true" />}
+                    onSelect={onPreviewArticle}
+                  />
+                  <DropdownMenuItem
+                    label="Copy link"
+                    icon={<Copy01 aria-hidden="true" />}
+                    onSelect={onCopyArticleLink}
+                  />
+                  <DropdownMenuItem
+                    label="Delete Article"
+                    icon={<Trash01 aria-hidden="true" />}
+                    onSelect={onDeleteArticle}
+                    tone="danger"
+                  />
+                </>
+              )}
             </RxDropdownMenu.Content>
           </RxDropdownMenu.Portal>
         </RxDropdownMenu.Root>
       );
     },
-    [openEditFolderModal, navigate, state.articles],
+    [openEditFolderModal, state.articles],
   );
 
   /* ── Render ────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Article rows: Preview / Copy link / Delete Article (danger).
- Folder rows: Edit / New article / Delete (danger).
- `DropdownMenuItem` adds `tone: 'neutral' | 'danger'` — danger sources from existing `--color-ai-removal` + `--color-btn-danger-bg` tokens.
- Preview opens new tab; Copy link uses clipboard (try/catch); Delete + New article stub TODO; Edit folder keeps existing NewCategoryModal edit flow.

## Test plan
- [ ] On `/kb/automations-workflows/rule-based-automations`, hover an article row in the explorer, click the 3-dot → Preview/Copy link/Delete Article appear; Delete Article is red with a red hover wash.
- [ ] Preview opens the article in a new tab.
- [ ] Copy link puts the article URL in the clipboard.
- [ ] Folder row 3-dot → Edit/New article/Delete; Delete is red; Edit opens the existing edit modal.
- [ ] Category page table 3-dot mirrors the article menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)