### PR TITLE
feat: two-stage publish flow with PublishingIndicator (Figma 1958:43597)

### DIFF
--- a/apps/demo/src/routes/kb/EditorPage.tsx
+++ b/apps/demo/src/routes/kb/EditorPage.tsx
@@ -35,6 +35,7 @@ import {
   ArticleSettingsPanel,
   ArticleTitleInput,
   ContentEditor,
+  PublishingIndicator,
   type ArticleSettings as KbUiArticleSettings,
   type ArticleSettingsPerson,
 } from '@test-kb-ui/kb-ui';
@@ -276,6 +277,15 @@ function EditorPageBody({ article }: { article: Article }) {
   // Save-just-fired guards an extra debounce flush from racing the
   // navigation that happens immediately after publish.
   const justSavedRef = useRef(false);
+  // `publishing` drives the PublishingIndicator overlay AND disables
+  // the breadcrumb Publish button so a frantic second click can't
+  // double-fire the action mid-1200ms-latency window.
+  const [publishing, setPublishing] = useState(false);
+  // Mirror `publishing` synchronously so the handler's re-entry guard
+  // is correct even if React hasn't committed the state update yet
+  // (the publish handler returns synchronously after setPublishing(true)
+  // — the next click can land before the commit).
+  const publishingRef = useRef(false);
 
   /* ── Debounced body write ──────────────────────────────────
    * 200ms idle window per TRD §7.4. Keeps the store roughly in sync
@@ -378,10 +388,22 @@ function EditorPageBody({ article }: { article: Article }) {
     }, 0);
   }, [article.id, bodyHTML, storeSettings, dispatch, showToast]);
 
-  const handlePublish = useCallback(() => {
-    // Persist current edits first, then flip status. This matches a
-    // real product's save-on-publish — the user's last edits before
-    // hitting Publish should be part of the published version.
+  const handlePublish = useCallback(async () => {
+    // Two-stage flow:
+    //   1. Persist current edits + show the PublishingIndicator overlay
+    //      immediately (the user's last keystrokes are part of the
+    //      published version).
+    //   2. After a 1200ms simulated publish latency, flip status →
+    //      'published', dismiss the overlay, fire the success toast,
+    //      and navigate back to the category.
+    //
+    // Re-entry guard: the breadcrumb Publish button is also `disabled`
+    // while publishing is true, so the synchronous ref + the disabled
+    // attribute together make a second click during the 1200ms window
+    // a no-op.
+    if (publishingRef.current) return;
+    publishingRef.current = true;
+    setPublishing(true);
     justSavedRef.current = true;
     dispatch({
       type: 'editor/saveDraft',
@@ -389,8 +411,11 @@ function EditorPageBody({ article }: { article: Article }) {
       bodyHTML,
       settings: storeSettings,
     });
+    await new Promise<void>((resolve) => window.setTimeout(resolve, 1200));
     dispatch({ type: 'editor/publish', articleId: article.id });
     setDirty(false);
+    publishingRef.current = false;
+    setPublishing(false);
     showToast('Article published.', 'success');
     navigate(categoryUrl);
   }, [
@@ -451,20 +476,33 @@ function EditorPageBody({ article }: { article: Article }) {
   const isTitleEmpty = titleDraft.trim() === '';
   const editorControls = useMemo<EditorPageControls>(
     () => ({
-      saveDisabled: !isDirty,
-      // Publish is gated on the title field having content. An untitled
-      // article should not be publishable — the breadcrumb's Publish
-      // button greys out and surfaces a `title=` tooltip when the title
-      // is empty (see BreadcrumbBar's actions wrapper).
-      publishDisabled: isTitleEmpty,
+      saveDisabled: !isDirty || publishing,
+      // Publish is gated on:
+      //   (a) the title field having content — an untitled article
+      //       should not be publishable; the breadcrumb greys out and
+      //       surfaces a `title=` tooltip when empty.
+      //   (b) `publishing` — during the 1200ms simulated latency window
+      //       a second click must be a no-op. The ref-based guard in
+      //       handlePublish covers the race; the `disabled` attribute
+      //       covers the visual + accessibility surface.
+      publishDisabled: isTitleEmpty || publishing,
       publishDisabledReason: isTitleEmpty
         ? 'Add a title to publish'
-        : undefined,
+        : publishing
+          ? 'Publishing in progress…'
+          : undefined,
       onSaveAsDraft: handleSaveAsDraft,
       onPublish: handlePublish,
       onClose: handleClose,
     }),
-    [isDirty, isTitleEmpty, handleSaveAsDraft, handlePublish, handleClose],
+    [
+      isDirty,
+      isTitleEmpty,
+      publishing,
+      handleSaveAsDraft,
+      handlePublish,
+      handleClose,
+    ],
   );
   useRegisterEditorPageControls(editorControls);
 
@@ -585,6 +623,10 @@ function EditorPageBody({ article }: { article: Article }) {
 
       {/* In-app navigation guard (rail clicks, breadcrumb, browser back). */}
       {guardElement}
+
+      {/* Two-stage publish overlay — dims the page + shows a
+       * "Publishing..." card for the 1200ms simulated latency window. */}
+      <PublishingIndicator open={publishing} />
     </div>
   );
 }

--- a/packages/kb-ui/src/components/overlays/PublishingIndicator.stories.tsx
+++ b/packages/kb-ui/src/components/overlays/PublishingIndicator.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useEffect, useState } from 'react';
+import '../../tokens.css';
+import { PublishingIndicator } from './PublishingIndicator';
+import { Button } from '../primitives/Button';
+
+/* ─────────────────────────────────────────────────────────────
+ * Playground — controls let you toggle `open` and edit `label`
+ * to verify the enter motion (and label legibility) against
+ * the Modal centering pattern.
+ *
+ * The "Open for 1.2s" button demonstrates the realistic usage
+ * pattern: the indicator appears, then dismisses after the
+ * mock-publish latency completes.
+ * ───────────────────────────────────────────────────────────── */
+
+const meta: Meta<typeof PublishingIndicator> = {
+  title: 'Components/Overlays/PublishingIndicator',
+  component: PublishingIndicator,
+  parameters: { layout: 'centered' },
+  globals: { backgrounds: { value: 'canvas' } },
+  argTypes: {
+    open: { control: 'boolean' },
+    label: { control: 'text' },
+    withBackdrop: { control: 'boolean' },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof PublishingIndicator>;
+
+function Playground({
+  open: initialOpen,
+  label,
+  withBackdrop,
+}: {
+  open: boolean;
+  label?: string;
+  withBackdrop?: boolean;
+}) {
+  const [open, setOpen] = useState(initialOpen);
+
+  // Mirror the controls panel into local state so toggling `open` from
+  // Storybook controls reflects immediately without remounting.
+  useEffect(() => {
+    setOpen(initialOpen);
+  }, [initialOpen]);
+
+  return (
+    <div className="flex flex-col items-start gap-3">
+      <div className="flex gap-2">
+        <Button variant="primary" onClick={() => setOpen(true)}>
+          Show indicator
+        </Button>
+        <Button
+          variant="subtle"
+          onClick={() => {
+            setOpen(true);
+            window.setTimeout(() => setOpen(false), 1200);
+          }}
+        >
+          Open for 1.2s
+        </Button>
+        <Button variant="subtle" onClick={() => setOpen(false)}>
+          Hide
+        </Button>
+      </div>
+      <p className="text-[13px] text-text-meta">
+        Backdrop washes the page; card sits dead-center via the same
+        grid-place-items centering pattern as Modal.
+      </p>
+      <PublishingIndicator
+        open={open}
+        label={label}
+        withBackdrop={withBackdrop}
+      />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  args: {
+    open: true,
+    label: 'Publishing...',
+    withBackdrop: true,
+  },
+  render: (args) => (
+    <Playground
+      open={args.open}
+      label={args.label}
+      withBackdrop={args.withBackdrop}
+    />
+  ),
+};

--- a/packages/kb-ui/src/components/overlays/PublishingIndicator.tsx
+++ b/packages/kb-ui/src/components/overlays/PublishingIndicator.tsx
@@ -1,0 +1,182 @@
+// PublishingIndicator — small "Publishing..." card centered over a dim
+// backdrop, used during the simulated publish-latency window on the
+// article editor. Mirrors the Modal centering pattern (grid wrapper +
+// scale-only animation, no translate) to avoid the centering-drift the
+// Modal recently fixed.
+//
+// Why a plain portal (not Radix Dialog):
+//   The indicator has no interactive content — no buttons, no inputs,
+//   no Esc-to-close behavior the user should reach. Wrapping it in
+//   Dialog would add a focus trap with nothing to focus, plus an
+//   aria-modal announcement that doesn't fit "transient progress."
+//   `createPortal(node, document.body)` is enough.
+//
+// Motion (emil-design-eng skill validated):
+//   - Reuses the existing `kb-modal-in/out` + `kb-backdrop-in/out`
+//     keyframes so this indicator harmonizes with Modal (same easing,
+//     same durations, same scale 0.96→1 + opacity).
+//   - `motion-reduce` swaps to the `-reduced` keyframes (opacity-only,
+//     100/80ms) so reduced-motion users still see a perceptible fade
+//     instead of a hard pop (per Emil: "suppress movement, not all
+//     motion").
+//   - Spinner uses Tailwind's standard `animate-spin` (linear). It's an
+//     indeterminate progress glyph — linear matches a continuous loop.
+
+import * as React from 'react';
+import { createPortal } from 'react-dom';
+import { cn } from '../../utils/cn';
+
+export type PublishingIndicatorProps = {
+  open: boolean;
+  /** Label text. Defaults to 'Publishing...' */
+  label?: string;
+  /**
+   * When true, render WITH a centered dim backdrop (portal mode).
+   * When false, render the card only (no portal/backdrop) — useful
+   * for Storybook decorators or embedded contexts.
+   * Defaults to true.
+   */
+  withBackdrop?: boolean;
+  className?: string;
+};
+
+/* ─────────────────────────────────────────────────────────────
+ * Spinner — 14×14, 3/4-arc on a faint background ring.
+ *
+ * `currentColor` lets the parent control hue via Tailwind. We pin
+ * it to text-primary at the card level so the spinner reads as a
+ * UI glyph, not a brand element.
+ * ───────────────────────────────────────────────────────────── */
+
+function Spinner() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      aria-hidden="true"
+      className="animate-spin shrink-0"
+    >
+      <circle
+        cx="7"
+        cy="7"
+        r="5.5"
+        stroke="currentColor"
+        strokeOpacity="0.2"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M12.5 7a5.5 5.5 0 0 0-5.5-5.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Card chrome — shared between portal + standalone modes so the
+ * visual stays in lock-step.
+ *
+ * The card itself runs the modal-in/out animation when mounted via
+ * the portal path (data-state driven by the open prop). In
+ * standalone (withBackdrop=false) mode, we render the card without
+ * the data-state attribute — the consumer owns presence.
+ * ───────────────────────────────────────────────────────────── */
+
+const cardBaseClass =
+  // Visual chrome — white card, 8px radius, shadow-md, padded 16px,
+  // horizontal flex with 8px gap and centered content.
+  'inline-flex items-center justify-center gap-2 rounded-lg bg-white p-4 ' +
+  'shadow-[var(--shadow-md)] text-text-primary origin-center';
+
+const labelClass =
+  'text-[14px] font-medium leading-5 text-text-primary whitespace-nowrap';
+
+function IndicatorCard({
+  label,
+  className,
+  animated,
+}: {
+  label: string;
+  className?: string;
+  animated: boolean;
+}) {
+  return (
+    <div
+      data-kb-component="publishing-indicator-card"
+      role="status"
+      aria-live="polite"
+      className={cn(
+        cardBaseClass,
+        // Only attach the motion classes in portal mode — standalone
+        // mode (no backdrop) is host-controlled and shouldn't auto-fire
+        // the enter animation on every render.
+        animated && [
+          'motion-safe:animate-kb-modal-in',
+          'motion-reduce:animate-kb-modal-in-reduced',
+        ],
+        className,
+      )}
+    >
+      <Spinner />
+      <span className={labelClass}>{label}</span>
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Main component.
+ * ───────────────────────────────────────────────────────────── */
+
+export function PublishingIndicator({
+  open,
+  label = 'Publishing...',
+  withBackdrop = true,
+  className,
+}: PublishingIndicatorProps) {
+  /* Standalone mode — card only, no portal, no backdrop. Consumer
+   * controls presence; host decides where to mount it. */
+  if (!withBackdrop) {
+    if (!open) return null;
+    return <IndicatorCard label={label} className={className} animated={false} />;
+  }
+
+  /* Portal mode — backdrop + centered card via document.body portal.
+   * We mount/unmount on `open` directly (no exit animation) because
+   * the indicator's job is "show while work is in flight, vanish
+   * when work completes." A 140ms exit fade between vanish and toast
+   * would visually compete with the success toast that fires the
+   * same frame. */
+  if (!open) return null;
+
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(
+    <>
+      {/* Backdrop — same wash + enter keyframe as Modal. */}
+      <div
+        data-kb-part="publishing-backdrop"
+        aria-hidden="true"
+        className={cn(
+          'fixed inset-0 z-[90] bg-text-primary/40',
+          'motion-safe:animate-kb-backdrop-in',
+          'motion-reduce:animate-kb-backdrop-in-reduced',
+        )}
+      />
+
+      {/* Centering wrapper — grid place-items-center handles centering
+       * robustly across viewport changes. `pointer-events-none` on
+       * both wrapper and card matches the transient-progress role
+       * (no interactive content, no clicks to intercept). */}
+      <div
+        className="fixed inset-0 z-[91] grid place-items-center p-4 pointer-events-none"
+      >
+        <IndicatorCard label={label} className={className} animated />
+      </div>
+    </>,
+    document.body,
+  );
+}

--- a/packages/kb-ui/src/components/overlays/index.ts
+++ b/packages/kb-ui/src/components/overlays/index.ts
@@ -9,6 +9,8 @@ export { SideSheet } from './SideSheet';
 export type { SideSheetProps } from './SideSheet';
 export { Modal } from './Modal';
 export type { ModalProps } from './Modal';
+export { PublishingIndicator } from './PublishingIndicator';
+export type { PublishingIndicatorProps } from './PublishingIndicator';
 export { NewCategoryModal } from './NewCategoryModal';
 export type {
   NewCategoryModalProps,


### PR DESCRIPTION
## Summary
- New kb-ui `PublishingIndicator` primitive — backdrop + centered card with 14px spinner + 'Publishing…' label. Reuses existing Modal motion tokens; uses the post-#123 grid-wrapper centering pattern.
- Demo editor Publish handler now: persist → 1200ms delay → status flip → toast + dismiss. Publish/Save disabled during the window.
- Storybook Playground story shipped.

## Test plan
- [ ] Open a draft article and click Publish — backdrop dims, indicator centers cleanly, ~1.2s later it dismisses, status flips to published, success toast appears.
- [ ] Publish button is disabled during the window; double-click does not re-fire.
- [ ] Reduced motion (DevTools): opacity-only fade, no scale pop.
- [ ] Storybook `PublishingIndicator` Playground renders cleanly; toggling `open` works; `withBackdrop=false` shows the card only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)